### PR TITLE
Limit CI push runs to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
 jobs:
     test:
         name: test


### PR DESCRIPTION
## Summary
- scope GitHub Actions workflow triggers to avoid duplicate runs
- restrict push-triggered CI to the main branch while leaving pull_request triggers intact

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d58d125078832fa72927515acf45d5