### PR TITLE
docs: update Node.js requirement in contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,6 @@ These checks ensure linting, formatting, and TypeScript compilation succeed.
 - Keep the subject under 72 characters and avoid ending it with a period.
 
 ## Additional Notes
-- Node.js version 16 or newer is required (per `package.json` engines).
+- Node.js version 18 or newer is required.
 - Example configurations live at `example-config-advanced.toml` and should stay in sync with config schema changes.
 - Assets (logos, etc.) reside in `/assets`; update paths carefully if moving files referenced in the README.


### PR DESCRIPTION
## Summary
- update the contributor guidelines to require Node.js 18 or newer

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d59556bf44832f8966b073faa29c6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the stated minimum Node.js requirement to version 18, ensuring users install a compatible runtime.
  - Clarified prerequisites in the notes to reduce setup issues and environment mismatches.
  - No behavioural or feature changes; existing workflows and functionality remain unaffected.
  - Guidance and references remain intact, with only the version requirement adjusted for accuracy and alignment with current platform expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->