### PR TITLE
Update docs and enforce Node 20.9.0 requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
             - name: Setup Node
               uses: actions/setup-node@v3
+              with:
+                  node-version: '20.9.0'
 
             - name: Print versions
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v3
               with:
-                  node-version: '20'
+                  node-version: '20.9.0'
 
             - name: Install dependencies
               run: npm install

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A CLI to import <a href="https://moneymoney-app.com" target="_blanK">MoneyMoney<
 Install with NPM:
 
 ```bash
-$ npm i -g actual-moneymoney
+$ npm i -g actual-monmon
 ```
 
 The application will be accessible as a CLI tool with the name `actual-monmon`.

--- a/example-config-advanced.toml
+++ b/example-config-advanced.toml
@@ -1,0 +1,60 @@
+# Advanced example configuration for Actual-MoneyMoney
+# This demonstrates optional settings beyond the basic example.
+
+[payeeTransformation]
+# Enable OpenAI-backed payee normalisation.
+enabled = true
+openAiApiKey = "<openAiKey>"
+openAiModel = "gpt-4o-mini"
+
+[import]
+# Import unchecked transactions and synchronise cleared status.
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+
+[import.ignorePatterns]
+# Ignore patterns use simple case-sensitive substring matching, not glob expressions.
+commentPatterns = ["test", "ignore"]
+payeePatterns = ["spam", "unwanted"]
+purposePatterns = ["internal", "transfer"]
+
+[[actualServers]]
+serverUrl = "http://localhost:5006"
+serverPassword = "<password>"
+
+[[actualServers.budgets]]
+syncId = "<syncId>"
+earliestImportDate = "2024-01-01"
+
+[actualServers.budgets.e2eEncryption]
+enabled = true
+password = "<budgetPassword>"
+
+[actualServers.budgets.accountMapping]
+"Main Account" = "Checking"
+"DE02 1234 5678 9012 3456 78" = "Savings"
+"Credit Card" = "Visa"
+
+[[actualServers.budgets]]
+syncId = "<anotherSyncId>"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+
+[actualServers.budgets.accountMapping]
+"Brokerage" = "Investments"
+
+[[actualServers]]
+serverUrl = "https://actual.example.com"
+serverPassword = "<anotherPassword>"
+
+[[actualServers.budgets]]
+syncId = "<remoteSyncId>"
+earliestImportDate = "2023-06-01"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+
+[actualServers.budgets.accountMapping]
+"Loan" = "Mortgage"
+"Savings" = "Emergency Fund"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
                 "ts-node": "^10.9.2",
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.37.0"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             }
         },
         "node_modules/@actual-app/api": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
         "yargs": "^18.0.0",
         "zod": "^3.23.8"
     },
-    "node": ">=16",
+    "engines": {
+        "node": ">=20.9.0"
+    },
     "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -81,10 +81,8 @@ class PayeeTransformer {
             availableModels = PayeeTransformer.availableModels;
         } else {
             this.logger.debug('Listing available models...');
-            const modelsIterator = await this.openai.models.list();
-            availableModels = (await Array.fromAsync(modelsIterator)).map(
-                (m) => m.id
-            );
+            const response = await this.openai.models.list();
+            availableModels = response.data.map((model) => model.id);
             PayeeTransformer.availableModels = availableModels;
         }
 


### PR DESCRIPTION
## Summary
- add an advanced configuration example that clarifies ignore pattern substring matching
- require Node.js >= 20.9.0 in package metadata and CI workflows
- fix the OpenAI model listing in PayeeTransformer and correct the CLI install command in the README

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d59d6d03e4832f94c4ea060b23f999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Requirements
  - Raised minimum Node.js version to 20.9.0.
- Chores
  - CI and Release workflows updated to use Node.js 20.9.0 for consistency.
- Documentation
  - Updated README to reflect the new CLI name: actual-monmon, including usage and configuration notes.
  - Added an advanced example configuration showcasing payee normalization, import options, multi-server and multi-budget setups, encryption settings, and account mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->