### PR TITLE
feat: support filtering imports by server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ To import transactions:
 actual-monmon import
 ```
 
+You can limit the scope of an import with additional flags:
+
+- `--server <url>` – import only budgets associated with the specified Actual server URL. Repeat the flag to include multiple servers.
+- `--budget <syncId>` – restrict imports to the given Actual budget sync ID. Repeat for multiple budgets.
+- `--account <ref>` – import transactions from a specific MoneyMoney account reference.
+- `--from YYYY-MM-DD` / `--to YYYY-MM-DD` – bound the transaction date range.
+- `--dry-run` – simulate the import without persisting any changes.
+
 ### Command Options
 
 For all available commands and options:


### PR DESCRIPTION
## Summary
- add a --server flag to the import command to restrict processing to selected Actual servers
- validate the provided server URLs before importing and reuse the subset for budget filtering
- document the new filtering options in the README

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a08ff048832fbf5fb0f9b413424d