### PR TITLE
chore: update project dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,30 +10,33 @@
             "license": "MIT",
             "dependencies": {
                 "@actual-app/api": "^25.9.0",
-                "chalk": "^5.6.0",
+                "chalk": "^5.6.2",
                 "date-fns": "^4.1.0",
                 "moneymoney": "^1.2.1",
                 "node-fetch": "^3.3.2",
-                "openai": "^5.16.0",
+                "openai": "^5.23.0",
                 "toml": "^3.0.0",
                 "yargs": "^18.0.0",
-                "zod": "3.25.76"
+                "zod": "^3.25.76"
             },
             "bin": {
                 "actual-monmon": "dist/index.js"
             },
             "devDependencies": {
-                "@commitlint/cli": "^19.8.1",
-                "@commitlint/config-conventional": "^19.8.1",
-                "@eslint/js": "^9.31.0",
+                "@commitlint/cli": "^20.0.0",
+                "@commitlint/config-conventional": "^20.0.0",
+                "@eslint/js": "^9.36.0",
                 "@types/yargs": "^17.0.33",
-                "eslint": "^9.34.0",
-                "globals": "^16.3.0",
+                "eslint": "^9.36.0",
+                "globals": "^16.4.0",
                 "prettier": "^3.6.2",
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^24.2.9",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.8.3",
-                "typescript-eslint": "^8.41.0"
+                "typescript": "^5.9.2",
+                "typescript-eslint": "^8.44.1"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             }
         },
         "node_modules/@actual-app/api": {
@@ -113,17 +116,17 @@
             }
         },
         "node_modules/@commitlint/cli": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
-            "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.0.0.tgz",
+            "integrity": "sha512-I3D7Yldq8ZhOB3qEaTvXWIgib6tSZhbCpRObfFQ/aYI0J9AH8NMwT07Ak+bpE3n6Yn7EtbqEhQUkJZ/jZ5kCeQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/format": "^19.8.1",
-                "@commitlint/lint": "^19.8.1",
-                "@commitlint/load": "^19.8.1",
-                "@commitlint/read": "^19.8.1",
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/format": "^20.0.0",
+                "@commitlint/lint": "^20.0.0",
+                "@commitlint/load": "^20.0.0",
+                "@commitlint/read": "^20.0.0",
+                "@commitlint/types": "^20.0.0",
                 "tinyexec": "^1.0.0",
                 "yargs": "^17.0.0"
             },
@@ -213,13 +216,13 @@
             }
         },
         "node_modules/@commitlint/config-conventional": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
-            "integrity": "sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.0.0.tgz",
+            "integrity": "sha512-q7JroPIkDBtyOkVe9Bca0p7kAUYxZMxkrBArCfuD3yN4KjRAenP9PmYwnn7rsw8Q+hHq1QB2BRmBh0/Z19ZoJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "conventional-changelog-conventionalcommits": "^7.0.2"
             },
             "engines": {
@@ -227,13 +230,13 @@
             }
         },
         "node_modules/@commitlint/config-validator": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
-            "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.0.0.tgz",
+            "integrity": "sha512-BeyLMaRIJDdroJuYM2EGhDMGwVBMZna9UiIqV9hxj+J551Ctc6yoGuGSmghOy/qPhBSuhA6oMtbEiTmxECafsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "ajv": "^8.11.0"
             },
             "engines": {
@@ -241,13 +244,13 @@
             }
         },
         "node_modules/@commitlint/ensure": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
-            "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.0.0.tgz",
+            "integrity": "sha512-WBV47Fffvabe68n+13HJNFBqiMH5U1Ryls4W3ieGwPC0C7kJqp3OVQQzG2GXqOALmzrgAB+7GXmyy8N9ct8/Fg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "lodash.camelcase": "^4.3.0",
                 "lodash.kebabcase": "^4.1.1",
                 "lodash.snakecase": "^4.1.1",
@@ -259,9 +262,9 @@
             }
         },
         "node_modules/@commitlint/execute-rule": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
-            "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+            "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -269,13 +272,13 @@
             }
         },
         "node_modules/@commitlint/format": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
-            "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.0.0.tgz",
+            "integrity": "sha512-zrZQXUcSDmQ4eGGrd+gFESiX0Rw+WFJk7nW4VFOmxub4mAATNKBQ4vNw5FgMCVehLUKG2OT2LjOqD0Hk8HvcRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "chalk": "^5.3.0"
             },
             "engines": {
@@ -283,13 +286,13 @@
             }
         },
         "node_modules/@commitlint/is-ignored": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
-            "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.0.0.tgz",
+            "integrity": "sha512-ayPLicsqqGAphYIQwh9LdAYOVAQ9Oe5QCgTNTj+BfxZb9b/JW222V5taPoIBzYnAP0z9EfUtljgBk+0BN4T4Cw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "semver": "^7.6.0"
             },
             "engines": {
@@ -297,32 +300,32 @@
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
-            "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.0.0.tgz",
+            "integrity": "sha512-kWrX8SfWk4+4nCexfLaQT3f3EcNjJwJBsSZ5rMBw6JCd6OzXufFHgel2Curos4LKIxwec9WSvs2YUD87rXlxNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/is-ignored": "^19.8.1",
-                "@commitlint/parse": "^19.8.1",
-                "@commitlint/rules": "^19.8.1",
-                "@commitlint/types": "^19.8.1"
+                "@commitlint/is-ignored": "^20.0.0",
+                "@commitlint/parse": "^20.0.0",
+                "@commitlint/rules": "^20.0.0",
+                "@commitlint/types": "^20.0.0"
             },
             "engines": {
                 "node": ">=v18"
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
-            "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.0.0.tgz",
+            "integrity": "sha512-WiNKO9fDPlLY90Rruw2HqHKcghrmj5+kMDJ4GcTlX1weL8K07Q6b27C179DxnsrjGCRAKVwFKyzxV4x+xDY28Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^19.8.1",
-                "@commitlint/execute-rule": "^19.8.1",
-                "@commitlint/resolve-extends": "^19.8.1",
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/config-validator": "^20.0.0",
+                "@commitlint/execute-rule": "^20.0.0",
+                "@commitlint/resolve-extends": "^20.0.0",
+                "@commitlint/types": "^20.0.0",
                 "chalk": "^5.3.0",
                 "cosmiconfig": "^9.0.0",
                 "cosmiconfig-typescript-loader": "^6.1.0",
@@ -335,9 +338,9 @@
             }
         },
         "node_modules/@commitlint/message": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
-            "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.0.0.tgz",
+            "integrity": "sha512-gLX4YmKnZqSwkmSB9OckQUrI5VyXEYiv3J5JKZRxIp8jOQsWjZgHSG/OgEfMQBK9ibdclEdAyIPYggwXoFGXjQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -345,13 +348,13 @@
             }
         },
         "node_modules/@commitlint/parse": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
-            "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.0.0.tgz",
+            "integrity": "sha512-j/PHCDX2bGM5xGcWObOvpOc54cXjn9g6xScXzAeOLwTsScaL4Y+qd0pFC6HBwTtrH92NvJQc+2Lx9HFkVi48cg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/types": "^20.0.0",
                 "conventional-changelog-angular": "^7.0.0",
                 "conventional-commits-parser": "^5.0.0"
             },
@@ -360,14 +363,14 @@
             }
         },
         "node_modules/@commitlint/read": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
-            "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.0.0.tgz",
+            "integrity": "sha512-Ti7Y7aEgxsM1nkwA4ZIJczkTFRX/+USMjNrL9NXwWQHqNqrBX2iMi+zfuzZXqfZ327WXBjdkRaytJ+z5vNqTOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/top-level": "^19.8.1",
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/top-level": "^20.0.0",
+                "@commitlint/types": "^20.0.0",
                 "git-raw-commits": "^4.0.0",
                 "minimist": "^1.2.8",
                 "tinyexec": "^1.0.0"
@@ -377,14 +380,14 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
-            "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.0.0.tgz",
+            "integrity": "sha512-BA4vva1hY8y0/Hl80YDhe9TJZpRFMsUYzVxvwTLPTEBotbGx/gS49JlVvtF1tOCKODQp7pS7CbxCpiceBgp3Dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^19.8.1",
-                "@commitlint/types": "^19.8.1",
+                "@commitlint/config-validator": "^20.0.0",
+                "@commitlint/types": "^20.0.0",
                 "global-directory": "^4.0.1",
                 "import-meta-resolve": "^4.0.0",
                 "lodash.mergewith": "^4.6.2",
@@ -395,25 +398,25 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
-            "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.0.0.tgz",
+            "integrity": "sha512-gvg2k10I/RfvHn5I5sxvVZKM1fl72Sqrv2YY/BnM7lMHcYqO0E2jnRWoYguvBfEcZ39t+rbATlciggVe77E4zA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/ensure": "^19.8.1",
-                "@commitlint/message": "^19.8.1",
-                "@commitlint/to-lines": "^19.8.1",
-                "@commitlint/types": "^19.8.1"
+                "@commitlint/ensure": "^20.0.0",
+                "@commitlint/message": "^20.0.0",
+                "@commitlint/to-lines": "^20.0.0",
+                "@commitlint/types": "^20.0.0"
             },
             "engines": {
                 "node": ">=v18"
             }
         },
         "node_modules/@commitlint/to-lines": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
-            "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+            "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -421,9 +424,9 @@
             }
         },
         "node_modules/@commitlint/top-level": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
-            "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.0.0.tgz",
+            "integrity": "sha512-drXaPSP2EcopukrUXvUXmsQMu3Ey/FuJDc/5oiW4heoCfoE5BdLQyuc7veGeE3aoQaTVqZnh4D5WTWe2vefYKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -434,9 +437,9 @@
             }
         },
         "node_modules/@commitlint/types": {
-            "version": "19.8.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
-            "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.0.0.tgz",
+            "integrity": "sha512-bVUNBqG6aznYcYjTjnc3+Cat/iBgbgpflxbIBTnsHTX0YVpnmINPEkSRWymT2Q8aSH3Y7aKnEbunilkYe8TybA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -461,9 +464,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-            "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -602,9 +605,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/js": {
-            "version": "9.34.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-            "integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
+            "version": "9.36.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+            "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1305,17 +1308,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
-            "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+            "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.41.0",
-                "@typescript-eslint/type-utils": "8.41.0",
-                "@typescript-eslint/utils": "8.41.0",
-                "@typescript-eslint/visitor-keys": "8.41.0",
+                "@typescript-eslint/scope-manager": "8.44.1",
+                "@typescript-eslint/type-utils": "8.44.1",
+                "@typescript-eslint/utils": "8.44.1",
+                "@typescript-eslint/visitor-keys": "8.44.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -1329,7 +1332,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.41.0",
+                "@typescript-eslint/parser": "^8.44.1",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -1345,16 +1348,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
-            "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+            "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.41.0",
-                "@typescript-eslint/types": "8.41.0",
-                "@typescript-eslint/typescript-estree": "8.41.0",
-                "@typescript-eslint/visitor-keys": "8.41.0",
+                "@typescript-eslint/scope-manager": "8.44.1",
+                "@typescript-eslint/types": "8.44.1",
+                "@typescript-eslint/typescript-estree": "8.44.1",
+                "@typescript-eslint/visitor-keys": "8.44.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1370,14 +1373,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
-            "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+            "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.41.0",
-                "@typescript-eslint/types": "^8.41.0",
+                "@typescript-eslint/tsconfig-utils": "^8.44.1",
+                "@typescript-eslint/types": "^8.44.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1392,14 +1395,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
-            "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+            "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.41.0",
-                "@typescript-eslint/visitor-keys": "8.41.0"
+                "@typescript-eslint/types": "8.44.1",
+                "@typescript-eslint/visitor-keys": "8.44.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1410,9 +1413,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
-            "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+            "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1427,15 +1430,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
-            "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+            "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.41.0",
-                "@typescript-eslint/typescript-estree": "8.41.0",
-                "@typescript-eslint/utils": "8.41.0",
+                "@typescript-eslint/types": "8.44.1",
+                "@typescript-eslint/typescript-estree": "8.44.1",
+                "@typescript-eslint/utils": "8.44.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -1452,9 +1455,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
-            "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+            "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1466,16 +1469,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
-            "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+            "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.41.0",
-                "@typescript-eslint/tsconfig-utils": "8.41.0",
-                "@typescript-eslint/types": "8.41.0",
-                "@typescript-eslint/visitor-keys": "8.41.0",
+                "@typescript-eslint/project-service": "8.44.1",
+                "@typescript-eslint/tsconfig-utils": "8.44.1",
+                "@typescript-eslint/types": "8.44.1",
+                "@typescript-eslint/visitor-keys": "8.44.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1521,16 +1524,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
-            "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+            "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.41.0",
-                "@typescript-eslint/types": "8.41.0",
-                "@typescript-eslint/typescript-estree": "8.41.0"
+                "@typescript-eslint/scope-manager": "8.44.1",
+                "@typescript-eslint/types": "8.44.1",
+                "@typescript-eslint/typescript-estree": "8.44.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1545,13 +1548,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
-            "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+            "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.41.0",
+                "@typescript-eslint/types": "8.44.1",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -1874,9 +1877,9 @@
             }
         },
         "node_modules/chalk": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-            "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -2708,19 +2711,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.34.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.34.0.tgz",
-            "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
+            "version": "9.36.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+            "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.21.0",
                 "@eslint/config-helpers": "^0.3.1",
                 "@eslint/core": "^0.15.2",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.34.0",
+                "@eslint/js": "9.36.0",
                 "@eslint/plugin-kit": "^0.3.5",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -3465,9 +3468,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-            "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3610,13 +3613,13 @@
             }
         },
         "node_modules/hook-std": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
-            "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+            "integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7349,9 +7352,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "5.16.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-5.16.0.tgz",
-            "integrity": "sha512-hoEH8ZNvg1HXjU9mp88L/ZH8O082Z8r6FHCXGiWAzVRrEv443aI57qhch4snu07yQydj+AUAWLenAiBXhu89Tw==",
+            "version": "5.23.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.0.tgz",
+            "integrity": "sha512-Cfq155NHzI7VWR67LUNJMIgPZy2oSh7Fld/OKhxq648BiUjELAvcge7g30xJ6vAfwwXf6TVK0KKuN+3nmIJG/A==",
             "license": "Apache-2.0",
             "bin": {
                 "openai": "bin/cli"
@@ -8024,9 +8027,9 @@
             "license": "MIT"
         },
         "node_modules/semantic-release": {
-            "version": "24.2.7",
-            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.7.tgz",
-            "integrity": "sha512-g7RssbTAbir1k/S7uSwSVZFfFXwpomUB9Oas0+xi9KStSCmeDXcA7rNhiskjLqvUe/Evhx8fVCT16OSa34eM5g==",
+            "version": "24.2.9",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.9.tgz",
+            "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8044,7 +8047,7 @@
                 "find-versions": "^6.0.0",
                 "get-stream": "^6.0.0",
                 "git-log-parser": "^1.2.0",
-                "hook-std": "^3.0.0",
+                "hook-std": "^4.0.0",
                 "hosted-git-info": "^8.0.0",
                 "import-from-esm": "^2.0.0",
                 "lodash-es": "^4.17.21",
@@ -8056,7 +8059,7 @@
                 "read-package-up": "^11.0.0",
                 "resolve-from": "^5.0.0",
                 "semver": "^7.3.2",
-                "semver-diff": "^4.0.0",
+                "semver-diff": "^5.0.0",
                 "signale": "^1.2.1",
                 "yargs": "^17.5.1"
             },
@@ -8158,9 +8161,10 @@
             }
         },
         "node_modules/semver-diff": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-            "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-5.0.0.tgz",
+            "integrity": "sha512-0HbGtOm+S7T6NGQ/pxJSJipJvc4DK3FcRVMRkhsIwJDJ4Jcz5DQC1cPPzB5GhzyHjwttW878HaWQq46CkL3cqg==",
+            "deprecated": "Deprecated as the semver package now supports this built-in.",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8919,16 +8923,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.41.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.41.0.tgz",
-            "integrity": "sha512-n66rzs5OBXW3SFSnZHr2T685q1i4ODm2nulFJhMZBotaTavsS8TrI3d7bDlRSs9yWo7HmyWrN9qDu14Qv7Y0Dw==",
+            "version": "8.44.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
+            "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.41.0",
-                "@typescript-eslint/parser": "8.41.0",
-                "@typescript-eslint/typescript-estree": "8.41.0",
-                "@typescript-eslint/utils": "8.41.0"
+                "@typescript-eslint/eslint-plugin": "8.44.1",
+                "@typescript-eslint/parser": "8.44.1",
+                "@typescript-eslint/typescript-estree": "8.44.1",
+                "@typescript-eslint/utils": "8.44.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -30,29 +30,29 @@
     "license": "MIT",
     "dependencies": {
         "@actual-app/api": "^25.9.0",
-        "chalk": "^5.6.0",
+        "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "moneymoney": "^1.2.1",
         "node-fetch": "^3.3.2",
-        "openai": "^5.16.0",
+        "openai": "^5.23.0",
         "toml": "^3.0.0",
         "yargs": "^18.0.0",
-        "zod": "3.25.76"
+        "zod": "^3.25.76"
     },
     "engines": {
         "node": ">=20.9.0"
     },
     "devDependencies": {
-        "@commitlint/cli": "^19.8.1",
-        "@commitlint/config-conventional": "^19.8.1",
-        "@eslint/js": "^9.31.0",
+        "@commitlint/cli": "^20.0.0",
+        "@commitlint/config-conventional": "^20.0.0",
+        "@eslint/js": "^9.36.0",
         "@types/yargs": "^17.0.33",
-        "eslint": "^9.34.0",
-        "globals": "^16.3.0",
+        "eslint": "^9.36.0",
+        "globals": "^16.4.0",
         "prettier": "^3.6.2",
-        "semantic-release": "^24.2.7",
+        "semantic-release": "^24.2.9",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3",
-        "typescript-eslint": "^8.41.0"
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.44.1"
     }
 }


### PR DESCRIPTION
## Summary
- bump runtime dependencies such as chalk and openai to their latest releases
- upgrade tooling packages including commitlint, eslint, semantic-release, and TypeScript
- keep zod on the latest v3 line to satisfy openai's optional peer dependency while allowing patch updates

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a06c5594832fae035e0b061e2daf