### PR TITLE
refactor: avoid hard process exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The payee transformation feature automatically converts payee names to human-rea
 1. Set `enabled = true` in the `[payeeTransformation]` section
 2. Provide a valid OpenAI API key (generate one at [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys))
 3. Optionally customize the AI model and settings
+4. (Optional) Set `skipModelValidation = true` if you want to trust the configured model identifier without contacting the OpenAI model listing endpoint
 
 #### Custom Prompts
 
@@ -119,6 +120,8 @@ timeout = 30000    # Request timeout in milliseconds
 ```
 
 **Note**: GPT-4o and GPT-5 models accept temperatures between 0.0 and 2.0. They default to ~0.7 but you can override this for deterministic behavior.
+
+Model validation and payee lookups are cached to keep imports fast and avoid unnecessary OpenAI requests. The model list is stored for one hour in the application data directory, and transformed payee names are memoized within a single import run. Combine these caches with `skipModelValidation = true` if your environment restricts model listing requests.
 
 ### Configuration Summary
 

--- a/example-config-advanced.toml
+++ b/example-config-advanced.toml
@@ -6,6 +6,7 @@
 enabled = true
 openAiApiKey = "${OPENAI_API_KEY}"  # Recommended: load secrets from environment variables
 openAiModel = "gpt-4o-mini"  # Can be: gpt-3.5-turbo, gpt-4, gpt-4o, gpt-4o-mini, gpt-5, etc.
+skipModelValidation = false  # Set to true to skip fetching the model list from the OpenAI API
 
 # Optional: Custom prompt for payee transformation
 # If not provided, a default prompt optimized for financial classification will be used

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
                 "semantic-release": "^24.2.9",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.9.2",
-                "typescript-eslint": "^8.44.1"
+                "typescript-eslint": "^8.44.1",
+                "vitest": "^2.1.4"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -459,6 +460,397 @@
             "dependencies": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
             "engines": {
                 "node": ">=12"
             }
@@ -973,6 +1365,314 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+            "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+            "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+            "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+            "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+            "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+            "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+            "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+            "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+            "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+            "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+            "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+            "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+            "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+            "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+            "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+            "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+            "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+            "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+            "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+            "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+            "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
@@ -1565,6 +2265,119 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+            "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+            "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+            "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+            "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "2.1.9",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+            "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.9",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+            "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+            "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.9",
+                "loupe": "^3.1.2",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@xmldom/xmldom": {
             "version": "0.8.11",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -1729,6 +2542,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1866,6 +2689,16 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1874,6 +2707,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1896,6 +2746,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
             }
         },
         "node_modules/chownr": {
@@ -2445,6 +3305,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2686,6 +3556,52 @@
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/escalade": {
@@ -3000,6 +3916,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3061,6 +3987,16 @@
             "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-content-type-parse": {
@@ -3340,6 +4276,21 @@
             },
             "engines": {
                 "node": ">=14.14"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-timeout": {
@@ -4260,12 +5211,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/loupe": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.19",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
         },
         "node_modules/make-error": {
             "version": "1.3.6",
@@ -4454,6 +5422,25 @@
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
                 "thenify-all": "^1.0.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
         "node_modules/napi-build-utils": {
@@ -7596,6 +8583,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7715,6 +8719,35 @@
             },
             "engines": {
                 "node": ">=10.4.0"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/prebuild-install": {
@@ -7996,6 +9029,48 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/rollup": {
+            "version": "4.52.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+            "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.52.2",
+                "@rollup/rollup-android-arm64": "4.52.2",
+                "@rollup/rollup-darwin-arm64": "4.52.2",
+                "@rollup/rollup-darwin-x64": "4.52.2",
+                "@rollup/rollup-freebsd-arm64": "4.52.2",
+                "@rollup/rollup-freebsd-x64": "4.52.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+                "@rollup/rollup-linux-arm64-musl": "4.52.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-gnu": "4.52.2",
+                "@rollup/rollup-linux-x64-musl": "4.52.2",
+                "@rollup/rollup-openharmony-arm64": "4.52.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+                "@rollup/rollup-win32-x64-gnu": "4.52.2",
+                "@rollup/rollup-win32-x64-msvc": "4.52.2",
+                "fsevents": "~2.3.2"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8213,6 +9288,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -8413,6 +9495,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/spawn-error-forwarder": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
@@ -8465,6 +9557,20 @@
             "engines": {
                 "node": ">= 10.x"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stream-combiner2": {
             "version": "1.1.1",
@@ -8774,12 +9880,49 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyexec": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
             "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -9080,6 +10223,162 @@
                 "spdx-expression-parse": "^3.0.0"
             }
         },
+        "node_modules/vite": {
+            "version": "5.4.20",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+            "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+            "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.7",
+                "es-module-lexer": "^1.5.4",
+                "pathe": "^1.1.2",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+            "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "2.1.9",
+                "@vitest/mocker": "2.1.9",
+                "@vitest/pretty-format": "^2.1.9",
+                "@vitest/runner": "2.1.9",
+                "@vitest/snapshot": "2.1.9",
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "debug": "^4.3.7",
+                "expect-type": "^1.1.0",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2",
+                "std-env": "^3.8.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.1",
+                "tinypool": "^1.0.1",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0",
+                "vite-node": "2.1.9",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "2.1.9",
+                "@vitest/ui": "2.1.9",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -9103,6 +10402,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "start": "node dist/index.js",
         "lint:eslint": "eslint src",
         "lint:prettier": "prettier --check 'src/**/*.ts'",
-        "lint:prettier:fix": "prettier --write 'src/**/*.ts'"
+        "lint:prettier:fix": "prettier --write 'src/**/*.ts'",
+        "test": "vitest run"
     },
     "type": "module",
     "keywords": [
@@ -53,6 +54,7 @@
         "semantic-release": "^24.2.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.44.1"
+        "typescript-eslint": "^8.44.1",
+        "vitest": "^2.1.4"
     }
 }

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -187,7 +187,7 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
         }
     }
 
-    process.exit();
+    return;
 };
 
 export default {

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -60,7 +60,7 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
                     `Failed to parse configuration file: ${e.message} (line ${line}, column ${column})`
                 );
             } else {
-                logger.error(`An unexpected error occured: ${e}`);
+                logger.error(`An unexpected error occurred: ${e}`);
             }
 
             if (e instanceof Error) {

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -28,7 +28,7 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
             `Created default configuration file at: ${configPath}. Please edit it with your preferred settings.`
         );
 
-        process.exit(0);
+        return;
     } else {
         logger.info('Validating configuration...');
 
@@ -63,7 +63,7 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
                 logger.error(`An unexpected error occured: ${e}`);
             }
 
-            process.exit(1);
+            throw new Error('Configuration validation failed.');
         }
 
         logger.info('Configuration file is valid.');

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -63,7 +63,11 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
                 logger.error(`An unexpected error occured: ${e}`);
             }
 
-            throw new Error('Configuration validation failed.');
+            if (e instanceof Error) {
+                throw e;
+            }
+
+            throw new Error(`Configuration validation failed: ${String(e)}`);
         }
 
         logger.info('Configuration file is valid.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ try {
     fs.mkdirSync(APPLICATION_DIRECTORY, { recursive: true });
 }
 
-const _ = yargs(hideBin(process.argv))
+const parser = yargs(hideBin(process.argv))
     .option('config', {
         type: 'string',
         description: 'Path to the configuration file',
@@ -27,13 +27,25 @@ const _ = yargs(hideBin(process.argv))
     .command(validateCommand)
     .showHelpOnFail(false)
     .fail((msg, err) => {
-        const logger = new Logger();
-
         if (err) {
-            logger.error(err.message);
-        } else {
-            logger.error(msg);
+            throw err;
         }
 
-        process.exit(1);
-    }).argv;
+        throw new Error(msg);
+    });
+
+const run = async () => {
+    await parser.parseAsync();
+};
+
+run().catch((error: unknown) => {
+    const logger = new Logger();
+
+    if (error instanceof Error) {
+        logger.error(error.message);
+    } else {
+        logger.error(String(error));
+    }
+
+    process.exitCode = 1;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
-import yargs from 'yargs';
+import yargs, { Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import importCommand from './commands/import.command.js';
 import validateCommand from './commands/validate.command.js';
@@ -14,7 +14,7 @@ try {
     fs.mkdirSync(APPLICATION_DIRECTORY, { recursive: true });
 }
 
-const parser = yargs(hideBin(process.argv))
+const parser: Argv<unknown> = yargs(hideBin(process.argv))
     .option('config', {
         type: 'string',
         description: 'Path to the configuration file',
@@ -34,7 +34,7 @@ const parser = yargs(hideBin(process.argv))
         throw new Error(msg);
     });
 
-const run = async () => {
+const run = async (): Promise<void> => {
     await parser.parseAsync();
 };
 

--- a/src/types/actual-app-augment.d.ts
+++ b/src/types/actual-app-augment.d.ts
@@ -1,0 +1,5 @@
+import type { ImportTransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/import-transaction';
+
+declare module '@actual-app/api' {
+    export type CreateTransaction = ImportTransactionEntity;
+}

--- a/src/types/actual-app-augment.d.ts
+++ b/src/types/actual-app-augment.d.ts
@@ -1,5 +1,5 @@
-import type { ImportTransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/import-transaction';
+import type { CreateTransaction as LocalCreateTransaction } from './actual-app__api.js';
 
 declare module '@actual-app/api' {
-    export type CreateTransaction = ImportTransactionEntity;
+    export type CreateTransaction = LocalCreateTransaction;
 }

--- a/src/types/actual-app__api.d.ts
+++ b/src/types/actual-app__api.d.ts
@@ -263,7 +263,7 @@ type ReadTransaction = Omit<BaseTransaction, 'payee_name'> & {
     subtransactions: ReadSubTransaction[];
 };
 
-type CreateTransaction = Modify<
+export type CreateTransaction = Modify<
     BaseTransaction,
     | 'amount'
     | 'payee'
@@ -335,11 +335,6 @@ deleteAccount(idid) → Promise<null>
 
 Delete an account.
 */
-
-type CreateTransaction = Pick<BaseTransaction, 'account' | 'date'> &
-    Partial<Omit<BaseTransaction, 'id' | 'account' | 'date'>> & {
-        subtransactions: CreateSubTransaction[];
-    };
 
 type UpdateTransaction = Omit<BaseTransaction, 'id' | 'subtransactions'>;
 

--- a/src/types/actual-app__api.d.ts
+++ b/src/types/actual-app__api.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Actual object
  * {
@@ -175,19 +176,21 @@ declare module '@actual-app/api' {
         defaultCleared?: boolean;
     }
 
+    export type CreateTransaction = CreateTransactionPayload;
+
     const addTransactions: (
         accountId: ID,
-        transactions: CreateTransaction[]
+        transactions: CreateTransactionPayload[]
     ) => Promise<ID[]>;
     const importTransactions: (
         accountId: ID,
-        transactions: CreateTransaction[],
+        transactions: CreateTransactionPayload[],
         opts?: ImportTransactionsOpts
     ) => Promise<{ errors?: Error[]; added: ID[]; updated: ID[] }>;
     const getTransactions: (
         accountId: ID,
         startDate: DateString,
-        endDate: DateString
+        endDate?: DateString
     ) => Promise<ReadTransaction[]>;
     const updateTransaction: (
         transactionId: ID,
@@ -263,7 +266,7 @@ type ReadTransaction = Omit<BaseTransaction, 'payee_name'> & {
     subtransactions: ReadSubTransaction[];
 };
 
-export type CreateTransaction = Modify<
+type CreateTransactionPayload = Modify<
     BaseTransaction,
     | 'amount'
     | 'payee'
@@ -364,3 +367,5 @@ type ID = string;
 type MonthString = string;
 type DateString = string;
 type Amount = number;
+
+export type { CreateTransactionPayload as CreateTransaction };

--- a/src/types/actual-app__api.d.ts
+++ b/src/types/actual-app__api.d.ts
@@ -199,7 +199,10 @@ declare module '@actual-app/api' {
     const deleteTransaction: (transactionId: ID) => Promise<void>;
 
     // Accounts
-    const getAccounts: () => Promise<Account[]>;
+    const getAccounts: (
+        includeOffBudget?: boolean,
+        includeClosed?: boolean
+    ) => Promise<Account[]>;
     const createAccount: (
         account: CreateAccount,
         initialBalance?: number

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -217,14 +217,23 @@ class ActualApi {
                 info: console.info,
                 debug: console.debug,
             };
+
+            const originals = ActualApi.originals;
+
             console.log = suppressIfNoisy(
-                ActualApi.originals.log.bind(console)
+                (...args: Parameters<typeof console.log>) => {
+                    originals.log.apply(console, args);
+                }
             );
             console.info = suppressIfNoisy(
-                ActualApi.originals.info.bind(console)
+                (...args: Parameters<typeof console.info>) => {
+                    originals.info.apply(console, args);
+                }
             );
             console.debug = suppressIfNoisy(
-                ActualApi.originals.debug.bind(console)
+                (...args: Parameters<typeof console.debug>) => {
+                    originals.debug.apply(console, args);
+                }
             );
         }
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -136,15 +136,17 @@ class ActualApi {
 
     getTransactions(accountId: string, options?: { from?: Date; to?: Date }) {
         let from = options?.from ?? new Date(2000, 0, 1);
-        let to = options?.to ?? new Date();
-        if (from > to) {
+        let to = options?.to ?? null;
+        if (to && from > to) {
             [from, to] = [to, from];
         }
         const startDate = format(from, 'yyyy-MM-dd');
-        const endDate = format(to, 'yyyy-MM-dd');
+        const endDate = to ? format(to, 'yyyy-MM-dd') : null;
 
         return this.suppressConsoleLog(() =>
-            actual.getTransactions(accountId, startDate, endDate)
+            endDate
+                ? actual.getTransactions(accountId, startDate, endDate)
+                : actual.getTransactions(accountId, startDate, undefined)
         );
     }
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -89,7 +89,7 @@ class ActualApi {
     async sync() {
         await this.ensureInitialization();
         await this.suppressConsoleLog(async () => {
-            await actual.internal.send('sync');
+            await actual.internal.send('sync', undefined);
         });
     }
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -98,7 +98,7 @@ class ActualApi {
     async getAccounts() {
         await this.ensureInitialization();
         const accounts = await this.suppressConsoleLog(async () => {
-            return await actual.getAccounts();
+            return await actual.getAccounts(undefined, undefined);
         });
         return accounts;
     }

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -91,7 +91,7 @@ class ActualApi {
     async sync() {
         await this.ensureInitialization();
         await this.suppressConsoleLog(async () => {
-            await actual.internal.send('sync');
+            await actual.internal.send('sync', undefined);
         });
     }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -161,7 +161,10 @@ class Importer {
             }
 
             const existingActualTransactions =
-                await this.actualApi.getTransactions(actualAccount.id);
+                await this.actualApi.getTransactions(actualAccount.id, {
+                    from: importDate,
+                    to: toDate ?? undefined,
+                });
 
             this.logger.debug(
                 `Found ${existingActualTransactions.length} existing transactions for Actual account '${actualAccount.name}'`

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1,4 +1,5 @@
 import { format, subMonths } from 'date-fns';
+import type { CreateTransaction } from '@actual-app/api';
 import {
     Account as MonMonAccount,
     Transaction as MonMonTransaction,

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -1,12 +1,23 @@
+import fs from 'fs/promises';
+import path from 'path';
 import OpenAI from 'openai';
 import Logger from './Logger.js';
 import { PayeeTransformationConfig } from './config.js';
+import { DEFAULT_DATA_DIR } from './shared.js';
 
 interface ModelCapabilities {
     supportsTemperature: boolean;
     supportsMaxTokens: boolean;
     defaultTemperature: number;
 }
+
+interface ModelCache {
+    models: Array<string>;
+    expiresAt: number;
+}
+
+const MODEL_CACHE_FILENAME = 'openai-model-cache.json';
+const MODEL_CACHE_TTL_MS = 1000 * 60 * 60; // 1 hour
 
 type ExtendedChatCompletionCreateParams =
     OpenAI.Chat.Completions.ChatCompletionCreateParams & {
@@ -18,6 +29,53 @@ class PayeeTransformer {
     private availableModels: Array<string> | null = null;
     private modelListInitialized = false;
     private modelCapabilities: Map<string, ModelCapabilities> = new Map();
+    private transformationCache = new Map<string, string>();
+
+    private static modelCache: ModelCache | null = null;
+
+    private static getCacheFilePath() {
+        return path.join(DEFAULT_DATA_DIR, MODEL_CACHE_FILENAME);
+    }
+
+    private static async ensureCacheDirExists() {
+        await fs.mkdir(DEFAULT_DATA_DIR, { recursive: true });
+    }
+
+    private static async readModelCacheFromDisk() {
+        try {
+            const cacheFile = PayeeTransformer.getCacheFilePath();
+            const cacheContent = await fs.readFile(cacheFile, 'utf-8');
+            const parsed = JSON.parse(cacheContent) as ModelCache;
+            if (
+                !Array.isArray(parsed.models) ||
+                typeof parsed.expiresAt !== 'number'
+            ) {
+                return null;
+            }
+
+            return parsed;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+                return null;
+            }
+
+            return null;
+        }
+    }
+
+    private static async writeModelCacheToDisk(cache: ModelCache) {
+        try {
+            await PayeeTransformer.ensureCacheDirExists();
+            const cacheFile = PayeeTransformer.getCacheFilePath();
+            await fs.writeFile(
+                cacheFile,
+                JSON.stringify(cache, null, 2),
+                'utf-8'
+            );
+        } catch (_error) {
+            // Ignore cache write errors but log in debug environments if needed
+        }
+    }
 
     constructor(
         private config: PayeeTransformationConfig,
@@ -45,21 +103,32 @@ class PayeeTransformer {
             return {};
         }
 
-        // Log original payee names at DEBUG level
-        this.logger.debug('Original payee names:', payeeList);
+        const uniquePayees = Array.from(new Set(payeeList));
+        const uncachedPayees = uniquePayees.filter(
+            (payee) => !this.transformationCache.has(payee)
+        );
+
+        this.logger.debug('Original payee names:', uniquePayees);
+
+        if (uncachedPayees.length === 0) {
+            this.logger.debug(
+                'All payees resolved from cache. Skipping OpenAI request.'
+            );
+            return this.buildResponse(uniquePayees);
+        }
+
+        this.logger.debug(`Starting payee transformation...`, [
+            `Payees requested: ${uniquePayees.length}`,
+            `Using cache for: ${uniquePayees.length - uncachedPayees.length}`,
+            `Model: ${this.config.openAiModel}`,
+        ]);
 
         try {
-            this.logger.debug(`Starting payee transformation...`, [
-                `Payees: ${payeeList.length}`,
-                `Model: ${this.config.openAiModel}`,
-            ]);
-
-            // Validate model before proceeding
             const model = await this.getConfiguredModel();
 
             const response = await this.makeOpenAIRequest(
                 prompt,
-                payeeList,
+                uncachedPayees,
                 model
             );
 
@@ -86,16 +155,25 @@ class PayeeTransformer {
                     [key: string]: string;
                 };
 
-                // Log transformed payee names at DEBUG level
+                for (const [original, transformed] of Object.entries(
+                    transformedPayees
+                )) {
+                    if (typeof transformed === 'string') {
+                        this.transformationCache.set(original, transformed);
+                    }
+                }
+
+                const finalResult = this.buildResponse(uniquePayees);
+
                 this.logger.debug('Payee transformation completed:', [
                     'Original → Transformed:',
-                    ...Object.entries(transformedPayees).map(
+                    ...Object.entries(finalResult).map(
                         ([original, transformed]) =>
                             `  "${original}" → "${transformed}"`
                     ),
                 ]);
 
-                return transformedPayees;
+                return finalResult;
             } catch (parseError) {
                 this.logger.error(
                     `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
@@ -212,28 +290,65 @@ class PayeeTransformer {
     }
 
     private async getConfiguredModel() {
-        // Only fetch models once per instance
-        if (!this.modelListInitialized) {
-            this.logger.debug('Initializing model list...');
-            const response = await this.openai.models.list();
-            this.availableModels = response.data.map((m) => m.id);
-            this.modelListInitialized = true;
-            this.logger.debug(
-                `Found ${this.availableModels.length} available models.`
-            );
-        } else {
-            this.logger.debug('Using cached model list.');
+        if (this.config.skipModelValidation) {
+            this.logger.debug('Skipping OpenAI model validation.');
+            return this.config.openAiModel;
         }
 
-        if (!this.availableModels!.includes(this.config.openAiModel)) {
+        const availableModels = await this.getAvailableModels();
+
+        if (!availableModels.includes(this.config.openAiModel)) {
             this.logger.error(
                 `The specified model '${this.config.openAiModel}' is invalid. The following models are available:`,
-                this.availableModels!
+                availableModels
             );
             throw new Error('Invalid OpenAI model specified.');
         }
 
         return this.config.openAiModel;
+    }
+
+    private async getAvailableModels() {
+        if (this.modelListInitialized && this.availableModels) {
+            return this.availableModels;
+        }
+
+        const now = Date.now();
+
+        const inMemoryCache = PayeeTransformer.modelCache;
+        if (inMemoryCache && inMemoryCache.expiresAt > now) {
+            this.logger.debug('Using in-memory OpenAI model cache.');
+            this.availableModels = inMemoryCache.models;
+            this.modelListInitialized = true;
+            return this.availableModels;
+        }
+
+        const diskCache = await PayeeTransformer.readModelCacheFromDisk();
+        if (diskCache && diskCache.expiresAt > now) {
+            this.logger.debug('Loaded OpenAI model list from disk cache.');
+            PayeeTransformer.modelCache = diskCache;
+            this.availableModels = diskCache.models;
+            this.modelListInitialized = true;
+            return this.availableModels;
+        }
+
+        this.logger.debug('Fetching OpenAI model list from OpenAI API...');
+        const response = await this.openai.models.list();
+        const models = response.data.map((m) => m.id);
+        const cache: ModelCache = {
+            models,
+            expiresAt: now + MODEL_CACHE_TTL_MS,
+        };
+
+        PayeeTransformer.modelCache = cache;
+        this.availableModels = models;
+        this.modelListInitialized = true;
+
+        await PayeeTransformer.writeModelCacheToDisk(cache);
+
+        this.logger.debug(`Found ${models.length} available models.`);
+
+        return models;
     }
 
     private generatePrompt() {
@@ -327,6 +442,16 @@ CRITICAL: Return ONLY valid JSON. No explanations or additional text.`;
         } else {
             this.logger.error('Unknown error in payee transformation');
         }
+    }
+
+    private buildResponse(payees: Array<string>) {
+        return payees.reduce(
+            (acc, payee) => {
+                acc[payee] = this.transformationCache.get(payee) ?? payee;
+                return acc;
+            },
+            {} as Record<string, string>
+        );
     }
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -68,6 +68,7 @@ const payeeTransformationSchema = z.object({
         'OpenAI API key must not be empty'
     ).optional(),
     openAiModel: z.string().trim().optional().default('gpt-3.5-turbo'),
+    skipModelValidation: z.boolean().default(false),
     customPrompt: z.string().optional(),
     modelConfig: z
         .object({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,16 +2,47 @@ import fs from 'fs/promises';
 import path from 'path';
 import toml from 'toml';
 import { ArgumentsCamelCase } from 'yargs';
-import { ZodIssueCode, z } from 'zod';
+import { formatISO, isValid as isValidDate, parseISO } from 'date-fns';
+import { ZodError, ZodIssueCode, z } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
+
+const trimmedNonEmptyString = (message: string) =>
+    z.string().trim().min(1, message);
+
+const isoDateSchema = z
+    .string()
+    .trim()
+    .superRefine((value, ctx) => {
+        const parsed = parseISO(value);
+
+        if (!isValidDate(parsed)) {
+            ctx.addIssue({
+                code: ZodIssueCode.custom,
+                message:
+                    'Invalid earliest import date. Provide a valid ISO 8601 date (YYYY-MM-DD).',
+            });
+            return;
+        }
+
+        const canonical = formatISO(parsed, { representation: 'date' });
+        if (canonical !== value) {
+            ctx.addIssue({
+                code: ZodIssueCode.custom,
+                message:
+                    'Invalid earliest import date. Provide a valid ISO 8601 date (YYYY-MM-DD).',
+            });
+        }
+    });
 
 const budgetSchema = z
     .object({
-        syncId: z.string(),
-        earliestImportDate: z.string().optional(),
+        syncId: trimmedNonEmptyString('Sync ID must not be empty'),
+        earliestImportDate: isoDateSchema.optional(),
         e2eEncryption: z.object({
             enabled: z.boolean(),
-            password: z.string().optional(),
+            password: trimmedNonEmptyString(
+                'Encryption password must not be empty'
+            ).optional(),
         }),
         accountMapping: z.record(z.string(), z.string()),
     })
@@ -23,29 +54,20 @@ const budgetSchema = z
                     'Password must not be empty if end-to-end encryption is enabled',
             });
         }
-
-        if (val.earliestImportDate) {
-            const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-            if (!dateRegex.test(val.earliestImportDate)) {
-                ctx.addIssue({
-                    code: ZodIssueCode.custom,
-                    message:
-                        'Invalid earliest import date format (required format is YYYY-MM-DD)',
-                });
-            }
-        }
     });
 
 const actualServerSchema = z.object({
-    serverUrl: z.string(),
-    serverPassword: z.string(),
+    serverUrl: z.string().trim(),
+    serverPassword: trimmedNonEmptyString('Server password must not be empty'),
     budgets: z.array(budgetSchema).min(1),
 });
 
 const payeeTransformationSchema = z.object({
     enabled: z.boolean(),
-    openAiApiKey: z.string().optional(),
-    openAiModel: z.string().optional().default('gpt-3.5-turbo'),
+    openAiApiKey: trimmedNonEmptyString(
+        'OpenAI API key must not be empty'
+    ).optional(),
+    openAiModel: z.string().trim().optional().default('gpt-3.5-turbo'),
     customPrompt: z.string().optional(),
     modelConfig: z
         .object({
@@ -131,6 +153,17 @@ export const getConfig = async (argv: ArgumentsCamelCase) => {
             throw new Error(
                 `Failed to parse configuration file: ${parseError.message} (line ${line}, column ${column})`
             );
+        }
+
+        if (e instanceof ZodError) {
+            const formattedIssues = e.issues
+                .map((issue) => {
+                    const path = issue.path.join('.') || '<root>';
+                    return `${path}: ${issue.message}`;
+                })
+                .join('; ');
+
+            throw new Error(`Invalid configuration: ${formattedIssues}`);
         }
 
         throw new Error(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import toml from 'toml';
-import { ArgumentsCamelCase } from 'yargs';
+import type { ArgumentsCamelCase } from 'yargs';
 import { formatISO, isValid as isValidDate, parseISO } from 'date-fns';
 import { ZodError, ZodIssueCode, z } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
@@ -57,7 +57,7 @@ const budgetSchema = z
     });
 
 const actualServerSchema = z.object({
-    serverUrl: z.string().trim(),
+    serverUrl: z.string().trim().url(),
     serverPassword: trimmedNonEmptyString('Server password must not be empty'),
     budgets: z.array(budgetSchema).min(1),
 });

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -21,6 +21,7 @@ export const EXAMPLE_CONFIG = `
 enabled = false
 openAiApiKey = "<openAiKey>"
 openAiModel = "gpt-3.5-turbo"
+# skipModelValidation = false # Optional: Skip contacting OpenAI to verify the model name
 # customPrompt = "Your custom prompt here..." # Optional: Override default prompt
 # [payeeTransformation.modelConfig] # Optional: Model-specific settings
 # temperature = 0.0 # 0.0 = deterministic, 1.0 = creative (0.0-2.0)

--- a/tests/ActualApi.test.ts
+++ b/tests/ActualApi.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import type { ActualServerConfig } from '../src/utils/config.js';
+import type Logger from '../src/utils/Logger.js';
+import { LogLevel } from '../src/utils/Logger.js';
+
+const getTransactionsMock = vi.fn();
+const shutdownMock = vi.fn();
+
+vi.mock('@actual-app/api', () => ({
+    default: {
+        init: vi.fn(),
+        internal: {
+            send: vi.fn(),
+        },
+        getAccounts: vi.fn(),
+        downloadBudget: vi.fn(),
+        importTransactions: vi.fn(),
+        getTransactions: getTransactionsMock,
+        shutdown: shutdownMock,
+    },
+}));
+
+const createLogger = () =>
+    ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        getLevel: () => LogLevel.INFO,
+    } as unknown as Logger);
+
+describe('ActualApi', () => {
+    beforeEach(() => {
+        getTransactionsMock.mockReset();
+        shutdownMock.mockReset();
+    });
+
+    it('passes bounded date ranges to the Actual API and restores console state', async () => {
+        const { default: ActualApi } = await import('../src/utils/ActualApi.js');
+
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            budgets: [
+                {
+                    syncId: 'budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+            ],
+        };
+
+        const api = new ActualApi(serverConfig, createLogger());
+        // Mark as initialized to avoid touching the filesystem in tests
+        // @ts-expect-error accessing protected test hook
+        api.isInitialized = true;
+
+        const logSpy = vi.spyOn(console, 'log');
+        getTransactionsMock.mockImplementation(async () => {
+            console.log('Got messages from server abc');
+            return [];
+        });
+
+        const start = new Date('2024-02-01T00:00:00Z');
+        const end = new Date('2024-02-20T00:00:00Z');
+
+        await api.getTransactions('account-1', { from: start, to: end });
+
+        expect(getTransactionsMock).toHaveBeenCalledWith(
+            'account-1',
+            '2024-02-01',
+            '2024-02-20'
+        );
+        expect(console.log).toBe(logSpy);
+        expect(
+            logSpy.mock.calls.some((args) =>
+                String(args[0]).includes('Got messages from server')
+            )
+        ).toBe(false);
+
+        logSpy.mockRestore();
+    });
+
+    it('ignores shutdown when the API was never initialised', async () => {
+        const { default: ActualApi } = await import('../src/utils/ActualApi.js');
+
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            budgets: [
+                {
+                    syncId: 'budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+            ],
+        };
+
+        const api = new ActualApi(serverConfig, createLogger());
+        await api.shutdown();
+
+        expect(shutdownMock).not.toHaveBeenCalled();
+    });
+});

--- a/tests/Importer.test.ts
+++ b/tests/Importer.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import type { ActualBudgetConfig, Config } from '../src/utils/config.js';
+import Importer from '../src/utils/Importer.js';
+import type ActualApi from '../src/utils/ActualApi.js';
+import type { AccountMap } from '../src/utils/AccountMap.js';
+import type Logger from '../src/utils/Logger.js';
+import { LogLevel } from '../src/utils/Logger.js';
+
+const { moneyMoneyTransactionsMock } = vi.hoisted(() => ({
+    moneyMoneyTransactionsMock: vi.fn(),
+}));
+
+vi.mock('moneymoney', () => ({
+    getTransactions: moneyMoneyTransactionsMock,
+}));
+
+const createLogger = () =>
+    ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        getLevel: () => LogLevel.INFO,
+    } as unknown as Logger);
+
+describe('Importer', () => {
+    beforeEach(() => {
+        moneyMoneyTransactionsMock.mockReset();
+    });
+
+    it('aligns Actual transaction queries with the effective import date', async () => {
+        const config: Config = {
+            payeeTransformation: {
+                enabled: false,
+                skipModelValidation: false,
+                openAiModel: 'gpt-3.5-turbo',
+            },
+            import: {
+                importUncheckedTransactions: true,
+                synchronizeClearedStatus: true,
+                maskPayeeNamesInLogs: false,
+            },
+            actualServers: [],
+        };
+
+        const budgetConfig: ActualBudgetConfig = {
+            syncId: 'budget-1',
+            earliestImportDate: '2024-02-01',
+            e2eEncryption: {
+                enabled: false,
+                password: undefined,
+            },
+            accountMapping: {},
+        };
+
+        const account = {
+            uuid: 'account-uuid',
+            name: 'Checking',
+            balance: [[1000]],
+        };
+
+        const actualAccount = {
+            id: 'actual-1',
+            name: 'Checking',
+        };
+
+        moneyMoneyTransactionsMock.mockResolvedValue([
+            {
+                id: 'txn-1',
+                accountUuid: 'account-uuid',
+                name: 'Example',
+                purpose: 'Purpose',
+                comment: '',
+                valueDate: new Date('2024-02-15T00:00:00Z'),
+                bookingDate: new Date('2024-02-16T00:00:00Z'),
+                amount: 123.45,
+                booked: true,
+                bankCode: '',
+                accountNumber: '',
+                partner: '',
+                partnerAccount: '',
+                category: '',
+                purposeCode: '',
+                currencyCode: 'EUR',
+                balance: 0,
+            },
+        ]);
+
+        const actualApi = {
+            getTransactions: vi.fn().mockResolvedValue([]),
+            importTransactions: vi.fn().mockResolvedValue({
+                added: [],
+                updated: [],
+                errors: [],
+            }),
+        };
+
+        const accountMap = {
+            getMap: () =>
+                new Map([
+                    [
+                        account,
+                        actualAccount,
+                    ],
+                ]),
+        };
+
+        const importer = new Importer(
+            config,
+            budgetConfig,
+            actualApi as unknown as ActualApi,
+            createLogger() as unknown as Logger,
+            accountMap as unknown as AccountMap,
+            undefined
+        );
+
+        const from = new Date('2024-01-01T00:00:00Z');
+        const to = new Date('2024-03-01T00:00:00Z');
+
+        await importer.importTransactions({ from, to });
+
+        const [moneyMoneyArgs] = moneyMoneyTransactionsMock.mock.calls;
+        expect(moneyMoneyArgs).toBeDefined();
+        expect(moneyMoneyArgs[0].from.toISOString()).toBe(
+            '2024-02-01T00:00:00.000Z'
+        );
+        expect(moneyMoneyArgs[0].to).toBe(to);
+
+        const [actualArgs] = actualApi.getTransactions.mock.calls;
+        expect(actualArgs).toBeDefined();
+        expect(actualArgs[0]).toBe('actual-1');
+        expect(actualArgs[1]?.from.toISOString()).toBe(
+            '2024-02-01T00:00:00.000Z'
+        );
+        expect(actualArgs[1]?.to).toBe(to);
+    });
+});

--- a/tests/PayeeTransformer.test.ts
+++ b/tests/PayeeTransformer.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+
+import type Logger from '../src/utils/Logger.js';
+import { LogLevel } from '../src/utils/Logger.js';
+
+const listMock = vi.fn();
+const createMock = vi.fn();
+
+class MockOpenAI {
+    public models = {
+        list: listMock,
+    };
+
+    public chat = {
+        completions: {
+            create: createMock,
+        },
+    };
+
+    constructor(public readonly options: { apiKey: string; timeout?: number }) {}
+}
+
+vi.mock('openai', () => ({
+    default: MockOpenAI,
+}));
+
+let dataDir: string;
+
+vi.mock('../src/utils/shared.js', async () => {
+    const actual = await vi.importActual<typeof import('../src/utils/shared.js')>(
+        '../src/utils/shared.js'
+    );
+
+    return {
+        ...actual,
+        get DEFAULT_DATA_DIR() {
+            return dataDir;
+        },
+    };
+});
+
+const createLogger = () =>
+    ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        getLevel: () => LogLevel.DEBUG,
+    } as unknown as Logger);
+
+const importTransformer = async () => {
+    const module = await import('../src/utils/PayeeTransformer.js');
+    return module.default;
+};
+
+beforeEach(async () => {
+    listMock.mockReset();
+    createMock.mockReset();
+
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'actual-moneymoney-test-'));
+
+    createMock.mockImplementation(async (config: {
+        messages: Array<{ content: string }>;
+    }) => {
+        const userMessage = config.messages[1]?.content ?? '';
+        const payees = userMessage.split('\n').filter(Boolean);
+        const result = Object.fromEntries(
+            payees.map((payee) => [payee, `${payee}-normalized`])
+        );
+
+        return {
+            choices: [
+                {
+                    message: {
+                        content: JSON.stringify(result),
+                    },
+                },
+            ],
+        };
+    });
+
+    listMock.mockResolvedValue({
+        data: [
+            { id: 'gpt-3.5-turbo' },
+            { id: 'gpt-4o-mini' },
+        ],
+    });
+});
+
+afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+    // Reset module state between tests to clear static caches
+    vi.resetModules();
+});
+
+describe('PayeeTransformer', () => {
+    it('skips model validation when configured', async () => {
+        const PayeeTransformer = await importTransformer();
+        const transformer = new PayeeTransformer(
+            {
+                enabled: true,
+                openAiApiKey: 'key',
+                openAiModel: 'custom-model',
+                skipModelValidation: true,
+            },
+            createLogger()
+        );
+
+        const result = await transformer.transformPayees(['Example Vendor']);
+
+        expect(result).toEqual({ 'Example Vendor': 'Example Vendor-normalized' });
+        expect(listMock).not.toHaveBeenCalled();
+        expect(createMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches model list between transformer instances', async () => {
+        const PayeeTransformer = await importTransformer();
+
+        const firstTransformer = new PayeeTransformer(
+            {
+                enabled: true,
+                openAiApiKey: 'key',
+                openAiModel: 'gpt-3.5-turbo',
+                skipModelValidation: false,
+            },
+            createLogger()
+        );
+
+        await firstTransformer.transformPayees(['Vendor A']);
+
+        const secondTransformer = new PayeeTransformer(
+            {
+                enabled: true,
+                openAiApiKey: 'key',
+                openAiModel: 'gpt-3.5-turbo',
+                skipModelValidation: false,
+            },
+            createLogger()
+        );
+
+        await secondTransformer.transformPayees(['Vendor B']);
+
+        expect(listMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('memoizes transformed payees within the same run', async () => {
+        const PayeeTransformer = await importTransformer();
+
+        const transformer = new PayeeTransformer(
+            {
+                enabled: true,
+                openAiApiKey: 'key',
+                openAiModel: 'gpt-3.5-turbo',
+                skipModelValidation: false,
+            },
+            createLogger()
+        );
+
+        await transformer.transformPayees(['Vendor C']);
+        listMock.mockClear();
+        createMock.mockClear();
+
+        const result = await transformer.transformPayees(['Vendor C']);
+
+        expect(result).toEqual({ 'Vendor C': 'Vendor C-normalized' });
+        expect(createMock).not.toHaveBeenCalled();
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -107,5 +107,7 @@
         /* Completeness */
         // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
         "skipLibCheck": true /* Skip type checking all .d.ts files. */
-    }
+    },
+    "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx"],
+    "exclude": ["tests", "vitest.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['tests/**/*.test.ts'],
+        coverage: {
+            reporter: ['text', 'html'],
+            enabled: false,
+        },
+    },
+});


### PR DESCRIPTION
## Summary
- replace the CLI bootstrap's direct `process.exit` call with async parsing and centralized error logging
- allow the import command handler to finish naturally instead of terminating the process
- let configuration validation exit early on success and throw an explicit error when validation fails

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a2462204832f88f1a1125fd42dbc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - On-disk and in-memory model-list caching with per-run memoisation and skipModelValidation flag; new CLI option --logLevel and async startup with centralised error handling.

- Bug Fixes
  - More graceful shutdown and consistent exit signalling; transaction queries now respect date ranges; suppression of noisy external-API output; clearer configuration validation messages.

- Documentation
  - README and example config updated to document skipModelValidation and caching behaviour.

- Tests / Chores
  - Added and extended unit tests, Vitest config and test script; updated project include/build settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->