### PR TITLE
fix: suppress additional Actual sync noise

### DIFF
--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -30,7 +30,14 @@ const isActualNoise = (args: unknown[]) => {
 
     const message = util.format(...(args as [unknown, ...unknown[]]));
 
-    return message.startsWith('Got messages from server');
+    const noisyPrefixes = [
+        'Got messages from server',
+        'Syncing since',
+        'SENT -------',
+        'RECEIVED -------',
+    ];
+
+    return noisyPrefixes.some((prefix) => message.startsWith(prefix));
 };
 
 const installActualNoiseFilter = () => {


### PR DESCRIPTION
## Summary
- extend the Actual console noise filter to include sync and transport message prefixes

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a530d98c832f848d06791f2d25f5