### PR TITLE
docs: refresh project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Indent using **4 spaces** (match existing code style).
 - Prefer explicit types for function parameters/returns when not inferred from obvious context.
 - Keep logging consistent by using the `Logger` utility instead of `console.log` directly.
-- Follow existing naming patterns (`*.command.ts` for CLI commands, PascalCase for classes, camelCase for variables/functions`).
+- Follow existing naming patterns (`*.command.ts` for CLI commands, `PascalCase` for classes, `camelCase` for variables and functions).
 - When adding new configuration options or command-line flags, update the TOML schema/validation in `src/utils/config.ts`, the generated default config in `src/utils/shared.ts`, and relevant documentation (e.g., `README.md`, `example-config-advanced.toml`).
 
 ## Testing & Tooling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@
 - Indent using **4 spaces** (match existing code style).
 - Prefer explicit types for function parameters/returns when not inferred from obvious context.
 - Keep logging consistent by using the `Logger` utility instead of `console.log` directly.
-- Follow existing naming patterns (`*.command.ts` for CLI commands, PascalCase for classes, camelCase for variables/functions).
-- When adding new configuration options or command-line flags, update relevant TOML schema/validation and documentation (e.g., `README.md`).
+- Follow existing naming patterns (`*.command.ts` for CLI commands, PascalCase for classes, camelCase for variables/functions`).
+- When adding new configuration options or command-line flags, update the TOML schema/validation in `src/utils/config.ts`, the generated default config in `src/utils/shared.ts`, and relevant documentation (e.g., `README.md`, `example-config-advanced.toml`).
 
 ## Testing & Tooling
 Run the following commands before committing changes:
@@ -31,6 +31,7 @@ These checks ensure linting, formatting, and TypeScript compilation succeed.
 - Keep the subject under 72 characters and avoid ending it with a period.
 
 ## Additional Notes
-- Node.js version 18 or newer is required.
-- Example configurations live at `example-config-advanced.toml` and should stay in sync with config schema changes.
+- Node.js v20.9.0 or newer is required (see `package.json` `engines` field).
+- Default configuration files live in `~/.actually/config.toml`. Keep the example config defined in `src/utils/shared.ts` aligned with the validation schema.
+- Example configurations such as `example-config-advanced.toml` should stay in sync with config schema changes and README documentation.
 - Assets (logos, etc.) reside in `/assets`; update paths carefully if moving files referenced in the README.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,16 @@ The application will be accessible as a CLI tool with the name `actual-monmon`.
 
 ## Dependencies
 
+- Node.js **v20.9.0 or newer** (see `package.json` `engines` field)
+- A licensed copy of MoneyMoney on macOS to access the transaction database
+
 **Note on zod version**: This project is currently pinned to zod v3.25.76 due to a peer dependency conflict with the openai package. The openai library requires zod v3.x (`^3.23.8`), but zod v4.x introduces breaking changes that are incompatible. This prevents dependabot from automatically updating to zod v4, which would break the application. We'll update zod when openai releases a version that supports zod v4.
 
 ## Configuration
 
-The application needs to be configured with a TOML document to function. You can validate your configuration by running `actual-monmon validate`. Running this for the first time will create an example configuration file. You can also pass a custom configuration path with the `--config` parameter.
+The application needs to be configured with a TOML document to function. By default, Actual-MoneyMoney stores and reads configuration files from `~/.actually/config.toml`.
+
+You can validate (and automatically create) your configuration by running `actual-monmon validate`. If the configuration file does not exist yet, the command will create a starter file at the resolved path (default: `~/.actually/config.toml`). You can point to a different location with the `--config <path>` option when running any command.
 
 For detailed command-line options, run `actual-monmon --help`.
 
@@ -53,6 +58,7 @@ openAiModel = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use
 [import]
 importUncheckedTransactions = true
 synchronizeClearedStatus = true
+maskPayeeNamesInLogs = true  # Optional: keep payee names obfuscated in non-debug logs
 
 # Actual servers, you can add multiple servers
 [[actualServers]]
@@ -140,6 +146,12 @@ Before importing, validate your configuration:
 actual-monmon validate
 ```
 
+You can increase or decrease CLI verbosity with `--logLevel` (`0 = ERROR`, `1 = WARN`, `2 = INFO`, `3 = DEBUG`). Combine it with `--config` to validate a different configuration file:
+
+```bash
+actual-monmon validate --config ./config.toml --logLevel 3
+```
+
 ### Import Transactions
 
 To import transactions:
@@ -155,6 +167,8 @@ You can limit the scope of an import with additional flags:
 - `--account <ref>` – import transactions from a specific MoneyMoney account reference.
 - `--from YYYY-MM-DD` / `--to YYYY-MM-DD` – bound the transaction date range.
 - `--dry-run` – simulate the import without persisting any changes.
+- `--logLevel <0-3>` – control CLI verbosity (defaults to `2`, INFO).
+- `--config <path>` – load a configuration file from a custom path.
 
 ### Command Options
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The application will be accessible as a CLI tool with the name `actual-monmon`.
 
 The application needs to be configured with a TOML document to function. By default, Actual-MoneyMoney stores and reads configuration files from `~/.actually/config.toml`.
 
-You can validate (and automatically create) your configuration by running `actual-monmon validate`. If the configuration file does not exist yet, the command will create a starter file at the resolved path (default: `~/.actually/config.toml`). You can point to a different location with the `--config <path>` option when running any command.
+You can validate (and automatically create) your configuration by running `actual-monmon validate`. If the configuration file does not exist yet, the command will create a starter file at the resolved path (default: `~/.actually/config.toml`). When the file already exists, `validate` leaves it unchanged and only reports schema issues. You can point to a different location with the `--config <path>` option when running any command.
 
 For detailed command-line options, run `actual-monmon --help`.
 

--- a/example-config-advanced.toml
+++ b/example-config-advanced.toml
@@ -57,8 +57,8 @@ maskPayeeNamesInLogs = true  # Mask payee names unless log level is DEBUG
 # Optional: Ignore patterns for filtering transactions (supports case-insensitive * wildcards)
 [import.ignorePatterns]
 commentPatterns = ["test", "ignore*"]
-payeePatterns = ["spam", "unwanted"]
-purposePatterns = ["internal", "transfer"]
+payeePatterns = ["spam*", "unwanted"]
+purposePatterns = ["internal", "transfer*"]
 
 # Actual servers configuration
 [[actualServers]]

--- a/example-config-advanced.toml
+++ b/example-config-advanced.toml
@@ -54,9 +54,9 @@ importUncheckedTransactions = true
 synchronizeClearedStatus = true
 maskPayeeNamesInLogs = true  # Mask payee names unless log level is DEBUG
 
-# Optional: Ignore patterns for filtering transactions
+# Optional: Ignore patterns for filtering transactions (supports case-insensitive * wildcards)
 [import.ignorePatterns]
-commentPatterns = ["test", "ignore"]  # Uses simple case-insensitive substring matching (no wildcards)
+commentPatterns = ["test", "ignore*"]
 payeePatterns = ["spam", "unwanted"]
 purposePatterns = ["internal", "transfer"]
 


### PR DESCRIPTION
## Summary
- clarify contributor guidance with updated Node.js requirements and config sync expectations in AGENTS.md
- document default configuration location, CLI verbosity flag, and other setup notes in the README
- refresh the advanced example configuration to highlight wildcard support for ignore patterns

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d63644ca98832fb49f85c9af69db03

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified configuration locations and defaults (e.g., ~/.actually/config.toml) and expanded CLI/config guidance with examples.
  - Documented new visible options: maskPayeeNamesInLogs and logLevel, plus --config CLI usage and examples.
  - Updated prerequisites: requires Node.js v20.9.0+ and MoneyMoney.
  - Improved naming convention formatting and contributing guidance.
  - Updated examples to show case-insensitive wildcard support in ignore patterns and alignment with config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->