### PR TITLE
feat: add payee log masking toggle and cleanup tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A CLI to import [MoneyMoney](https://moneymoney-app.com) transactions into [Actu
   - [Advanced Configuration](#advanced-configuration)
   - [Payee Transformation](#payee-transformation)
 - [Usage](#usage)
+- [Development](#development)
 - [Account Mapping](#account-mapping)
 - [Troubleshooting](#troubleshooting)
 
@@ -53,6 +54,7 @@ A basic configuration document looks like this:
 enabled = false
 openAiApiKey = "<openAiKey>"  # Your OpenAI API key
 openAiModel = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use
+# maskPayeeNamesInLogs = true     # Optional: keep payee names obfuscated in payee transformation debug logs
 
 # Import settings
 [import]
@@ -101,6 +103,8 @@ The payee transformation feature automatically converts payee names to human-rea
 2. Provide a valid OpenAI API key (generate one at [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys))
 3. Optionally customize the AI model and settings
 4. (Optional) Set `skipModelValidation = true` if you want to trust the configured model identifier without contacting the OpenAI model listing endpoint
+
+By default, payee transformation debug logs mask payee names unless you opt out with `maskPayeeNamesInLogs = false`. This keeps sensitive payee data hidden even when running with verbose logging levels.
 
 #### Custom Prompts
 
@@ -180,6 +184,16 @@ For all available commands and options:
 ```bash
 actual-monmon --help
 ```
+
+## Development
+
+Helpful npm scripts when working on the project:
+
+- `npm run lint:eslint` – run ESLint against the TypeScript sources.
+- `npm run lint:prettier` – check formatting with Prettier.
+- `npm run typecheck` – perform a strict TypeScript type check without emitting files.
+- `npm run build` – compile the CLI for distribution.
+- `npm test` – execute the Vitest suite.
 
 ## Account Mapping
 

--- a/example-config-advanced.toml
+++ b/example-config-advanced.toml
@@ -7,6 +7,7 @@ enabled = true
 openAiApiKey = "${OPENAI_API_KEY}"  # Recommended: load secrets from environment variables
 openAiModel = "gpt-4o-mini"  # Can be: gpt-3.5-turbo, gpt-4, gpt-4o, gpt-4o-mini, gpt-5, etc.
 skipModelValidation = false  # Set to true to skip fetching the model list from the OpenAI API
+maskPayeeNamesInLogs = true  # Keep payee names obfuscated in PayeeTransformer debug logs
 
 # Optional: Custom prompt for payee transformation
 # If not provided, a default prompt optimized for financial classification will be used

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "chalk": "^5.6.2",
                 "date-fns": "^4.1.0",
                 "moneymoney": "^1.2.1",
-                "node-fetch": "^3.3.2",
                 "openai": "^5.23.0",
                 "toml": "^3.0.0",
                 "yargs": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "exports": "./index.js",
     "scripts": {
         "build": "npx tsc",
-        "typecheck": "tsc --noEmit",
+        "typecheck": "tsc --noEmit -p tsconfig.json",
         "start": "node dist/index.js",
         "lint:eslint": "eslint src",
         "lint:prettier": "prettier --check 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "exports": "./index.js",
     "scripts": {
         "build": "npx tsc",
+        "typecheck": "tsc --noEmit",
         "start": "node dist/index.js",
         "lint:eslint": "eslint src",
         "lint:prettier": "prettier --check 'src/**/*.ts'",
@@ -34,7 +35,6 @@
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "moneymoney": "^1.2.1",
-        "node-fetch": "^3.3.2",
         "openai": "^5.23.0",
         "toml": "^3.0.0",
         "yargs": "^18.0.0",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -69,6 +69,7 @@ const payeeTransformationSchema = z.object({
     ).optional(),
     openAiModel: z.string().trim().optional().default('gpt-3.5-turbo'),
     skipModelValidation: z.boolean().default(false),
+    maskPayeeNamesInLogs: z.boolean().default(true),
     customPrompt: z.string().optional(),
     modelConfig: z
         .object({

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -21,6 +21,7 @@ export const EXAMPLE_CONFIG = `
 enabled = false
 openAiApiKey = "<openAiKey>"
 openAiModel = "gpt-3.5-turbo"
+# maskPayeeNamesInLogs = true
 # skipModelValidation = false # Optional: Skip contacting OpenAI to verify the model name
 # customPrompt = "Your custom prompt here..." # Optional: Override default prompt
 # [payeeTransformation.modelConfig] # Optional: Model-specific settings


### PR DESCRIPTION
## Summary
- add a dedicated `npm run typecheck` script and document the local development workflow
- mask payee names in PayeeTransformer debug logs by default with an opt-out configuration switch
- remove the unused Actual API user file helpers and drop the redundant node-fetch dependency

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64fc500bc832fb7c7a225f8bef95a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Config option to mask payee names in logs (enabled by default); logging now respects masking and limits verbose entries.

- Documentation
  - README and example config updated to document payee-name masking and add a Development section listing npm scripts (lint, typecheck, build, test).

- Chores
  - Removed an unused dependency and added a typecheck npm script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->