### PR TITLE
Split CI verification into dedicated npm jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,74 @@ on:
             - main
     pull_request:
 jobs:
-    test:
-        name: test
+    lint:
+        name: lint
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: oven-sh/setup-bun@v1
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - name: Install dependencies
+              run: npm ci
+            - name: ESLint
+              run: npm run lint:eslint
+            - name: Prettier
+              run: npm run lint:prettier
 
-            - run: bun install
-            - run: bun run lint:eslint
-            - run: bun run lint:prettier
-            - run: bun run build
+    typecheck:
+        name: typecheck
+        needs: lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - name: Install dependencies
+              run: npm ci
+            - name: Type check
+              run: npm run typecheck
+
+    build:
+        name: build
+        needs:
+            - lint
+            - typecheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - name: Install dependencies
+              run: npm ci
+            - name: Build
+              run: npm run build
+
+    test:
+        name: test
+        needs:
+            - lint
+            - typecheck
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+            - name: Install dependencies
+              run: npm ci
+            - name: Run tests
+              run: npm test
 
     commitlint:
         runs-on: ubuntu-latest
@@ -24,8 +81,10 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node
-              uses: actions/setup-node@v3
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
 
             - name: Print versions
               run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,14 @@
 - When adding new configuration options or command-line flags, update the TOML schema/validation in `src/utils/config.ts`, the generated default config in `src/utils/shared.ts`, and relevant documentation (e.g., `README.md`, `example-config-advanced.toml`).
 
 ## Testing & Tooling
-Run the following commands before committing changes:
+Run the following commands before committing changes so local development matches CI:
 1. `npm run lint:eslint`
 2. `npm run lint:prettier`
-3. `npm run build`
+3. `npm run typecheck`
+4. `npm run build`
+5. `npm test`
 
-These checks ensure linting, formatting, and TypeScript compilation succeed.
+These checks ensure code quality, formatting, type safety, build output, and automated tests remain healthy.
 
 ## Commit Messages
 - Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification so that commitlint accepts new commits.


### PR DESCRIPTION
## Summary
- split the CI workflow into lint, typecheck, build, and test jobs that share a consistent Node 20 setup and run via npm
- restore ESLint coverage in CI and developer guidance, updating the commitlint job to actions/setup-node v4

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test -- --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68d683b756f8832f871c5deff4a18568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardised CI to use npm with separate lint, type-check, build, and test jobs for more reliable pipelines.
  - Unified Node.js setup across jobs and streamlined steps for consistency and maintainability.
  - Improved commit message checks to align with the updated workflow.

- Documentation
  - Updated contributor guidance to match the new CI process and tooling.
  - Added instructions for running type checks locally.
  - Clarified success criteria to include type safety and automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->