### PR TITLE
fix: add auto-approve step to dependabot workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -12,6 +12,11 @@ jobs:
             contents: write
             pull-requests: write
         steps:
+            - name: Auto-approve Dependabot PR
+              uses: hmarr/auto-approve-action@v3
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  
             - name: Auto-merge minor and patch updates
               uses: fastify/github-action-merge-dependabot@v3
               with:

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -16,7 +16,7 @@ jobs:
               uses: hmarr/auto-approve-action@v3
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  
+
             - name: Auto-merge minor and patch updates
               uses: fastify/github-action-merge-dependabot@v3
               with:


### PR DESCRIPTION
## Problem

The Dependabot auto-merge workflow was missing the auto-approve step, causing:
- Dependabot PRs to get stuck waiting for manual approval
- Auto-merge functionality to fail because PRs weren't approved
- Existing Dependabot PRs to remain open indefinitely

## Solution

Added the auto-approve step using `hmarr/auto-approve-action@v3` to automatically approve Dependabot PRs before attempting to merge them.

## Changes

- Added auto-approve step to `.github/workflows/auto-merge-dependabot.yml`
- Dependabot PRs will now be auto-approved and auto-merged when CI passes
- Maintains approval requirement for human PRs while automating dependency updates

## Benefits

- ✅ Dependabot PRs will be automatically approved
- ✅ Auto-merge will work properly for safe updates
- ✅ Reduces manual maintenance overhead
- ✅ Faster security updates

## Testing

Once merged, the existing 6 Dependabot PRs should be automatically approved and merged (except for the zod major update which requires manual review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated approval for Dependabot pull requests in the CI workflow, enabling approvals to occur before automatic merging of eligible updates.
  * Streamlines routine dependency maintenance, reducing manual intervention and accelerating delivery of minor and patch updates.
  * Improves reliability and consistency of dependency upgrades with a predictable, hands-off process.
  * No changes to user-facing behaviour or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->