### PR TITLE
chore: update sync script to use temporary upstream remote

### DIFF
--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -6,9 +6,33 @@ set -e
 
 echo "🔄 Syncing with upstream repository..."
 
+# Cleanup function to remove upstream remote if it was added by this script
+cleanup() {
+    if git remote get-url upstream >/dev/null 2>&1; then
+        echo "🧹 Cleaning up temporary upstream remote..."
+        git remote remove upstream
+    fi
+}
+
+# Set up cleanup on script exit
+trap cleanup EXIT
+
+# Check if upstream remote exists, if not add it temporarily
+if ! git remote get-url upstream >/dev/null 2>&1; then
+    echo "📡 Adding temporary upstream remote..."
+    git remote add upstream https://github.com/NikxDa/actual-moneymoney.git
+    echo "✅ Upstream remote added (will be removed when script exits)"
+fi
+
 # Fetch latest changes from upstream
 echo "📥 Fetching upstream changes..."
 git fetch upstream
+
+# Check if there are any changes to sync
+if git merge-base --is-ancestor upstream/main develop; then
+    echo "✅ Develop is already up to date with upstream"
+    exit 0
+fi
 
 # Show what's new in upstream
 echo "📊 Upstream changes since last sync:"


### PR DESCRIPTION
## Summary

This PR updates the sync script to use a temporary upstream remote instead of permanently configuring it, preventing accidental PRs to the upstream repository.

## Changes

- Add automatic cleanup of upstream remote on script exit
- Use `trap cleanup EXIT` to remove temporary upstream remote
- Prevent permanent upstream remote configuration
- Improve script robustness and user experience
- Maintain clean git remote configuration

## Benefits

- ✅ **No permanent pollution**: Git remotes stay clean
- ✅ **Reusable**: Can run the script multiple times without issues
- ✅ **Self-cleaning**: Automatically removes temporary configuration
- ✅ **Safe**: Won't interfere with normal git workflow
- ✅ **Prevents accidents**: No risk of creating PRs on upstream repo

## How It Works

1. Script checks if upstream remote exists
2. If not, adds temporary upstream remote
3. Performs sync operation
4. Automatically removes upstream remote on exit

## Testing

The script now:
- Only temporarily configures upstream remote
- Automatically cleans up after itself
- Maintains clean git remote state
- Prevents accidental upstream PRs

Fixes the issue where the upstream remote was permanently configured, leading to accidental PR creation on the upstream repository.