### PR TITLE
fix(config): allow empty E2E encryption password when disabled

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -43,9 +43,7 @@ const budgetSchema = z
         earliestImportDate: isoDateSchema.optional(),
         e2eEncryption: z.object({
             enabled: z.boolean(),
-            password: trimmedNonEmptyString(
-                'Encryption password must not be empty'
-            ).optional(),
+            password: z.string().trim().optional(),
         }),
         accountMapping: z.record(z.string(), z.string()),
     })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -53,6 +53,7 @@ const budgetSchema = z
                 code: ZodIssueCode.custom,
                 message:
                     'Password must not be empty if end-to-end encryption is enabled',
+                path: ['e2eEncryption', 'password'],
             });
         }
     });
@@ -117,6 +118,7 @@ export const configSchema = z
                 code: ZodIssueCode.custom,
                 message:
                     'OpenAI key must not be empty if payeeTransformation is enabled',
+                path: ['payeeTransformation', 'openAiApiKey'],
             });
         }
     });
@@ -128,7 +130,7 @@ export type ActualServerConfig = z.infer<typeof actualServerSchema>;
 export type ActualBudgetConfig = z.infer<typeof budgetSchema>;
 export type Config = z.infer<typeof configSchema>;
 
-export const getConfigFile = (argv: ArgumentsCamelCase) => {
+export const getConfigFile = (argv: ArgumentsCamelCase): string => {
     if (argv.config) {
         const argvConfigFile = path.resolve(argv.config as string);
         return argvConfigFile;
@@ -137,7 +139,7 @@ export const getConfigFile = (argv: ArgumentsCamelCase) => {
     return DEFAULT_CONFIG_FILE;
 };
 
-export const getConfig = async (argv: ArgumentsCamelCase) => {
+export const getConfig = async (argv: ArgumentsCamelCase): Promise<Config> => {
     const configFile = getConfigFile(argv);
 
     const configFileExists = await fs

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { configSchema } from '../src/utils/config.js';
+
+describe('Config Validation', () => {
+    describe('E2E Encryption Validation', () => {
+        it('should allow empty password when encryption is disabled', () => {
+            const validConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: false,
+                                    password: '',
+                                },
+                                accountMapping: {
+                                    'test-account': 'actual-account-id',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(validConfig)).not.toThrow();
+        });
+
+        it('should allow undefined password when encryption is disabled', () => {
+            const validConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: false,
+                                    // password is undefined
+                                },
+                                accountMapping: {
+                                    'test-account': 'actual-account-id',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(validConfig)).not.toThrow();
+        });
+
+        it('should require non-empty password when encryption is enabled', () => {
+            const invalidConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: true,
+                                    password: '',
+                                },
+                                accountMapping: {
+                                    'test-account': 'actual-account-id',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(invalidConfig)).toThrow();
+        });
+
+        it('should require password when encryption is enabled (undefined password)', () => {
+            const invalidConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: true,
+                                    // password is undefined
+                                },
+                                accountMapping: {
+                                    'test-account': 'actual-account-id',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(invalidConfig)).toThrow();
+        });
+
+        it('should accept valid password when encryption is enabled', () => {
+            const validConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: true,
+                                    password: 'valid-encryption-password',
+                                },
+                                accountMapping: {
+                                    'test-account': 'actual-account-id',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(validConfig)).not.toThrow();
+        });
+
+        it('should handle multiple budgets with different encryption settings', () => {
+            const validConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id-1',
+                                e2eEncryption: {
+                                    enabled: false,
+                                    password: '',
+                                },
+                                accountMapping: {
+                                    'test-account-1': 'actual-account-id-1',
+                                },
+                            },
+                            {
+                                syncId: 'test-sync-id-2',
+                                e2eEncryption: {
+                                    enabled: true,
+                                    password: 'valid-encryption-password',
+                                },
+                                accountMapping: {
+                                    'test-account-2': 'actual-account-id-2',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(validConfig)).not.toThrow();
+        });
+    });
+
+    describe('Basic Config Validation', () => {
+        it('should validate a minimal valid configuration', () => {
+            const validConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: false,
+                                    password: '',
+                                },
+                                accountMapping: {},
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(validConfig)).not.toThrow();
+        });
+
+        it('should reject configuration with missing required fields', () => {
+            const invalidConfig = {
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        // missing serverPassword
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: false,
+                                    password: '',
+                                },
+                                accountMapping: {},
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(invalidConfig)).toThrow();
+        });
+    });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -96,6 +96,31 @@ describe('Config Validation', () => {
             expect(() => configSchema.parse(invalidConfig)).toThrow();
         });
 
+        it('should reject whitespace-only password when encryption is enabled', () => {
+            const invalidConfig = {
+                payeeTransformation: { enabled: false },
+                import: { importUncheckedTransactions: true },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'test-password',
+                        budgets: [
+                            {
+                                syncId: 'test-sync-id',
+                                e2eEncryption: {
+                                    enabled: true,
+                                    password: '   ',
+                                },
+                                accountMapping: { 'test-account': 'actual-account-id' },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            expect(() => configSchema.parse(invalidConfig)).toThrow();
+        });
+
         it('should require password when encryption is enabled (undefined password)', () => {
             const invalidConfig = {
                 payeeTransformation: {


### PR DESCRIPTION
- Fix validation schema to allow empty strings when encryption is disabled
- Add comprehensive test coverage for E2E encryption validation scenarios
- Prevents regression where empty passwords were incorrectly rejected
- Resolves validation error: 'Encryption password must not be empty'

Fixes the issue where users with disabled E2E encryption couldn't use empty password fields, causing configuration validation to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted configuration validation: encryption password can be empty or omitted when encryption is disabled, and must be non-empty when enabled. Error feedback is clearer and more consistent across related fields.

- Tests
  - Added comprehensive tests covering encryption on/off scenarios, empty/undefined passwords, valid passwords, multiple budgets with mixed settings, minimal valid configuration, and missing required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->