### PR TITLE
fix: harden validate config creation

### DIFF
--- a/docs/deep-review.md
+++ b/docs/deep-review.md
@@ -2,12 +2,12 @@
 
 ## 1. Executive Summary
 
-The project has evolved significantly with robust foundations now in place. The Actual adapter successfully completes the download → load → sync lifecycle with proper console state management, and the test suite runs cleanly without hangs.【F:src/utils/ActualApi.ts†L85-L219】【F:tests/ActualApi.test.ts†L53-L195】 The CI/CD pipeline is well-structured with comprehensive checks including linting, type checking, testing, and building.【F:.github/workflows/ci.yml†L1-L106】【F:.github/workflows/release.yml†L1-L50】 However, several critical issues remain: the `validate` command still fails to create parent directories, security vulnerabilities exist in dependencies, and some architectural improvements are needed for production readiness.
+The project has evolved significantly with robust foundations now in place. The Actual adapter successfully completes the download → load → sync lifecycle with proper console state management, and the test suite runs cleanly without hangs.【F:src/utils/ActualApi.ts†L85-L219】【F:tests/ActualApi.test.ts†L53-L195】 The CI/CD pipeline is well-structured with comprehensive checks including linting, type checking, testing, and building.【F:.github/workflows/ci.yml†L1-L106】【F:.github/workflows/release.yml†L1-L50】 However, several critical issues remain: security vulnerabilities exist in dependencies, and some architectural improvements are needed for production readiness.
 
 ### 5-Point Action Plan
 
 1. ✅ Fix the budget lifecycle (download → load → sync) and add error/timeout handling in the Actual adapter (completed).
-1. 🚧 **CRITICAL**: Fix the `validate` command directory creation issue (B2) - still failing to create parent directories.
+1. ✅ Fix the `validate` command directory creation issue (B2) so parent directories are created automatically.
 1. ✅ Identify and fix the Vitest hang issue with console patching (completed with proper cleanup).
 1. 🚧 **HIGH**: Address security vulnerabilities in dependencies (5 moderate severity issues in esbuild/vitest chain).
 1. ✅ Align the toolchain with npm, add typecheck script, and secure the release flow (completed).
@@ -17,7 +17,7 @@ The project has evolved significantly with robust foundations now in place. The 
 | ID | Status | Category | File:Line | Short Description | Repro Steps | Expected vs. Current Behaviour | Fix Proposal |
 | --- | ----------- | -------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | B1 | ✅ Resolved | Bug | `src/utils/ActualApi.ts:176-219` | Budget lifecycle previously stopped at `downloadBudget`, leaving the session without an active budget.【F:src/utils/ActualApi.ts†L176-L219】 | Covered by the `ActualApi` unit suite (loadBudget test).【F:tests/ActualApi.test.ts†L103-L141】 | Budget download, load, and sync now complete before returning, so account/transaction calls see fresh data.【F:src/utils/ActualApi.ts†L176-L219】 | Fix landed: `loadBudget` chains download → load → sync and logs failures, with regression coverage in Vitest.【F:src/utils/ActualApi.ts†L176-L219】【F:tests/ActualApi.test.ts†L103-L141】 |
-| B2 | 🚧 **CRITICAL** | Bug | `src/commands/validate.command.ts:22-29` | `validate` writes config files but does not create parent directories.【F:src/commands/validate.command.ts†L22-L29】 | 1. Run `actual-monmon validate --config ./tmp/custom/config.toml` in an empty project. 2. Command fails with `ENOENT`. | Expected: path is created recursively and example config written (README promise). Actual: write attempt aborts. | Call `fs.mkdir(path.dirname(configPath), { recursive: true })` before `writeFile` and log errors clearly.【F:README.md†L40-L44】 |
+| B2 | ✅ Resolved | Bug | `src/commands/validate.command.ts:18-77` | `validate` writes config files and now creates parent directories before writing the default config.【F:src/commands/validate.command.ts†L18-L77】 | Covered by new validate command tests for directory creation, current-directory configs, and write failures.【F:tests/commands/validate.command.test.ts†L1-L199】 | Path is created recursively and example config written when missing, with detailed logging for failures.【F:src/commands/validate.command.ts†L18-L77】 | Fix landed: create parent directory with recursive mkdir, write template, and log errors with context; regression coverage added in Vitest.【F:src/commands/validate.command.ts†L18-L77】【F:tests/commands/validate.command.test.ts†L1-L199】 |
 | B3 | ✅ Resolved | Bug | `tests/ActualApi.test.ts` | Vitest run used to hang because console patching never unwound after timeouts.【F:tests/ActualApi.test.ts†L143-L195】 | Regression covered by `npm test` and targeted Actual API specs.【chunk:6f7772†L1-L6】【F:tests/ActualApi.test.ts†L53-L195】 | Test suite now exits cleanly; console patching restores globals and clears fake timers.【F:src/utils/ActualApi.ts†L85-L121】【F:tests/ActualApi.test.ts†L53-L195】 | Fixed by wrapping each Actual API request in a scoped `patchConsole` guard and adding timer cleanup in the timeout test.【F:src/utils/ActualApi.ts†L85-L121】【F:tests/ActualApi.test.ts†L143-L195】 |
 | B4 | 🚧 **HIGH** | Security | `package.json` dependencies | 5 moderate severity vulnerabilities in esbuild/vitest dependency chain.【F:package.json†L46-L60】 | Run `npm audit --audit-level=high` to see vulnerabilities. | Expected: No high-severity vulnerabilities. Actual: 5 moderate vulnerabilities in dev dependencies. | Update vitest to v3.2.4+ or consider alternative testing framework.【F:package.json†L58】 |
 
@@ -48,7 +48,7 @@ _Target state:_ Users can create/validate configs anywhere.
 _Acceptance criteria:_ `validate` creates paths, error text offers guidance, README stays in sync.
 _Risks:_ Path handling on Windows/macOS.
 
-- 🚧 **CRITICAL** Story B1 (S): recursive `mkdir` before `writeFile`, add tests for success/error paths.【F:src/commands/validate.command.ts†L22-L29】
+- ✅ Story B1 (S): recursive `mkdir` before `writeFile`, add tests for success/error paths.【F:src/commands/validate.command.ts†L18-L77】【F:tests/commands/validate.command.test.ts†L1-L199】
 - ✅ Story B2 (S): document CLI option normalisation (`--server`, `--budget`) and add tests for filter logic.【F:src/commands/import.command.ts†L84-L200】
 
 ### Epic C – Test/CI hardening
@@ -80,7 +80,7 @@ _Risks:_ Breaking changes in major version updates.
 ## 5. Test Strategy & Coverage
 
 - **Importer E2E**: Scenarios for dedupe (`imported_id`), starting balance, `ignorePatterns`, dry-run against mocked Actual.【F:src/utils/Importer.ts†L175-L209】
-- **Config validation**: Tests for custom paths, schema failures, skip-model-validation flag, and TOML syntax errors.【F:src/utils/config.ts†L8-L104】【F:src/commands/validate.command.ts†L22-L73】
+- **Config validation**: Tests for custom paths, schema failures, skip-model-validation flag, and TOML syntax errors.【F:src/utils/config.ts†L8-L104】【F:src/commands/validate.command.ts†L18-L105】
 - **ActualApi**: Unit tests for budget lifecycle (init/download/load/shutdown), error handling (401/500), console patch behaviour.
 - **CLI smoke**: `--help`, `import --dry-run`, `validate` (new/broken config). Use snapshots with masked payees (respect `maskPayeeNamesInLogs`).【F:src/utils/Importer.ts†L200-L236】
 - **Determinism**: Mock timers/date access (`Date.now`, `subMonths`) for reproducible logs.
@@ -114,4 +114,4 @@ _Risks:_ Breaking changes in major version updates.
 - 🚧 `npm audit --audit-level=high` highlights the existing esbuild advisory (5 moderate vulnerabilities in dev dependencies).
 - ✅ All CI/CD workflows are properly configured with comprehensive checks.
 - ✅ Test suite runs cleanly with 11 passing tests across 3 test files.
-- 🚧 **CRITICAL**: `validate` command still fails to create parent directories (B2).
+- ✅ `validate` command now creates parent directories and writes the default config when missing (B2).

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -1,8 +1,8 @@
 import toml from 'toml';
-import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { z } from 'zod';
+import type { ArgumentsCamelCase, CommandModule } from 'yargs';
 import path from 'node:path';
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import Logger, { LogLevel } from '../utils/Logger.js';
 import { configSchema, getConfigFile } from '../utils/config.js';
 import { EXAMPLE_CONFIG } from '../utils/shared.js';
@@ -42,7 +42,10 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
 
             logger.debug('Writing default configuration template...');
             try {
-                await fs.writeFile(configPath, EXAMPLE_CONFIG, 'utf-8');
+                await fs.writeFile(configPath, EXAMPLE_CONFIG, {
+                    encoding: 'utf-8',
+                    mode: 0o600,
+                });
             } catch (writeError) {
                 const writeMessage =
                     writeError instanceof Error
@@ -109,4 +112,4 @@ export default {
     command: 'validate',
     describe: 'View information about and validate the current configuration',
     handler: handleValidate,
-} as CommandModule;
+} as CommandModule<ArgumentsCamelCase>;

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -1,9 +1,10 @@
 import toml from 'toml';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
-import { configSchema, getConfigFile } from '../utils/config.js';
+import { z } from 'zod';
+import path from 'node:path';
 import fs from 'fs/promises';
 import Logger, { LogLevel } from '../utils/Logger.js';
-import { z } from 'zod';
+import { configSchema, getConfigFile } from '../utils/config.js';
 import { EXAMPLE_CONFIG } from '../utils/shared.js';
 
 const handleValidate = async (argv: ArgumentsCamelCase) => {
@@ -20,8 +21,39 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
         configContent = await fs.readFile(configPath, 'utf-8');
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-            // Create path to file and file itself if it doesn't exist
-            await fs.writeFile(configPath, EXAMPLE_CONFIG);
+            const targetDirectory = path.dirname(configPath);
+
+            logger.debug(
+                `Ensuring configuration directory exists: ${targetDirectory}`
+            );
+            try {
+                await fs.mkdir(targetDirectory, { recursive: true });
+            } catch (mkdirError) {
+                const mkdirMessage =
+                    mkdirError instanceof Error
+                        ? mkdirError.message
+                        : String(mkdirError);
+                logger.error('Failed to create configuration directory.', [
+                    `Path: ${targetDirectory}`,
+                    `Reason: ${mkdirMessage}`,
+                ]);
+                throw mkdirError;
+            }
+
+            logger.debug('Writing default configuration template...');
+            try {
+                await fs.writeFile(configPath, EXAMPLE_CONFIG, 'utf-8');
+            } catch (writeError) {
+                const writeMessage =
+                    writeError instanceof Error
+                        ? writeError.message
+                        : String(writeError);
+                logger.error('Failed to create configuration file.', [
+                    `Path: ${configPath}`,
+                    `Reason: ${writeMessage}`,
+                ]);
+                throw writeError;
+            }
 
             logger.warn('Configuration file not found.');
             logger.info(

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -80,11 +80,11 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
         if (e instanceof z.ZodError) {
             logger.error('Configuration file is invalid:');
             for (const issue of e.issues) {
-                const path = issue.path.length
+                const issuePath = issue.path.length
                     ? issue.path.join('.')
                     : '<root>';
                 logger.error(
-                    `Code ${issue.code} at path [${path}]: ${issue.message}`
+                    `Code ${issue.code} at path [${issuePath}]: ${issue.message}`
                 );
             }
         } else if (e instanceof Error && e.name === 'SyntaxError') {
@@ -95,7 +95,9 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
                 `Failed to parse configuration file: ${e.message} (line ${line}, column ${column})`
             );
         } else {
-            logger.error(`An unexpected error occurred: ${e}`);
+            logger.error('An unexpected error occurred.', [
+                e instanceof Error ? e.message : String(e),
+            ]);
         }
 
         if (e instanceof Error) {

--- a/tests/commands/validate.command.test.ts
+++ b/tests/commands/validate.command.test.ts
@@ -3,11 +3,11 @@ import type { ArgumentsCamelCase } from 'yargs';
 
 import { EXAMPLE_CONFIG } from '../../src/utils/shared.js';
 
-const readFileMock = vi.fn<typeof import('fs/promises')['readFile']>();
-const writeFileMock = vi.fn<typeof import('fs/promises')['writeFile']>();
-const mkdirMock = vi.fn<typeof import('fs/promises')['mkdir']>();
+const readFileMock = vi.fn<typeof import('node:fs/promises')['readFile']>();
+const writeFileMock = vi.fn<typeof import('node:fs/promises')['writeFile']>();
+const mkdirMock = vi.fn<typeof import('node:fs/promises')['mkdir']>();
 
-vi.mock('fs/promises', () => ({
+vi.mock('node:fs/promises', () => ({
     __esModule: true,
     default: {
         readFile: readFileMock,
@@ -98,7 +98,7 @@ describe('validate command', () => {
         expect(writeFileMock).toHaveBeenCalledWith(
             configPath,
             EXAMPLE_CONFIG,
-            'utf-8'
+            { encoding: 'utf-8', mode: 0o600 }
         );
         expect(configSchemaParseMock).not.toHaveBeenCalled();
     });
@@ -130,7 +130,7 @@ describe('validate command', () => {
         expect(writeFileMock).toHaveBeenCalledWith(
             configPath,
             EXAMPLE_CONFIG,
-            'utf-8'
+            { encoding: 'utf-8', mode: 0o600 }
         );
     });
 

--- a/tests/commands/validate.command.test.ts
+++ b/tests/commands/validate.command.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ArgumentsCamelCase } from 'yargs';
+
+import { EXAMPLE_CONFIG } from '../../src/utils/shared.js';
+
+const readFileMock = vi.fn<typeof import('fs/promises')['readFile']>();
+const writeFileMock = vi.fn<typeof import('fs/promises')['writeFile']>();
+const mkdirMock = vi.fn<typeof import('fs/promises')['mkdir']>();
+
+vi.mock('fs/promises', () => ({
+    __esModule: true,
+    default: {
+        readFile: readFileMock,
+        writeFile: writeFileMock,
+        mkdir: mkdirMock,
+    },
+    readFile: readFileMock,
+    writeFile: writeFileMock,
+    mkdir: mkdirMock,
+}));
+
+const getConfigFileMock = vi.fn<
+    typeof import('../../src/utils/config.js')['getConfigFile']
+>();
+const configSchemaParseMock = vi.fn();
+
+vi.mock('../../src/utils/config.js', () => ({
+    __esModule: true,
+    getConfigFile: getConfigFileMock,
+    configSchema: {
+        parse: configSchemaParseMock,
+    },
+}));
+
+const LogLevelMock = { ERROR: 0, WARN: 1, INFO: 2, DEBUG: 3 } as const;
+
+let loggerInfoMock: ReturnType<typeof vi.fn>;
+let loggerWarnMock: ReturnType<typeof vi.fn>;
+let loggerErrorMock: ReturnType<typeof vi.fn>;
+let loggerDebugMock: ReturnType<typeof vi.fn>;
+
+const loggerConstructorMock = vi.fn();
+
+vi.mock('../../src/utils/Logger.js', () => ({
+    __esModule: true,
+    default: loggerConstructorMock,
+    LogLevel: LogLevelMock,
+}));
+
+describe('validate command', () => {
+    beforeEach(() => {
+        vi.resetModules();
+
+        readFileMock.mockReset();
+        writeFileMock.mockReset();
+        mkdirMock.mockReset();
+        getConfigFileMock.mockReset();
+        configSchemaParseMock.mockReset();
+        loggerConstructorMock.mockReset();
+
+        loggerInfoMock = vi.fn();
+        loggerWarnMock = vi.fn();
+        loggerErrorMock = vi.fn();
+        loggerDebugMock = vi.fn();
+
+        loggerConstructorMock.mockImplementation(() => ({
+            info: loggerInfoMock,
+            warn: loggerWarnMock,
+            error: loggerErrorMock,
+            debug: loggerDebugMock,
+        }));
+    });
+
+    it('creates parent directories when config file is missing', async () => {
+        const configPath = 'tmp/custom/config.toml';
+
+        getConfigFileMock.mockResolvedValue(configPath);
+        readFileMock.mockRejectedValue(
+            Object.assign(new Error('missing'), { code: 'ENOENT' })
+        );
+        writeFileMock.mockResolvedValue();
+        mkdirMock.mockResolvedValue(undefined);
+
+        const { default: commandModule } = await import(
+            '../../src/commands/validate.command.js'
+        );
+
+        if (!commandModule.handler) {
+            throw new Error('validate command handler not registered');
+        }
+
+        await commandModule.handler({
+            _: [],
+            $0: 'test',
+        } as ArgumentsCamelCase);
+
+        expect(mkdirMock).toHaveBeenCalledWith('tmp/custom', { recursive: true });
+        expect(writeFileMock).toHaveBeenCalledWith(
+            configPath,
+            EXAMPLE_CONFIG,
+            'utf-8'
+        );
+        expect(configSchemaParseMock).not.toHaveBeenCalled();
+    });
+
+    it('initialises the current directory when config file path has no parent', async () => {
+        const configPath = 'config.toml';
+
+        getConfigFileMock.mockResolvedValue(configPath);
+        readFileMock.mockRejectedValue(
+            Object.assign(new Error('missing'), { code: 'ENOENT' })
+        );
+        writeFileMock.mockResolvedValue();
+        mkdirMock.mockResolvedValue(undefined);
+
+        const { default: commandModule } = await import(
+            '../../src/commands/validate.command.js'
+        );
+
+        if (!commandModule.handler) {
+            throw new Error('validate command handler not registered');
+        }
+
+        await commandModule.handler({
+            _: [],
+            $0: 'test',
+        } as ArgumentsCamelCase);
+
+        expect(mkdirMock).toHaveBeenCalledWith('.', { recursive: true });
+        expect(writeFileMock).toHaveBeenCalledWith(
+            configPath,
+            EXAMPLE_CONFIG,
+            'utf-8'
+        );
+    });
+
+    it('logs and rethrows when the configuration directory cannot be created', async () => {
+        const configPath = 'tmp/custom/config.toml';
+        const mkdirError = new Error('permission denied');
+
+        getConfigFileMock.mockResolvedValue(configPath);
+        readFileMock.mockRejectedValue(
+            Object.assign(new Error('missing'), { code: 'ENOENT' })
+        );
+        mkdirMock.mockRejectedValue(mkdirError);
+
+        const { default: commandModule } = await import(
+            '../../src/commands/validate.command.js'
+        );
+
+        if (!commandModule.handler) {
+            throw new Error('validate command handler not registered');
+        }
+
+        await expect(
+            commandModule.handler({
+                _: [],
+                $0: 'test',
+            } as ArgumentsCamelCase)
+        ).rejects.toThrow(mkdirError);
+
+        expect(loggerErrorMock).toHaveBeenCalledWith(
+            'Failed to create configuration directory.',
+            ['Path: tmp/custom', 'Reason: permission denied']
+        );
+        expect(writeFileMock).not.toHaveBeenCalled();
+    });
+
+    it('logs and rethrows when the configuration file cannot be written', async () => {
+        const configPath = 'tmp/custom/config.toml';
+        const writeError = new Error('disk full');
+
+        getConfigFileMock.mockResolvedValue(configPath);
+        readFileMock.mockRejectedValue(
+            Object.assign(new Error('missing'), { code: 'ENOENT' })
+        );
+        mkdirMock.mockResolvedValue(undefined);
+        writeFileMock.mockRejectedValue(writeError);
+
+        const { default: commandModule } = await import(
+            '../../src/commands/validate.command.js'
+        );
+
+        if (!commandModule.handler) {
+            throw new Error('validate command handler not registered');
+        }
+
+        await expect(
+            commandModule.handler({
+                _: [],
+                $0: 'test',
+            } as ArgumentsCamelCase)
+        ).rejects.toThrow(writeError);
+
+        expect(loggerErrorMock).toHaveBeenCalledWith(
+            'Failed to create configuration file.',
+            ['Path: tmp/custom/config.toml', 'Reason: disk full']
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- ensure the validate command always creates parent directories and logs failures when writing the default config
- extend validate command coverage to include current-directory configs and write failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7290f4990832f98613f31852b7e11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically creates missing configuration directories and writes a default config when none is found.

- **Bug Fixes**
  - Improved reliability when initialising without an existing configuration: clearer logging, safer file writes, and robust error propagation.

- **Tests**
  - Added comprehensive tests covering directory creation, default config writing, parser/schema errors, logging and failure scenarios.

- **Documentation**
  - Updated executive summary and risk/status notes to reflect the new behaviour and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->