### PR TITLE
feat: harden Actual API session lifecycle

### DIFF
--- a/docs/deep-review-backlog.md
+++ b/docs/deep-review-backlog.md
@@ -1,9 +1,10 @@
 # Deep Review
 
 ## Epic 1: Actual session lifecycle resilience
-- Story 1.1: Derive the Actual budget data directory before calling `actual.init` so `loadBudget` reinitializes sessions with the correct path; cover discovery of the `metadata.json` match in unit tests using multiple mock directories.
-- Story 1.2: Iterate every directory under the data root when resolving a budget `syncId` and surface an actionable error when none match instead of silently reusing the fallback path; add a regression test capturing the new error text.
-- Story 1.3: Add tests exercising sequential imports across different budgets to ensure `ActualApi` reinitializes between runs and does not leak session state after `shutdown`.
+- [x] Story 1.1: Derive the Actual budget data directory before calling `actual.init` so `loadBudget` reinitializes sessions with the correct path; cover discovery of the `metadata.json` match in unit tests using multiple mock directories.
+- [x] Story 1.2: Iterate every directory under the data root when resolving a budget `syncId` and surface an actionable error when none match instead of silently reusing the fallback path; add a regression test capturing the new error text.
+- [x] Story 1.3: Add tests exercising sequential imports across different budgets to ensure `ActualApi` reinitializes between runs and does not leak session state after `shutdown`.
+- [x] Story 1.4: Emit debug logging when Actual switches data directories so lifecycle transitions remain observable (e.g. `Using budget directory: <dir> for syncId <id>`).
 
 ## Epic 2: Importer determinism and guard rails
 - Story 2.1: Normalize MoneyMoney transactions by sorting on value date and identifier before conversion so deduplication and starting balances behave deterministically; update importer tests with an unsorted fixture.

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -164,9 +164,13 @@ class ActualApi {
             reason?: unknown;
         };
 
+        const reason = typeof details.reason === 'string' ? details.reason : '';
+
         if (
             details.type === 'PostError' &&
-            details.reason === 'file-not-found'
+            /(^|[-\s])file[-\s]?not[-\s]?found$|group[-\s]?not[-\s]?found/i.test(
+                reason
+            )
         ) {
             return (
                 'The Actual server could not find the requested budget file. ' +
@@ -193,7 +197,12 @@ class ActualApi {
                     operation,
                     timeoutMs
                 );
-                Promise.resolve(actual.shutdown())
+                Promise.race([
+                    Promise.resolve(actual.shutdown()),
+                    new Promise((resolve) =>
+                        setTimeout(resolve, Math.min(5_000, timeoutMs / 3))
+                    ),
+                ])
                     .catch((shutdownError) => {
                         const reason =
                             shutdownError instanceof Error
@@ -350,9 +359,10 @@ class ActualApi {
 
         await this.ensureInitialization(rootDataDir);
 
+        const downloadRootDir = this.currentDataDir ?? rootDataDir;
         const initialBudgetDir = await this.tryResolveBudgetDirectory(
             budgetConfig.syncId,
-            this.currentDataDir ?? rootDataDir
+            downloadRootDir
         );
 
         if (initialBudgetDir) {
@@ -368,15 +378,15 @@ class ActualApi {
             budgetConfig.e2eEncryption.password
                 ? { password: budgetConfig.e2eEncryption.password }
                 : undefined;
+        const downloadHints = [...budgetHints, `Data root: ${downloadRootDir}`];
 
         await this.runActualRequest(
             `download budget '${budgetConfig.syncId}'`,
             () =>
                 actual.downloadBudget(budgetConfig.syncId, encryptionPassword),
-            budgetHints
+            downloadHints
         );
 
-        const downloadRootDir = this.currentDataDir ?? rootDataDir;
         const finalBudgetDir = await this.resolveBudgetDataDir(
             budgetConfig.syncId,
             downloadRootDir
@@ -579,7 +589,9 @@ class ActualApi {
 
         if (sortedEntries.length > MAX_DIRS_TO_SCAN) {
             this.logger.warn(
-                `Found ${sortedEntries.length} directories, scanning first ${MAX_DIRS_TO_SCAN}`
+                `Found ${sortedEntries.length} directories, scanning first ${MAX_DIRS_TO_SCAN} (omitting ${
+                    sortedEntries.length - MAX_DIRS_TO_SCAN
+                })`
             );
         }
 
@@ -593,9 +605,11 @@ class ActualApi {
 
             try {
                 const metadataRaw = await fs.readFile(metadataPath, 'utf8');
-                const metadata = JSON.parse(metadataRaw) as {
-                    groupId?: string;
-                };
+                const parsed = JSON.parse(metadataRaw);
+                const metadata =
+                    parsed && typeof parsed === 'object' && 'groupId' in parsed
+                        ? (parsed as { groupId?: string })
+                        : {};
 
                 if (metadata.groupId === syncId) {
                     const resolvedDir = path.join(actualDataDir, entry.name);

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -20,6 +20,7 @@ type ImportTransaction = {
 };
 import { format } from 'date-fns';
 import fs from 'fs/promises';
+import type { Dirent } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import util from 'node:util';
@@ -29,7 +30,7 @@ import {
     DEFAULT_ACTUAL_REQUEST_TIMEOUT_MS,
     FALLBACK_ACTUAL_REQUEST_TIMEOUT_MS,
 } from './config.js';
-import Logger from './Logger.js';
+import type Logger from './Logger.js';
 import { DEFAULT_DATA_DIR } from './shared.js';
 
 const isActualNoise = (args: unknown[]) => {
@@ -106,10 +107,11 @@ export class ActualApiTimeoutError extends Error {
 
 class ActualApi {
     protected isInitialized = false;
+    private currentDataDir: string | null = null;
 
     constructor(
-        private serverConfig: ActualServerConfig,
-        private logger: Logger
+        private readonly serverConfig: ActualServerConfig,
+        private readonly logger: Logger
     ) {}
 
     private getRequestTimeoutMs(): number {
@@ -145,6 +147,36 @@ class ActualApi {
         return [`Server URL: ${this.serverConfig.serverUrl}`, ...extras];
     }
 
+    private getFriendlyErrorMessage(
+        operation: string,
+        error: unknown
+    ): string | null {
+        if (
+            !operation.startsWith('download budget') ||
+            !error ||
+            typeof error !== 'object'
+        ) {
+            return null;
+        }
+
+        const details = error as {
+            type?: unknown;
+            reason?: unknown;
+        };
+
+        if (
+            details.type === 'PostError' &&
+            details.reason === 'file-not-found'
+        ) {
+            return (
+                'The Actual server could not find the requested budget file. ' +
+                'Open the budget in Actual Desktop so it can re-upload the file before retrying.'
+            );
+        }
+
+        return null;
+    }
+
     private async runActualRequest<T>(
         operation: string,
         callback: () => Promise<T>,
@@ -174,6 +206,7 @@ class ActualApi {
                     })
                     .finally(() => {
                         this.isInitialized = false;
+                        this.currentDataDir = null;
                         reject(timeoutError);
                     });
             }, timeoutMs);
@@ -206,8 +239,16 @@ class ActualApi {
                 throw error;
             }
 
-            const message =
-                error instanceof Error ? error.message : 'Unknown error';
+            const friendlyMessage = this.getFriendlyErrorMessage(
+                operation,
+                error
+            );
+
+            const message = friendlyMessage
+                ? friendlyMessage
+                : error instanceof Error
+                  ? error.message
+                  : 'Unknown error';
 
             const wrappedError =
                 error instanceof Error
@@ -256,11 +297,26 @@ class ActualApi {
         );
 
         this.isInitialized = true;
+        this.currentDataDir = actualDataDir;
     }
 
     public async ensureInitialization(customDataDir?: string): Promise<void> {
+        const desiredDataDir =
+            customDataDir ?? this.currentDataDir ?? DEFAULT_DATA_DIR;
+
         if (!this.isInitialized) {
-            await this.init(customDataDir);
+            await this.init(desiredDataDir);
+            return;
+        }
+
+        if (this.currentDataDir !== desiredDataDir) {
+            this.logger.debug(
+                `Reinitialising Actual data directory: ${
+                    this.currentDataDir ?? '(none)'
+                } -> ${desiredDataDir}`
+            );
+            await this.shutdown();
+            await this.init(desiredDataDir);
         }
     }
 
@@ -290,72 +346,44 @@ class ActualApi {
         }
 
         const budgetHints = [`Budget sync ID: ${budgetConfig.syncId}`];
+        const rootDataDir = this.currentDataDir ?? DEFAULT_DATA_DIR;
 
-        // Find the actual budget directory name (skip in test environments)
-        let budgetDataDir = DEFAULT_DATA_DIR;
+        await this.ensureInitialization(rootDataDir);
 
-        // Skip directory detection if already initialized (test environment)
-        if (!this.isInitialized) {
-            try {
-                const actualDataDir = DEFAULT_DATA_DIR;
-                const budgetDirs = await fs
-                    .readdir(actualDataDir)
-                    .catch(() => []);
-                const matchingDir = budgetDirs.find((dir) => {
-                    return dir !== '.' && dir !== '..';
-                });
+        const initialBudgetDir = await this.tryResolveBudgetDirectory(
+            budgetConfig.syncId,
+            this.currentDataDir ?? rootDataDir
+        );
 
-                if (matchingDir) {
-                    try {
-                        const metadataPath = path.join(
-                            actualDataDir,
-                            matchingDir,
-                            'metadata.json'
-                        );
-                        const metadata = JSON.parse(
-                            await fs.readFile(metadataPath, 'utf8')
-                        );
-                        if (metadata.groupId === budgetConfig.syncId) {
-                            // Use the actual budget directory instead of the data directory
-                            budgetDataDir = path.join(
-                                actualDataDir,
-                                matchingDir
-                            );
-                            this.logger.debug(
-                                `Using budget directory: ${matchingDir}`
-                            );
-                        }
-                    } catch (_error) {
-                        // Ignore metadata read errors, fall back to default data directory
-                    }
-                }
-            } catch (_error) {
-                // Skip directory detection in test environments or when filesystem access fails
-                this.logger.debug(
-                    'Skipping directory detection, using default data directory'
-                );
-            }
+        if (initialBudgetDir) {
+            const resolvedRootDir = path.dirname(initialBudgetDir);
+            await this.ensureInitialization(resolvedRootDir);
         }
-
-        // Initialize with the correct budget directory
-        await this.ensureInitialization(budgetDataDir);
 
         this.logger.debug(
             `Downloading budget with syncId '${budgetConfig.syncId}'...`
         );
+        const encryptionPassword =
+            budgetConfig.e2eEncryption.enabled &&
+            budgetConfig.e2eEncryption.password
+                ? { password: budgetConfig.e2eEncryption.password }
+                : undefined;
+
         await this.runActualRequest(
             `download budget '${budgetConfig.syncId}'`,
             () =>
-                actual.downloadBudget(
-                    budgetConfig.syncId,
-                    budgetConfig.e2eEncryption.enabled
-                        ? {
-                              password: budgetConfig.e2eEncryption.password,
-                          }
-                        : undefined
-                ),
+                actual.downloadBudget(budgetConfig.syncId, encryptionPassword),
             budgetHints
         );
+
+        const downloadRootDir = this.currentDataDir ?? rootDataDir;
+        const finalBudgetDir = await this.resolveBudgetDataDir(
+            budgetConfig.syncId,
+            downloadRootDir
+        );
+
+        const finalRootDir = path.dirname(finalBudgetDir);
+        await this.ensureInitialization(finalRootDir);
 
         this.logger.debug(
             `Loading budget with syncId '${budgetConfig.syncId}'...`
@@ -371,6 +399,24 @@ class ActualApi {
             `Synchronizing budget with syncId '${budgetConfig.syncId}'...`
         );
         await this.sync(budgetHints);
+    }
+
+    private async tryResolveBudgetDirectory(
+        syncId: string,
+        rootDir: string
+    ): Promise<string | null> {
+        try {
+            return await this.resolveBudgetDataDir(syncId, rootDir);
+        } catch (error) {
+            if (
+                error instanceof Error &&
+                error.message.includes('No Actual budget directory found')
+            ) {
+                return null;
+            }
+
+            throw error;
+        }
     }
 
     public async importTransactions(
@@ -466,6 +512,7 @@ class ActualApi {
             );
         } finally {
             this.isInitialized = false;
+            this.currentDataDir = null;
         }
     }
 
@@ -502,6 +549,86 @@ class ActualApi {
             ...transaction,
             imported_id: this.createFallbackImportedId(accountId, transaction),
         };
+    }
+
+    private async resolveBudgetDataDir(
+        syncId: string,
+        rootDir?: string
+    ): Promise<string> {
+        const actualDataDir =
+            rootDir ?? this.currentDataDir ?? DEFAULT_DATA_DIR;
+
+        let entries: Dirent[];
+        try {
+            entries = await fs.readdir(actualDataDir, { withFileTypes: true });
+        } catch (error) {
+            const maybeErrno = error as NodeJS.ErrnoException | undefined;
+            if (maybeErrno?.code === 'ENOENT') {
+                entries = [];
+            } else {
+                throw error;
+            }
+        }
+
+        const inspectedDirs: string[] = [];
+        const MAX_DIRS_TO_SCAN = 100;
+
+        const sortedEntries = entries
+            .filter((entry) => entry.isDirectory())
+            .sort((left, right) => left.name.localeCompare(right.name));
+
+        if (sortedEntries.length > MAX_DIRS_TO_SCAN) {
+            this.logger.warn(
+                `Found ${sortedEntries.length} directories, scanning first ${MAX_DIRS_TO_SCAN}`
+            );
+        }
+
+        for (const entry of sortedEntries.slice(0, MAX_DIRS_TO_SCAN)) {
+            inspectedDirs.push(entry.name);
+            const metadataPath = path.join(
+                actualDataDir,
+                entry.name,
+                'metadata.json'
+            );
+
+            try {
+                const metadataRaw = await fs.readFile(metadataPath, 'utf8');
+                const metadata = JSON.parse(metadataRaw) as {
+                    groupId?: string;
+                };
+
+                if (metadata.groupId === syncId) {
+                    const resolvedDir = path.join(actualDataDir, entry.name);
+                    this.logger.debug(
+                        `Using budget directory: ${entry.name} for syncId ${syncId}`
+                    );
+                    return resolvedDir;
+                }
+            } catch (error) {
+                const maybeErrno = error as NodeJS.ErrnoException | undefined;
+                if (
+                    maybeErrno?.code === 'ENOENT' ||
+                    maybeErrno?.code === 'EISDIR'
+                ) {
+                    continue;
+                }
+
+                if (error instanceof SyntaxError) {
+                    continue;
+                }
+
+                throw error;
+            }
+        }
+
+        const inspectedSummary =
+            inspectedDirs.length > 0 ? inspectedDirs.join(', ') : '(none)';
+
+        throw new Error(
+            `No Actual budget directory found for syncId '${syncId}'. ` +
+                `Checked directories under '${actualDataDir}': ${inspectedSummary}. ` +
+                'Open the budget in Actual Desktop and sync it before retrying.'
+        );
     }
 
     private createFallbackImportedId(
@@ -551,7 +678,8 @@ class ActualApi {
         // entire process while an Actual request is in flight. Concurrent requests
         // share the suppression window, so unrelated log output may be filtered.
         // The Actual client may still emit logs outside this window (e.g. after a
-        // timeout) because the SDK lacks granular logger hooks.
+        // timeout) because the SDK lacks granular logger hooks. In the future we
+        // could scope suppression per logger if the SDK exposes suitable hooks.
         if (ActualApi.suppressDepth === 0) {
             ActualApi.originals = {
                 log: console.log,

--- a/tests/ActualApi.test.ts
+++ b/tests/ActualApi.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import path from 'node:path';
 import type { Dirent } from 'node:fs';
+import { withFakeTimers } from './helpers/timers.js';
 
 // Type for transaction import - matches the ImportTransaction interface
 type ImportTransaction = {
@@ -264,7 +265,8 @@ describe('ActualApi', () => {
             '../src/utils/ActualApi.js'
         );
 
-        const api = new ActualApi(makeServerConfig('budget'), createLogger());
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
 
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
         readFileMock.mockImplementation(async (filePath: string) => {
@@ -279,10 +281,10 @@ describe('ActualApi', () => {
         });
 
         const postError = Object.assign(
-            new Error('PostError: file-not-found'),
+            new Error('PostError: file not found'),
             {
                 type: 'PostError',
-                reason: 'file-not-found',
+                reason: 'file not found',
             }
         );
 
@@ -291,35 +293,76 @@ describe('ActualApi', () => {
         await expect(api.loadBudget('budget')).rejects.toThrow(
             /Actual server could not find the requested budget file/
         );
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Actual server could not find the requested budget file'
+            ),
+            expect.arrayContaining([
+                'Server URL: http://localhost:5006',
+                'Budget sync ID: budget',
+                `Data root: ${DEFAULT_DATA_DIR}`,
+            ])
+        );
+        expect(loadBudgetMock).not.toHaveBeenCalled();
+    });
+
+    it('treats group-not-found errors as friendly download failures', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
+
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+
+        const postError = Object.assign(
+            new Error('PostError: group-not-found'),
+            {
+                type: 'PostError',
+                reason: 'group-not-found',
+            }
+        );
+
+        downloadBudgetMock.mockRejectedValue(postError);
+
+        await expect(api.loadBudget('budget')).rejects.toThrow(
+            /Actual server could not find the requested budget file/
+        );
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'Actual server could not find the requested budget file'
+            ),
+            expect.arrayContaining([
+                'Server URL: http://localhost:5006',
+                'Budget sync ID: budget',
+                `Data root: ${DEFAULT_DATA_DIR}`,
+            ])
+        );
         expect(loadBudgetMock).not.toHaveBeenCalled();
     });
 
     it('surfaces timeout errors from Actual API calls', async () => {
-        vi.useFakeTimers();
+        const { default: ActualApi, ActualApiTimeoutError } = await import(
+            '../src/utils/ActualApi.js'
+        );
 
-        let timersRestored = false;
+        const logger = createLogger();
+        const api = new ActualApi(
+            makeServerConfig('budget', { requestTimeoutMs: 5 }),
+            logger
+        );
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
 
-        try {
-            const { default: ActualApi, ActualApiTimeoutError } = await import(
-                '../src/utils/ActualApi.js'
-            );
+        downloadBudgetMock.mockImplementationOnce(
+            () => new Promise(() => undefined)
+        );
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
 
-            const logger = createLogger();
-            const api = new ActualApi(
-                makeServerConfig('budget', { requestTimeoutMs: 5 }),
-                logger
-            );
-            readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-            readFileMock.mockResolvedValue(
-                JSON.stringify({ groupId: 'budget' })
-            );
-
-            downloadBudgetMock.mockImplementationOnce(
-                () => new Promise(() => undefined)
-            );
-            loadBudgetMock.mockResolvedValue(undefined);
-            syncMock.mockResolvedValue(undefined);
-
+        await withFakeTimers(async () => {
             const loadPromise = api.loadBudget('budget');
             const capturedError = loadPromise.catch((error) => error);
 
@@ -336,35 +379,52 @@ describe('ActualApi', () => {
             expect(loadBudgetMock).not.toHaveBeenCalled();
             expect(shutdownMock).toHaveBeenCalledTimes(1);
             expect(initMock).toHaveBeenCalledTimes(1);
+        });
 
-            await vi.runOnlyPendingTimersAsync();
-            vi.clearAllTimers();
-            vi.useRealTimers();
-            timersRestored = true;
+        downloadBudgetMock.mockReset();
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockReset();
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockReset();
+        syncMock.mockResolvedValue(undefined);
+        initMock.mockClear();
+        shutdownMock.mockClear();
 
-            downloadBudgetMock.mockReset();
-            downloadBudgetMock.mockResolvedValue(undefined);
-            loadBudgetMock.mockReset();
-            loadBudgetMock.mockResolvedValue(undefined);
-            syncMock.mockReset();
-            syncMock.mockResolvedValue(undefined);
-            initMock.mockClear();
-            shutdownMock.mockClear();
+        await api.loadBudget('budget');
 
-            await api.loadBudget('budget');
+        expect(initMock).toHaveBeenCalledTimes(1);
+        expect(shutdownMock).not.toHaveBeenCalled();
+    });
 
-            expect(initMock).toHaveBeenCalledTimes(1);
-            expect(shutdownMock).not.toHaveBeenCalled();
-        } finally {
-            if (!timersRestored) {
-                try {
-                    await vi.runOnlyPendingTimersAsync();
-                    vi.clearAllTimers();
-                } finally {
-                    vi.useRealTimers();
-                }
-            }
-        }
+    it('caps shutdown duration when timeout-triggered shutdown hangs', async () => {
+        const { default: ActualApi, ActualApiTimeoutError } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(
+            makeServerConfig('budget', { requestTimeoutMs: 6 }),
+            logger
+        );
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+
+        downloadBudgetMock.mockImplementationOnce(
+            () => new Promise(() => undefined)
+        );
+        shutdownMock.mockImplementationOnce(() => new Promise(() => undefined));
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await withFakeTimers(async () => {
+            const loadPromise = api.loadBudget('budget');
+            const capturedError = loadPromise.catch((error) => error);
+
+            await vi.advanceTimersByTimeAsync(10);
+            const timeoutError = await capturedError;
+            expect(timeoutError).toBeInstanceOf(ActualApiTimeoutError);
+            expect(shutdownMock).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('populates imported ids and deduplicates transactions before import', async () => {
@@ -517,10 +577,7 @@ describe('ActualApi', () => {
             return Promise.resolve({ added: newTransactions, updated: [] });
         });
 
-        const firstAttempt = api.importTransactions(
-            'account-1',
-            transactions
-        );
+        const firstAttempt = api.importTransactions('account-1', transactions);
         const firstAttemptError = firstAttempt.catch((error) => error);
 
         await vi.advanceTimersByTimeAsync(10);
@@ -539,10 +596,7 @@ describe('ActualApi', () => {
         resolveFirstAttempt!();
         await Promise.resolve();
 
-        const secondAttempt = api.importTransactions(
-            'account-1',
-            transactions
-        );
+        const secondAttempt = api.importTransactions('account-1', transactions);
         const result = await secondAttempt;
         expect(result).toBeDefined();
 
@@ -644,6 +698,7 @@ describe('ActualApi', () => {
 
         readdirMock.mockResolvedValue([
             createDirent('corrupt'),
+            createDirent('non-object'),
             createDirent('valid'),
         ]);
         readFileMock.mockImplementation(async (filePath: string) => {
@@ -652,6 +707,12 @@ describe('ActualApi', () => {
                 path.join(DEFAULT_DATA_DIR, 'corrupt', 'metadata.json')
             ) {
                 throw new SyntaxError('Unexpected token');
+            }
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'non-object', 'metadata.json')
+            ) {
+                return '"unexpected"';
             }
             if (
                 filePath ===
@@ -752,7 +813,7 @@ describe('ActualApi', () => {
         await api.loadBudget('budget');
 
         expect(logger.warn).toHaveBeenCalledWith(
-            expect.stringContaining('scanning first 100')
+            expect.stringContaining('scanning first 100 (omitting 5)')
         );
         expect(downloadBudgetMock).toHaveBeenCalled();
         expect(loadBudgetMock).toHaveBeenCalled();

--- a/tests/ActualApi.test.ts
+++ b/tests/ActualApi.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import type { Dirent } from 'node:fs';
 
 // Type for transaction import - matches the ImportTransaction interface
 type ImportTransaction = {
@@ -23,6 +25,7 @@ type ImportTransaction = {
 import type { ActualServerConfig } from '../src/utils/config.js';
 import type Logger from '../src/utils/Logger.js';
 import { LogLevel } from '../src/utils/Logger.js';
+import { DEFAULT_DATA_DIR } from '../src/utils/shared.js';
 
 const initMock = vi.fn();
 const getAccountsMock = vi.fn();
@@ -49,6 +52,20 @@ vi.mock('@actual-app/api', () => ({
     },
 }));
 
+const accessMock = vi.fn();
+const mkdirMock = vi.fn();
+const readdirMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock('fs/promises', () => ({
+    default: {
+        access: accessMock,
+        mkdir: mkdirMock,
+        readdir: readdirMock,
+        readFile: readFileMock,
+    },
+}));
+
 const createLogger = () =>
     ({
         debug: vi.fn(),
@@ -57,6 +74,48 @@ const createLogger = () =>
         error: vi.fn(),
         getLevel: () => LogLevel.INFO,
     }) as unknown as Logger;
+
+const createDirent = (
+    name: string,
+    { isDirectory = true }: { isDirectory?: boolean } = {}
+): Dirent =>
+    ({
+        name,
+        isDirectory: () => isDirectory,
+        isFile: () => !isDirectory,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isFIFO: () => false,
+        isSymbolicLink: () => false,
+        isSocket: () => false,
+    }) as unknown as Dirent;
+
+const makeServerConfig = (
+    syncId: string,
+    overrides: Partial<ActualServerConfig> = {}
+): ActualServerConfig => {
+    const base: ActualServerConfig = {
+        serverUrl: 'http://localhost:5006',
+        serverPassword: 'secret',
+        requestTimeoutMs: 45000,
+        budgets: [
+            {
+                syncId,
+                e2eEncryption: {
+                    enabled: false,
+                    password: undefined,
+                },
+                accountMapping: {},
+            },
+        ],
+    };
+
+    return {
+        ...base,
+        ...overrides,
+        budgets: overrides.budgets ?? base.budgets,
+    };
+};
 
 describe('ActualApi', () => {
     beforeEach(() => {
@@ -69,6 +128,15 @@ describe('ActualApi', () => {
         getTransactionsMock.mockReset();
         shutdownMock.mockReset();
         shutdownMock.mockResolvedValue(undefined);
+        initMock.mockResolvedValue(undefined);
+        accessMock.mockReset();
+        mkdirMock.mockReset();
+        readdirMock.mockReset();
+        readFileMock.mockReset();
+        accessMock.mockResolvedValue(undefined);
+        mkdirMock.mockResolvedValue(undefined);
+        readdirMock.mockResolvedValue([]);
+        readFileMock.mockRejectedValue(new Error('missing metadata'));
     });
 
     afterEach(() => {
@@ -97,10 +165,9 @@ describe('ActualApi', () => {
             ],
         };
 
-        const api = new ActualApi(serverConfig, createLogger());
-        // Mark as initialized to avoid touching the filesystem in tests
-        // @ts-expect-error accessing protected test hook
-        api.isInitialized = true;
+        const logger = createLogger();
+        const api = new ActualApi(serverConfig, logger);
+        await api.init();
 
         const logSpy = vi.spyOn(console, 'log');
         getTransactionsMock.mockImplementation(async () => {
@@ -149,10 +216,25 @@ describe('ActualApi', () => {
             ],
         };
 
-        const api = new ActualApi(serverConfig, createLogger());
-        // @ts-expect-error accessing protected test hook
-        api.isInitialized = true;
+        const logger = createLogger();
+        const api = new ActualApi(serverConfig, logger);
 
+        readdirMock.mockResolvedValue([
+            createDirent('budget-dir'),
+            createDirent('other'),
+        ]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'budget-dir', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'budget' });
+            }
+
+            return JSON.stringify({ groupId: 'other-budget' });
+        });
+
+        initMock.mockResolvedValue(undefined);
         downloadBudgetMock.mockResolvedValue(undefined);
         loadBudgetMock.mockResolvedValue(undefined);
         syncMock.mockResolvedValue(undefined);
@@ -162,46 +244,81 @@ describe('ActualApi', () => {
         expect(downloadBudgetMock).toHaveBeenCalledWith('budget', undefined);
         expect(loadBudgetMock).toHaveBeenCalledWith('budget');
         expect(syncMock).toHaveBeenCalled();
+        expect(initMock).toHaveBeenCalledWith(
+            expect.objectContaining({ dataDir: DEFAULT_DATA_DIR })
+        );
+        expect(initMock).toHaveBeenCalledTimes(1);
         expect(downloadBudgetMock.mock.invocationCallOrder[0]).toBeLessThan(
             loadBudgetMock.mock.invocationCallOrder[0]
         );
         expect(loadBudgetMock.mock.invocationCallOrder[0]).toBeLessThan(
             syncMock.mock.invocationCallOrder[0]
         );
+        expect(logger.debug).toHaveBeenCalledWith(
+            'Using budget directory: budget-dir for syncId budget'
+        );
+    });
+
+    it('surfaces a helpful error when the server no longer has the budget file', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const api = new ActualApi(makeServerConfig('budget'), createLogger());
+
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'budget-dir', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'budget' });
+            }
+
+            throw new Error('Unexpected file path');
+        });
+
+        const postError = Object.assign(
+            new Error('PostError: file-not-found'),
+            {
+                type: 'PostError',
+                reason: 'file-not-found',
+            }
+        );
+
+        downloadBudgetMock.mockRejectedValue(postError);
+
+        await expect(api.loadBudget('budget')).rejects.toThrow(
+            /Actual server could not find the requested budget file/
+        );
+        expect(loadBudgetMock).not.toHaveBeenCalled();
     });
 
     it('surfaces timeout errors from Actual API calls', async () => {
         vi.useFakeTimers();
+
+        let timersRestored = false;
 
         try {
             const { default: ActualApi, ActualApiTimeoutError } = await import(
                 '../src/utils/ActualApi.js'
             );
 
-            const serverConfig: ActualServerConfig = {
-                serverUrl: 'http://localhost:5006',
-                serverPassword: 'secret',
-                requestTimeoutMs: 5,
-                budgets: [
-                    {
-                        syncId: 'budget',
-                        e2eEncryption: {
-                            enabled: false,
-                            password: undefined,
-                        },
-                        accountMapping: {},
-                    },
-                ],
-            };
-
             const logger = createLogger();
-            const api = new ActualApi(serverConfig, logger);
-            // @ts-expect-error accessing protected test hook
-            api.isInitialized = true;
+            const api = new ActualApi(
+                makeServerConfig('budget', { requestTimeoutMs: 5 }),
+                logger
+            );
+            readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+            readFileMock.mockResolvedValue(
+                JSON.stringify({ groupId: 'budget' })
+            );
 
-            downloadBudgetMock.mockImplementation(
+            downloadBudgetMock.mockImplementationOnce(
                 () => new Promise(() => undefined)
             );
+            loadBudgetMock.mockResolvedValue(undefined);
+            syncMock.mockResolvedValue(undefined);
 
             const loadPromise = api.loadBudget('budget');
             const capturedError = loadPromise.catch((error) => error);
@@ -218,13 +335,34 @@ describe('ActualApi', () => {
             );
             expect(loadBudgetMock).not.toHaveBeenCalled();
             expect(shutdownMock).toHaveBeenCalledTimes(1);
+            expect(initMock).toHaveBeenCalledTimes(1);
+
+            await vi.runOnlyPendingTimersAsync();
+            vi.clearAllTimers();
+            vi.useRealTimers();
+            timersRestored = true;
+
+            downloadBudgetMock.mockReset();
+            downloadBudgetMock.mockResolvedValue(undefined);
+            loadBudgetMock.mockReset();
+            loadBudgetMock.mockResolvedValue(undefined);
+            syncMock.mockReset();
+            syncMock.mockResolvedValue(undefined);
+            initMock.mockClear();
+            shutdownMock.mockClear();
+
+            await api.loadBudget('budget');
+
+            expect(initMock).toHaveBeenCalledTimes(1);
+            expect(shutdownMock).not.toHaveBeenCalled();
         } finally {
-            // Ensure no timers remain and restore timers
-            try {
-                await vi.runOnlyPendingTimersAsync();
-                vi.clearAllTimers();
-            } finally {
-                vi.useRealTimers();
+            if (!timersRestored) {
+                try {
+                    await vi.runOnlyPendingTimersAsync();
+                    vi.clearAllTimers();
+                } finally {
+                    vi.useRealTimers();
+                }
             }
         }
     });
@@ -251,8 +389,7 @@ describe('ActualApi', () => {
         };
 
         const api = new ActualApi(serverConfig, createLogger());
-        // @ts-expect-error accessing protected test hook
-        api.isInitialized = true;
+        await api.init();
 
         const transactions: ImportTransaction[] = [
             {
@@ -306,121 +443,115 @@ describe('ActualApi', () => {
 
         let resolveFirstAttempt: (() => void) | null = null;
 
-        try {
-            const { default: ActualApi, ActualApiTimeoutError } = await import(
-                '../src/utils/ActualApi.js'
-            );
+        const { default: ActualApi, ActualApiTimeoutError } = await import(
+            '../src/utils/ActualApi.js'
+        );
 
-            const serverConfig: ActualServerConfig = {
-                serverUrl: 'http://localhost:5006',
-                serverPassword: 'secret',
-                requestTimeoutMs: 5,
-                budgets: [
-                    {
-                        syncId: 'budget',
-                        e2eEncryption: {
-                            enabled: false,
-                            password: undefined,
-                        },
-                        accountMapping: {},
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            requestTimeoutMs: 5,
+            budgets: [
+                {
+                    syncId: 'budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
                     },
-                ],
-            };
-
-            const logger = createLogger();
-            const api = new ActualApi(serverConfig, logger);
-            // @ts-expect-error accessing protected test hook
-            api.isInitialized = true;
-
-            const transactions: ImportTransaction[] = [
-                {
-                    date: '2024-02-01',
-                    amount: 100,
-                    imported_id: 'existing',
-                    imported_payee: 'Alpha',
-                    notes: 'first',
+                    accountMapping: {},
                 },
-                {
-                    date: '2024-02-03',
-                    amount: 300,
-                    imported_payee: 'Gamma',
-                    notes: 'needs id',
-                },
-            ];
+            ],
+        };
 
-            const serverRecords = new Map<string, ImportTransaction>();
-            const callPayloads: string[][] = [];
+        const logger = createLogger();
+        const api = new ActualApi(serverConfig, logger);
+        await api.init();
 
-            importTransactionsMock.mockImplementation((accountId, txns) => {
-                expect(accountId).toBe('account-1');
-                const ids = txns.map((tx) => tx.imported_id ?? '');
-                callPayloads.push(ids);
-                expect(new Set(ids).size).toBe(ids.length);
+        const transactions: ImportTransaction[] = [
+            {
+                date: '2024-02-01',
+                amount: 100,
+                imported_id: 'existing',
+                imported_payee: 'Alpha',
+                notes: 'first',
+            },
+            {
+                date: '2024-02-03',
+                amount: 300,
+                imported_payee: 'Gamma',
+                notes: 'needs id',
+            },
+        ];
 
-                const newTransactions = txns.filter((tx) => {
-                    const importedId = tx.imported_id;
-                    expect(importedId).toBeTruthy();
-                    return importedId ? !serverRecords.has(importedId) : false;
-                });
+        const serverRecords = new Map<string, ImportTransaction>();
+        const callPayloads: string[][] = [];
 
-                const finalize = () => {
-                    for (const tx of newTransactions) {
-                        serverRecords.set(tx.imported_id as string, tx);
-                    }
-                };
+        importTransactionsMock.mockImplementation((accountId, txns) => {
+            expect(accountId).toBe('account-1');
+            const ids = txns.map((tx) => tx.imported_id ?? '');
+            callPayloads.push(ids);
+            expect(new Set(ids).size).toBe(ids.length);
 
-                if (!resolveFirstAttempt) {
-                    return new Promise((resolve) => {
-                        resolveFirstAttempt = () => {
-                            finalize();
-                            resolve({ added: newTransactions, updated: [] });
-                        };
-                    });
-                }
-
-                finalize();
-                return Promise.resolve({ added: newTransactions, updated: [] });
+            const newTransactions = txns.filter((tx) => {
+                const importedId = tx.imported_id;
+                expect(importedId).toBeTruthy();
+                return importedId ? !serverRecords.has(importedId) : false;
             });
 
-            const firstAttempt = api.importTransactions(
-                'account-1',
-                transactions
-            );
-            const firstAttemptError = firstAttempt.catch((error) => error);
+            const finalize = () => {
+                for (const tx of newTransactions) {
+                    serverRecords.set(tx.imported_id as string, tx);
+                }
+            };
 
-            await vi.advanceTimersByTimeAsync(10);
-
-            const timeoutError = await firstAttemptError;
-            expect(timeoutError).toBeInstanceOf(ActualApiTimeoutError);
-            expect(logger.error).toHaveBeenCalledWith(
-                expect.stringContaining('timed out'),
-                expect.arrayContaining([
-                    'Server URL: http://localhost:5006',
-                    'Account ID: account-1',
-                ])
-            );
-
-            expect(resolveFirstAttempt).toBeTruthy();
-            resolveFirstAttempt!();
-            await Promise.resolve();
-
-            const secondAttempt = api.importTransactions('account-1', transactions);
-            await secondAttempt;
-
-            expect(callPayloads).toHaveLength(2);
-            expect(callPayloads[0]).toEqual(callPayloads[1]);
-            expect(importTransactionsMock).toHaveBeenCalledTimes(2);
-            const secondPayloadIds = callPayloads[1];
-            expect(new Set(secondPayloadIds).size).toBe(secondPayloadIds.length);
-            expect(serverRecords.size).toBe(2);
-        } finally {
-            try {
-                await vi.runOnlyPendingTimersAsync();
-                vi.clearAllTimers();
-            } finally {
-                vi.useRealTimers();
+            if (!resolveFirstAttempt) {
+                return new Promise((resolve) => {
+                    resolveFirstAttempt = () => {
+                        finalize();
+                        resolve({ added: newTransactions, updated: [] });
+                    };
+                });
             }
-        }
+
+            finalize();
+            return Promise.resolve({ added: newTransactions, updated: [] });
+        });
+
+        const firstAttempt = api.importTransactions(
+            'account-1',
+            transactions
+        );
+        const firstAttemptError = firstAttempt.catch((error) => error);
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        const timeoutError = await firstAttemptError;
+        expect(timeoutError).toBeInstanceOf(ActualApiTimeoutError);
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('timed out'),
+            expect.arrayContaining([
+                'Server URL: http://localhost:5006',
+                'Account ID: account-1',
+            ])
+        );
+
+        expect(resolveFirstAttempt).toBeTruthy();
+        resolveFirstAttempt!();
+        await Promise.resolve();
+
+        const secondAttempt = api.importTransactions(
+            'account-1',
+            transactions
+        );
+        const result = await secondAttempt;
+        expect(result).toBeDefined();
+
+        expect(callPayloads).toHaveLength(2);
+        expect(callPayloads[0]).toEqual(callPayloads[1]);
+        expect(importTransactionsMock).toHaveBeenCalledTimes(2);
+        const secondPayloadIds = callPayloads[1];
+        expect(new Set(secondPayloadIds).size).toBe(secondPayloadIds.length);
+        expect(serverRecords.size).toBe(2);
     });
 
     it('ignores shutdown when the API was never initialised', async () => {
@@ -450,11 +581,7 @@ describe('ActualApi', () => {
         expect(shutdownMock).not.toHaveBeenCalled();
     });
 
-    it('handles directory naming mismatch by using correct directory', async () => {
-        // This test verifies that the directory naming mismatch fix is working
-        // by ensuring the loadBudget method can handle the scenario where
-        // the budget directory has a different name than the sync ID
-
+    it('derives the budget directory from metadata before initialisation', async () => {
         const { default: ActualApi } = await import(
             '../src/utils/ActualApi.js'
         );
@@ -465,7 +592,7 @@ describe('ActualApi', () => {
             requestTimeoutMs: 45000,
             budgets: [
                 {
-                    syncId: 'test-budget-sync-id',
+                    syncId: 'target-budget',
                     e2eEncryption: {
                         enabled: false,
                         password: undefined,
@@ -477,13 +604,307 @@ describe('ActualApi', () => {
 
         const api = new ActualApi(serverConfig, createLogger());
 
-        // Mock the Actual API calls
+        readdirMock.mockResolvedValue([
+            createDirent('alpha'),
+            createDirent('target-directory'),
+            createDirent('beta'),
+        ]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'target-directory', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'target-budget' });
+            }
+
+            return JSON.stringify({ groupId: 'other-budget' });
+        });
+
+        initMock.mockResolvedValue(undefined);
         downloadBudgetMock.mockResolvedValue(undefined);
         loadBudgetMock.mockResolvedValue(undefined);
         syncMock.mockResolvedValue(undefined);
 
-        // This should not throw an error even if there's a directory naming mismatch
-        // The test verifies that the method handles the mismatch gracefully
-        await expect(api.loadBudget('test-budget-sync-id')).resolves.not.toThrow();
+        await api.loadBudget('target-budget');
+
+        expect(initMock).toHaveBeenCalledTimes(1);
+        expect(initMock).toHaveBeenCalledWith(
+            expect.objectContaining({ dataDir: DEFAULT_DATA_DIR })
+        );
+        expect(downloadBudgetMock).toHaveBeenCalled();
+    });
+
+    it('skips corrupt metadata entries while resolving the budget directory', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
+
+        readdirMock.mockResolvedValue([
+            createDirent('corrupt'),
+            createDirent('valid'),
+        ]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'corrupt', 'metadata.json')
+            ) {
+                throw new SyntaxError('Unexpected token');
+            }
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'valid', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'budget' });
+            }
+            throw new Error(`unexpected file ${filePath}`);
+        });
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await expect(api.loadBudget('budget')).resolves.toBeUndefined();
+
+        expect(logger.debug).toHaveBeenCalledWith(
+            'Using budget directory: valid for syncId budget'
+        );
+    });
+
+    it('throws a helpful error when no metadata matches the requested budget', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            requestTimeoutMs: 45000,
+            budgets: [
+                {
+                    syncId: 'missing-budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+            ],
+        };
+
+        const api = new ActualApi(serverConfig, createLogger());
+
+        const nonMatchingMetadata = JSON.stringify({
+            groupId: 'different-budget',
+        });
+
+        readdirMock.mockResolvedValue([
+            createDirent('alpha'),
+            createDirent('beta'),
+        ]);
+        readFileMock.mockResolvedValue(nonMatchingMetadata);
+        downloadBudgetMock.mockResolvedValue(undefined);
+
+        const escapedRoot = DEFAULT_DATA_DIR.replace(
+            /[.*+?^${}()|[\]\\]/g,
+            '\\$&'
+        );
+
+        await expect(api.loadBudget('missing-budget')).rejects.toThrow(
+            new RegExp(
+                `No Actual budget directory found for syncId 'missing-budget'\\. ` +
+                    `Checked directories under '${escapedRoot}': alpha, beta\\. ` +
+                    'Open the budget in Actual Desktop and sync it before retrying\\.'
+            )
+        );
+        expect(downloadBudgetMock).toHaveBeenCalledTimes(1);
+        expect(readdirMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('warns when scanning large Actual data directories', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
+
+        const targetDirectory = 'dir-050';
+        const directories = Array.from({ length: 105 }, (_, index) =>
+            createDirent(`dir-${index.toString().padStart(3, '0')}`)
+        );
+
+        readdirMock.mockResolvedValue(directories);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            const directoryName = path.basename(path.dirname(filePath));
+            if (directoryName === targetDirectory) {
+                return JSON.stringify({ groupId: 'budget' });
+            }
+
+            return JSON.stringify({ groupId: 'other-budget' });
+        });
+
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await api.loadBudget('budget');
+
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('scanning first 100')
+        );
+        expect(downloadBudgetMock).toHaveBeenCalled();
+        expect(loadBudgetMock).toHaveBeenCalled();
+    });
+
+    it('resets initialization state after a manual shutdown', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            requestTimeoutMs: 45000,
+            budgets: [
+                {
+                    syncId: 'budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+            ],
+        };
+
+        const api = new ActualApi(serverConfig, createLogger());
+
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await api.loadBudget('budget');
+        initMock.mockClear();
+        await api.shutdown();
+
+        await api.loadBudget('budget');
+
+        expect(initMock).toHaveBeenCalledTimes(1);
+        const [[initArgs]] = initMock.mock.calls;
+        expect(initArgs.dataDir).toBe(DEFAULT_DATA_DIR);
+        expect(shutdownMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the e2e encryption password through to the download request', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const password = 'budget-secret';
+        const api = new ActualApi(
+            makeServerConfig('budget', {
+                budgets: [
+                    {
+                        syncId: 'budget',
+                        e2eEncryption: {
+                            enabled: true,
+                            password,
+                        },
+                        accountMapping: {},
+                    },
+                ],
+            }),
+            createLogger()
+        );
+
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await api.loadBudget('budget');
+
+        expect(downloadBudgetMock).toHaveBeenCalledTimes(1);
+        expect(downloadBudgetMock).toHaveBeenCalledWith('budget', {
+            password,
+        });
+    });
+
+    it('switches Actual data directories when loading different budgets', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const serverConfig: ActualServerConfig = {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'secret',
+            requestTimeoutMs: 45000,
+            budgets: [
+                {
+                    syncId: 'first-budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+                {
+                    syncId: 'second-budget',
+                    e2eEncryption: {
+                        enabled: false,
+                        password: undefined,
+                    },
+                    accountMapping: {},
+                },
+            ],
+        };
+
+        const logger = createLogger();
+        const api = new ActualApi(serverConfig, logger);
+
+        readdirMock.mockResolvedValue([
+            createDirent('dir-first'),
+            createDirent('dir-second'),
+        ]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'dir-first', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'first-budget' });
+            }
+            if (
+                filePath ===
+                path.join(DEFAULT_DATA_DIR, 'dir-second', 'metadata.json')
+            ) {
+                return JSON.stringify({ groupId: 'second-budget' });
+            }
+            throw new Error('unexpected file');
+        });
+
+        initMock.mockResolvedValue(undefined);
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock.mockResolvedValue(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await api.loadBudget('first-budget');
+        await api.loadBudget('second-budget');
+
+        expect(logger.debug).toHaveBeenCalledWith(
+            'Using budget directory: dir-first for syncId first-budget'
+        );
+        expect(logger.debug).toHaveBeenCalledWith(
+            'Using budget directory: dir-second for syncId second-budget'
+        );
+
+        expect(initMock).toHaveBeenCalledTimes(1);
+        const [[singleInitArgs]] = initMock.mock.calls;
+        expect(singleInitArgs.dataDir).toBe(DEFAULT_DATA_DIR);
+        expect(shutdownMock).not.toHaveBeenCalled();
     });
 });

--- a/tests/helpers/timers.ts
+++ b/tests/helpers/timers.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+export async function withFakeTimers<T>(fn: () => Promise<T>): Promise<T> {
+    vi.useFakeTimers();
+    try {
+        const result = await fn();
+        await vi.runOnlyPendingTimersAsync();
+        vi.clearAllTimers();
+        return result;
+    } finally {
+        vi.useRealTimers();
+    }
+}


### PR DESCRIPTION
## Summary
- avoid redundant Actual init cycles by remembering the active data directory and logging when sessions swap roots
- resolve budgets via metadata using withFileTypes, emit targeted errors listing inspected directories (now including the root path), reuse the directory after download, ensure initialization always targets the cache root instead of per-budget subdirectories, and cap scans to 100 entries with a warning when more are present
- extend ActualApi tests for metadata resolution, timeout recovery, manual shutdown resets, automatic reinitialisation across budgets, shared root usage, the new per-budget debug log assertions, corrupt metadata tolerance, e2e password propagation, and the directory-scan warning, and document the Story 1.4 log format for assertions

## Testing
- npm run lint:eslint
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e4fc3964832faf5dace1453ea4d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added debug logging when switching data directories.
  - Improved automatic detection and initialisation of the correct budget directory.

- Bug Fixes
  - Clearer, friendlier error messages when a budget file is missing.
  - More reliable switching between multiple budgets with proper reinitialisation.
  - Ensures clean state after timeouts or failures and more robust shutdown behaviour.

- Documentation
  - Reformatted backlog to checkbox style; added a new story about debug logging on directory switches.

- Tests
  - Added comprehensive tests for directory resolution, errors, timeouts, encryption handling and a fake-timers test helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->