### PR TITLE
Fix Actual budget loading retries and shutdown handling

### DIFF
--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -458,15 +458,15 @@ class ActualApi {
             } catch (error) {
                 lastError = error;
 
-                if (attempt >= maxAttempts || !this.shouldRetryBudgetLoad(error)) {
+                if (
+                    attempt >= maxAttempts ||
+                    !this.shouldRetryBudgetLoad(error)
+                ) {
                     throw error;
                 }
 
                 const retryHints: Array<string | Error> = [
-                    ...this.createContextHints([
-                        ...budgetHints,
-                        attemptHint,
-                    ]),
+                    ...this.createContextHints([...budgetHints, attemptHint]),
                 ];
                 if (error instanceof Error) {
                     retryHints.push(error);
@@ -592,10 +592,12 @@ class ActualApi {
             return false;
         }
 
-        const message = error.message ?? '';
+        const message = error.message;
         return (
             error instanceof TypeError &&
-            message.includes("Cannot read properties of null (reading 'prepare')")
+            message.includes(
+                "Cannot read properties of null (reading 'prepare')"
+            )
         );
     }
 
@@ -810,9 +812,7 @@ class ActualApi {
                 const record = parsed as Record<string, unknown>;
                 const groupIdRaw = record.groupId;
                 const groupId =
-                    typeof groupIdRaw === 'string'
-                        ? groupIdRaw.trim()
-                        : '';
+                    typeof groupIdRaw === 'string' ? groupIdRaw.trim() : '';
                 if (!groupId) {
                     metadataDiagnostics.push(
                         `${entry.name}: metadata missing groupId`
@@ -846,10 +846,7 @@ class ActualApi {
                 };
                 this.logger.debug(
                     `Using budget directory: ${entry.name} for syncId ${syncId}`,
-                    [
-                        `Metadata path: ${metadataPath}`,
-                        `Local budget ID: ${id}`,
-                    ]
+                    [`Metadata path: ${metadataPath}`, `Local budget ID: ${id}`]
                 );
                 return {
                     directory: resolvedDir,
@@ -858,7 +855,10 @@ class ActualApi {
                 };
             } catch (error) {
                 const maybeErrno = error as NodeJS.ErrnoException | undefined;
-                if (maybeErrno?.code === 'ENOENT' || maybeErrno?.code === 'EISDIR') {
+                if (
+                    maybeErrno?.code === 'ENOENT' ||
+                    maybeErrno?.code === 'EISDIR'
+                ) {
                     metadataDiagnostics.push(
                         `${entry.name}: metadata.json not found`
                     );

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -96,6 +96,18 @@ const createErrorWithCause = (message: string, cause: Error): Error => {
     }
 };
 
+type BudgetMetadata = {
+    id: string;
+    groupId?: string;
+    [key: string]: unknown;
+};
+
+type BudgetDirectoryResolution = {
+    directory: string;
+    metadata: BudgetMetadata;
+    metadataPath: string;
+};
+
 export class ActualApiTimeoutError extends Error {
     constructor(operation: string, timeoutMs: number) {
         super(
@@ -356,68 +368,139 @@ class ActualApi {
 
         const budgetHints = [`Budget sync ID: ${budgetConfig.syncId}`];
         const rootDataDir = this.currentDataDir ?? DEFAULT_DATA_DIR;
-
-        await this.ensureInitialization(rootDataDir);
-
-        const downloadRootDir = this.currentDataDir ?? rootDataDir;
-        const initialBudgetDir = await this.tryResolveBudgetDirectory(
-            budgetConfig.syncId,
-            downloadRootDir
-        );
-
-        if (initialBudgetDir) {
-            const resolvedRootDir = path.dirname(initialBudgetDir);
-            await this.ensureInitialization(resolvedRootDir);
-        }
-
-        this.logger.debug(
-            `Downloading budget with syncId '${budgetConfig.syncId}'...`
-        );
         const encryptionPassword =
             budgetConfig.e2eEncryption.enabled &&
             budgetConfig.e2eEncryption.password
                 ? { password: budgetConfig.e2eEncryption.password }
                 : undefined;
-        const downloadHints = [...budgetHints, `Data root: ${downloadRootDir}`];
 
-        await this.runActualRequest(
-            `download budget '${budgetConfig.syncId}'`,
-            () =>
-                actual.downloadBudget(budgetConfig.syncId, encryptionPassword),
-            downloadHints
-        );
+        const maxAttempts = 2;
+        let lastError: unknown;
 
-        const finalBudgetDir = await this.resolveBudgetDataDir(
-            budgetConfig.syncId,
-            downloadRootDir
-        );
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            const attemptHint = `Attempt ${attempt}/${maxAttempts}`;
+            try {
+                await this.ensureInitialization(rootDataDir);
 
-        const finalRootDir = path.dirname(finalBudgetDir);
-        await this.ensureInitialization(finalRootDir);
+                let downloadRootDir = this.currentDataDir ?? rootDataDir;
 
-        this.logger.debug(
-            `Loading budget with syncId '${budgetConfig.syncId}'...`
-        );
+                const initialResolution = await this.tryResolveBudgetDirectory(
+                    budgetConfig.syncId,
+                    downloadRootDir
+                );
 
-        await this.runActualRequest(
-            `load budget '${budgetConfig.syncId}'`,
-            () => actual.loadBudget(budgetConfig.syncId),
-            budgetHints
-        );
+                if (initialResolution) {
+                    const resolvedRootDir = path.dirname(
+                        initialResolution.directory
+                    );
+                    await this.ensureInitialization(resolvedRootDir);
+                    downloadRootDir = this.currentDataDir ?? resolvedRootDir;
+                }
 
-        this.logger.debug(
-            `Synchronizing budget with syncId '${budgetConfig.syncId}'...`
-        );
-        await this.sync(budgetHints);
+                const downloadHints = [
+                    ...budgetHints,
+                    `Data root: ${downloadRootDir}`,
+                    attemptHint,
+                ];
+
+                this.logger.debug(
+                    `Downloading budget with syncId '${budgetConfig.syncId}' (attempt ${attempt}/${maxAttempts})...`
+                );
+
+                await this.runActualRequest(
+                    `download budget '${budgetConfig.syncId}'`,
+                    () =>
+                        actual.downloadBudget(
+                            budgetConfig.syncId,
+                            encryptionPassword
+                        ),
+                    downloadHints
+                );
+
+                const resolvedBudget = await this.resolveBudgetDataDir(
+                    budgetConfig.syncId,
+                    downloadRootDir
+                );
+
+                const finalRootDir = path.dirname(resolvedBudget.directory);
+
+                await this.ensureBudgetDirectoryAccessible(
+                    resolvedBudget.directory,
+                    resolvedBudget.metadata,
+                    budgetConfig.syncId
+                );
+
+                await this.ensureInitialization(finalRootDir);
+
+                const localBudgetId = resolvedBudget.metadata.id;
+                const loadHints = [
+                    ...budgetHints,
+                    `Local budget ID: ${localBudgetId}`,
+                    `Data root: ${finalRootDir}`,
+                    attemptHint,
+                ];
+
+                this.logger.debug(
+                    `Loading budget with syncId '${budgetConfig.syncId}' from local id '${localBudgetId}'...`
+                );
+
+                await this.runActualRequest(
+                    `load budget '${budgetConfig.syncId}'`,
+                    () => actual.loadBudget(localBudgetId),
+                    loadHints
+                );
+
+                this.logger.debug(
+                    `Synchronizing budget with syncId '${budgetConfig.syncId}'...`
+                );
+                await this.sync([...budgetHints, attemptHint]);
+                return;
+            } catch (error) {
+                lastError = error;
+
+                if (attempt >= maxAttempts || !this.shouldRetryBudgetLoad(error)) {
+                    throw error;
+                }
+
+                const retryHints: Array<string | Error> = [
+                    ...this.createContextHints([
+                        ...budgetHints,
+                        attemptHint,
+                    ]),
+                ];
+                if (error instanceof Error) {
+                    retryHints.push(error);
+                } else {
+                    retryHints.push(String(error));
+                }
+
+                this.logger.warn(
+                    `Budget load attempt ${attempt} failed (${this.getErrorSummary(
+                        error
+                    )}). Retrying...`,
+                    retryHints
+                );
+
+                await this.shutdownSilently([...budgetHints, attemptHint]);
+            }
+        }
+
+        if (lastError) {
+            throw lastError;
+        }
     }
 
     private async tryResolveBudgetDirectory(
         syncId: string,
         rootDir: string
-    ): Promise<string | null> {
+    ): Promise<BudgetDirectoryResolution | null> {
         try {
             return await this.resolveBudgetDataDir(syncId, rootDir);
         } catch (error) {
+            if (this.shouldRetryBudgetLoad(error)) {
+                return null;
+            }
+
             if (
                 error instanceof Error &&
                 error.message.includes('No Actual budget directory found')
@@ -427,6 +510,93 @@ class ActualApi {
 
             throw error;
         }
+    }
+
+    private async ensureBudgetDirectoryAccessible(
+        directory: string,
+        metadata: BudgetMetadata,
+        syncId: string
+    ): Promise<void> {
+        try {
+            await fs.access(directory);
+        } catch (error) {
+            throw createErrorWithCause(
+                `Budget directory '${directory}' for syncId '${syncId}' is not accessible`,
+                error instanceof Error ? error : new Error(String(error))
+            );
+        }
+
+        if (!metadata.id || metadata.groupId !== syncId) {
+            throw new Error(
+                `Budget metadata for syncId '${syncId}' is invalid or mismatched`
+            );
+        }
+    }
+
+    private shouldRetryBudgetLoad(error: unknown): boolean {
+        if (!error) {
+            return false;
+        }
+
+        const message =
+            error instanceof Error ? error.message : String(error ?? '');
+        const lower = message.toLowerCase();
+        const retryPatterns = [
+            'budget directory does not exist',
+            'budget-not-found',
+            'no actual budget directory found',
+            'not accessible',
+        ];
+
+        return retryPatterns.some((pattern) => lower.includes(pattern));
+    }
+
+    private getErrorSummary(error: unknown): string {
+        if (error instanceof Error) {
+            return error.message;
+        }
+
+        if (typeof error === 'string') {
+            return error;
+        }
+
+        try {
+            return JSON.stringify(error);
+        } catch {
+            return String(error);
+        }
+    }
+
+    private async shutdownSilently(contextHints: string[]): Promise<void> {
+        try {
+            await this.shutdown();
+        } catch (error) {
+            const hints: Array<string | Error> = [
+                ...this.createContextHints(contextHints),
+            ];
+            if (error instanceof Error) {
+                hints.push(error);
+            } else {
+                hints.push(String(error));
+            }
+
+            this.logger.warn(
+                'Failed to shutdown Actual client cleanly after budget load failure',
+                hints
+            );
+        }
+    }
+
+    private isIgnorableShutdownError(error: unknown): boolean {
+        if (!(error instanceof Error)) {
+            return false;
+        }
+
+        const message = error.message ?? '';
+        return (
+            error instanceof TypeError &&
+            message.includes("Cannot read properties of null (reading 'prepare')")
+        );
     }
 
     public async importTransactions(
@@ -517,9 +687,32 @@ class ActualApi {
         }
 
         try {
-            await this.runActualRequest('shutdown session', () =>
-                actual.shutdown()
-            );
+            await this.runActualRequest('shutdown session', async () => {
+                try {
+                    await actual.shutdown();
+                } catch (error) {
+                    if (this.isIgnorableShutdownError(error)) {
+                        const hints: Array<string | Error> = [
+                            ...this.createContextHints(
+                                'Operation: shutdown session'
+                            ),
+                        ];
+                        if (error instanceof Error) {
+                            hints.push(error);
+                        } else {
+                            hints.push(String(error));
+                        }
+
+                        this.logger.warn(
+                            'Actual client shutdown completed despite a missing database connection',
+                            hints
+                        );
+                        return;
+                    }
+
+                    throw error;
+                }
+            });
         } finally {
             this.isInitialized = false;
             this.currentDataDir = null;
@@ -564,7 +757,7 @@ class ActualApi {
     private async resolveBudgetDataDir(
         syncId: string,
         rootDir?: string
-    ): Promise<string> {
+    ): Promise<BudgetDirectoryResolution> {
         const actualDataDir =
             rootDir ?? this.currentDataDir ?? DEFAULT_DATA_DIR;
 
@@ -581,6 +774,7 @@ class ActualApi {
         }
 
         const inspectedDirs: string[] = [];
+        const metadataDiagnostics: string[] = [];
         const MAX_DIRS_TO_SCAN = 100;
 
         const sortedEntries = entries
@@ -606,28 +800,75 @@ class ActualApi {
             try {
                 const metadataRaw = await fs.readFile(metadataPath, 'utf8');
                 const parsed = JSON.parse(metadataRaw);
-                const metadata =
-                    parsed && typeof parsed === 'object' && 'groupId' in parsed
-                        ? (parsed as { groupId?: string })
-                        : {};
-
-                if (metadata.groupId === syncId) {
-                    const resolvedDir = path.join(actualDataDir, entry.name);
-                    this.logger.debug(
-                        `Using budget directory: ${entry.name} for syncId ${syncId}`
+                if (!parsed || typeof parsed !== 'object') {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata is not an object`
                     );
-                    return resolvedDir;
+                    continue;
                 }
+
+                const record = parsed as Record<string, unknown>;
+                const groupIdRaw = record.groupId;
+                const groupId =
+                    typeof groupIdRaw === 'string'
+                        ? groupIdRaw.trim()
+                        : '';
+                if (!groupId) {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata missing groupId`
+                    );
+                    continue;
+                }
+
+                if (groupId !== syncId) {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata groupId '${groupId}' does not match requested syncId '${syncId}'`
+                    );
+                    continue;
+                }
+
+                const idRaw = record.id;
+                const id =
+                    typeof idRaw === 'string' ? idRaw.trim() : entry.name;
+
+                if (!id) {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata missing id`
+                    );
+                    continue;
+                }
+
+                const resolvedDir = path.join(actualDataDir, entry.name);
+                const metadata: BudgetMetadata = {
+                    ...(record as BudgetMetadata),
+                    id,
+                    groupId,
+                };
+                this.logger.debug(
+                    `Using budget directory: ${entry.name} for syncId ${syncId}`,
+                    [
+                        `Metadata path: ${metadataPath}`,
+                        `Local budget ID: ${id}`,
+                    ]
+                );
+                return {
+                    directory: resolvedDir,
+                    metadata,
+                    metadataPath,
+                };
             } catch (error) {
                 const maybeErrno = error as NodeJS.ErrnoException | undefined;
-                if (
-                    maybeErrno?.code === 'ENOENT' ||
-                    maybeErrno?.code === 'EISDIR'
-                ) {
+                if (maybeErrno?.code === 'ENOENT' || maybeErrno?.code === 'EISDIR') {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata.json not found`
+                    );
                     continue;
                 }
 
                 if (error instanceof SyntaxError) {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata.json could not be parsed`
+                    );
                     continue;
                 }
 
@@ -637,11 +878,16 @@ class ActualApi {
 
         const inspectedSummary =
             inspectedDirs.length > 0 ? inspectedDirs.join(', ') : '(none)';
+        const metadataSummary =
+            metadataDiagnostics.length > 0
+                ? ` Metadata issues: ${metadataDiagnostics.join('; ')}.`
+                : '';
 
         throw new Error(
             `No Actual budget directory found for syncId '${syncId}'. ` +
-                `Checked directories under '${actualDataDir}': ${inspectedSummary}. ` +
-                'Open the budget in Actual Desktop and sync it before retrying.'
+                `Checked directories under '${actualDataDir}': ${inspectedSummary}.` +
+                metadataSummary +
+                ' Open the budget in Actual Desktop and sync it before retrying.'
         );
     }
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -196,7 +196,8 @@ class ActualApi {
     private async runActualRequest<T>(
         operation: string,
         callback: () => Promise<T>,
-        additionalHints?: string | string[]
+        additionalHints?: string | string[],
+        options?: { skipTimeoutShutdown?: boolean }
     ): Promise<T> {
         const timeoutMs = this.getRequestTimeoutMs();
         let timeoutHandle: NodeJS.Timeout | null = null;
@@ -209,27 +210,49 @@ class ActualApi {
                     operation,
                     timeoutMs
                 );
+                const finalizeTimeout = () => {
+                    this.isInitialized = false;
+                    this.currentDataDir = null;
+                    reject(timeoutError);
+                };
+
+                if (options?.skipTimeoutShutdown) {
+                    finalizeTimeout();
+                    return;
+                }
+
+                const extraHints = Array.isArray(additionalHints)
+                    ? additionalHints
+                    : additionalHints
+                      ? [additionalHints]
+                      : [];
+                const fallbackHints = [
+                    ...extraHints,
+                    `Timeout triggered by operation '${operation}'`,
+                ];
+                const warnHints = this.createContextHints(fallbackHints);
+                const shutdownAttempt = this.runActualRequest(
+                    'shutdown session',
+                    () => actual.shutdown(),
+                    fallbackHints,
+                    { skipTimeoutShutdown: true }
+                ).catch((shutdownError) => {
+                    const reason =
+                        shutdownError instanceof Error
+                            ? shutdownError.message
+                            : String(shutdownError);
+                    this.logger.warn(
+                        `Actual client shutdown after timeout failed: ${reason}`,
+                        warnHints
+                    );
+                });
+
                 Promise.race([
-                    Promise.resolve(actual.shutdown()),
+                    shutdownAttempt,
                     new Promise((resolve) =>
                         setTimeout(resolve, Math.min(5_000, timeoutMs / 3))
                     ),
-                ])
-                    .catch((shutdownError) => {
-                        const reason =
-                            shutdownError instanceof Error
-                                ? shutdownError.message
-                                : String(shutdownError);
-                        this.logger.warn(
-                            `Actual client shutdown after timeout failed: ${reason}`,
-                            hints
-                        );
-                    })
-                    .finally(() => {
-                        this.isInitialized = false;
-                        this.currentDataDir = null;
-                        reject(timeoutError);
-                    });
+                ]).finally(finalizeTimeout);
             }, timeoutMs);
         });
 
@@ -534,18 +557,19 @@ class ActualApi {
     }
 
     private shouldRetryBudgetLoad(error: unknown): boolean {
-        if (!error) {
+        const lower = (
+            error instanceof Error ? error.message : String(error ?? '')
+        ).toLowerCase();
+        if (!lower) {
             return false;
         }
-
-        const message =
-            error instanceof Error ? error.message : String(error ?? '');
-        const lower = message.toLowerCase();
         const retryPatterns = [
             'budget directory does not exist',
             'budget-not-found',
             'no actual budget directory found',
             'not accessible',
+            'enoent',
+            'eisdir',
         ];
 
         return retryPatterns.some((pattern) => lower.includes(pattern));

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -7,7 +7,7 @@ export enum LogLevel {
     DEBUG = 3,
 }
 
-type LogHint = string | string[];
+type LogHint = string | Error | Array<string | Error>;
 
 class Logger {
     private logLevel: LogLevel;
@@ -48,16 +48,44 @@ class Logger {
             }[level];
 
             console.log(chalkColor(prefix), `[${timestamp}]`, message);
-            if (hint) {
-                const arrayHint = Array.isArray(hint) ? hint : [hint];
+            const hints = this.normaliseHints(hint);
+            if (hints.length > 0) {
                 const hintIndent = ' '.repeat(
                     `${prefix} [${timestamp}] `.length
                 );
-                for (const hint of arrayHint) {
-                    console.log(chalk.gray(hintIndent, '↳ ', hint));
+                for (const line of hints) {
+                    console.log(chalk.gray(hintIndent, '↳ ', line));
                 }
             }
         }
+    }
+
+    private normaliseHints(hint?: LogHint): string[] {
+        if (!hint) {
+            return [];
+        }
+
+        const rawHints = Array.isArray(hint) ? hint : [hint];
+        const normalised: string[] = [];
+
+        for (const entry of rawHints) {
+            if (entry instanceof Error) {
+                const stack = entry.stack;
+                if (stack) {
+                    const lines = stack.split('\n').map((line) => line.trim());
+                    if (lines.length > 0) {
+                        normalised.push(...lines.filter((line) => line.length));
+                        continue;
+                    }
+                }
+                normalised.push(`Error: ${entry.message || entry.name}`);
+                continue;
+            }
+
+            normalised.push(entry);
+        }
+
+        return normalised;
     }
 
     public getLevel(): LogLevel {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -72,9 +72,17 @@ class Logger {
             if (entry instanceof Error) {
                 const stack = entry.stack;
                 if (stack) {
-                    const lines = stack.split('\n').map((line) => line.trim());
+                    const max = 15;
+                    const raw = stack.split('\n');
+                    const lines = raw
+                        .slice(0, max)
+                        .map((line) => line.trim())
+                        .filter((line) => line.length);
+                    if (raw.length > max) {
+                        lines.push(`… ${raw.length - max} more lines`);
+                    }
                     if (lines.length > 0) {
-                        normalised.push(...lines.filter((line) => line.length));
+                        normalised.push(...lines);
                         continue;
                     }
                 }

--- a/tests/ActualApi.test.ts
+++ b/tests/ActualApi.test.ts
@@ -384,6 +384,12 @@ describe('ActualApi', () => {
         expect(downloadBudgetMock).toHaveBeenCalledTimes(2);
         expect(loadBudgetMock).toHaveBeenCalledTimes(2);
         expect(loadBudgetMock).toHaveBeenLastCalledWith('local-budget-id');
+        expect(
+            downloadBudgetMock.mock.invocationCallOrder[0]
+        ).toBeLessThan(loadBudgetMock.mock.invocationCallOrder[0]);
+        expect(
+            downloadBudgetMock.mock.invocationCallOrder[1]
+        ).toBeLessThan(loadBudgetMock.mock.invocationCallOrder[1]);
         const warnCall = logger.warn.mock.calls.find(([message]) =>
             String(message).includes('Budget load attempt 1 failed')
         );

--- a/tests/ActualApi.test.ts
+++ b/tests/ActualApi.test.ts
@@ -229,10 +229,16 @@ describe('ActualApi', () => {
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'budget-dir', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'budget' });
+                return JSON.stringify({
+                    id: 'local-budget-id',
+                    groupId: 'budget',
+                });
             }
 
-            return JSON.stringify({ groupId: 'other-budget' });
+            return JSON.stringify({
+                id: 'other-budget',
+                groupId: 'other-budget',
+            });
         });
 
         initMock.mockResolvedValue(undefined);
@@ -243,7 +249,7 @@ describe('ActualApi', () => {
         await api.loadBudget('budget');
 
         expect(downloadBudgetMock).toHaveBeenCalledWith('budget', undefined);
-        expect(loadBudgetMock).toHaveBeenCalledWith('budget');
+        expect(loadBudgetMock).toHaveBeenCalledWith('local-budget-id');
         expect(syncMock).toHaveBeenCalled();
         expect(initMock).toHaveBeenCalledWith(
             expect.objectContaining({ dataDir: DEFAULT_DATA_DIR })
@@ -256,7 +262,15 @@ describe('ActualApi', () => {
             syncMock.mock.invocationCallOrder[0]
         );
         expect(logger.debug).toHaveBeenCalledWith(
-            'Using budget directory: budget-dir for syncId budget'
+            'Using budget directory: budget-dir for syncId budget',
+            expect.arrayContaining([
+                `Metadata path: ${path.join(
+                    DEFAULT_DATA_DIR,
+                    'budget-dir',
+                    'metadata.json'
+                )}`,
+                'Local budget ID: local-budget-id',
+            ])
         );
     });
 
@@ -274,7 +288,7 @@ describe('ActualApi', () => {
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'budget-dir', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'budget' });
+                return JSON.stringify({ id: 'budget-dir', groupId: 'budget' });
             }
 
             throw new Error('Unexpected file path');
@@ -315,7 +329,9 @@ describe('ActualApi', () => {
         const api = new ActualApi(makeServerConfig('budget'), logger);
 
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'budget-dir', groupId: 'budget' })
+        );
 
         const postError = Object.assign(
             new Error('PostError: group-not-found'),
@@ -343,6 +359,46 @@ describe('ActualApi', () => {
         expect(loadBudgetMock).not.toHaveBeenCalled();
     });
 
+    it('retries budget loading when Actual cannot find the local directory', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
+
+        readdirMock.mockResolvedValue([createDirent('budget-dir')]);
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'local-budget-id', groupId: 'budget' })
+        );
+
+        const missingDirError = new Error('budget directory does not exist');
+        downloadBudgetMock.mockResolvedValue(undefined);
+        loadBudgetMock
+            .mockRejectedValueOnce(missingDirError)
+            .mockResolvedValueOnce(undefined);
+        syncMock.mockResolvedValue(undefined);
+
+        await expect(api.loadBudget('budget')).resolves.toBeUndefined();
+
+        expect(downloadBudgetMock).toHaveBeenCalledTimes(2);
+        expect(loadBudgetMock).toHaveBeenCalledTimes(2);
+        expect(loadBudgetMock).toHaveBeenLastCalledWith('local-budget-id');
+        const warnCall = logger.warn.mock.calls.find(([message]) =>
+            String(message).includes('Budget load attempt 1 failed')
+        );
+        expect(warnCall).toBeDefined();
+        const [, warnHints] = warnCall!;
+        expect(warnHints).toEqual(
+            expect.arrayContaining([
+                'Server URL: http://localhost:5006',
+                'Budget sync ID: budget',
+                'Attempt 1/2',
+                expect.any(Error),
+            ])
+        );
+    });
+
     it('surfaces timeout errors from Actual API calls', async () => {
         const { default: ActualApi, ActualApiTimeoutError } = await import(
             '../src/utils/ActualApi.js'
@@ -354,7 +410,9 @@ describe('ActualApi', () => {
             logger
         );
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'budget-dir', groupId: 'budget' })
+        );
 
         downloadBudgetMock.mockImplementationOnce(
             () => new Promise(() => undefined)
@@ -407,7 +465,9 @@ describe('ActualApi', () => {
             logger
         );
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'budget-dir', groupId: 'budget' })
+        );
 
         downloadBudgetMock.mockImplementationOnce(
             () => new Promise(() => undefined)
@@ -635,6 +695,34 @@ describe('ActualApi', () => {
         expect(shutdownMock).not.toHaveBeenCalled();
     });
 
+    it('logs and suppresses benign shutdown errors when the database connection is missing', async () => {
+        const { default: ActualApi } = await import(
+            '../src/utils/ActualApi.js'
+        );
+
+        const logger = createLogger();
+        const api = new ActualApi(makeServerConfig('budget'), logger);
+
+        await api.init();
+
+        const shutdownError = new TypeError(
+            "Cannot read properties of null (reading 'prepare')"
+        );
+        shutdownMock.mockRejectedValueOnce(shutdownError);
+
+        await expect(api.shutdown()).resolves.toBeUndefined();
+
+        expect(shutdownMock).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('missing database connection'),
+            expect.arrayContaining([
+                'Server URL: http://localhost:5006',
+                'Operation: shutdown session',
+                expect.any(Error),
+            ])
+        );
+    });
+
     it('derives the budget directory from metadata before initialisation', async () => {
         const { default: ActualApi } = await import(
             '../src/utils/ActualApi.js'
@@ -668,10 +756,16 @@ describe('ActualApi', () => {
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'target-directory', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'target-budget' });
+                return JSON.stringify({
+                    id: 'target-directory',
+                    groupId: 'target-budget',
+                });
             }
 
-            return JSON.stringify({ groupId: 'other-budget' });
+            return JSON.stringify({
+                id: 'other-budget',
+                groupId: 'other-budget',
+            });
         });
 
         initMock.mockResolvedValue(undefined);
@@ -718,7 +812,7 @@ describe('ActualApi', () => {
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'valid', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'budget' });
+                return JSON.stringify({ id: 'valid', groupId: 'budget' });
             }
             throw new Error(`unexpected file ${filePath}`);
         });
@@ -729,7 +823,15 @@ describe('ActualApi', () => {
         await expect(api.loadBudget('budget')).resolves.toBeUndefined();
 
         expect(logger.debug).toHaveBeenCalledWith(
-            'Using budget directory: valid for syncId budget'
+            'Using budget directory: valid for syncId budget',
+            expect.arrayContaining([
+                `Metadata path: ${path.join(
+                    DEFAULT_DATA_DIR,
+                    'valid',
+                    'metadata.json'
+                )}`,
+                'Local budget ID: valid',
+            ])
         );
     });
 
@@ -757,6 +859,7 @@ describe('ActualApi', () => {
         const api = new ActualApi(serverConfig, createLogger());
 
         const nonMatchingMetadata = JSON.stringify({
+            id: 'alpha',
             groupId: 'different-budget',
         });
 
@@ -775,12 +878,13 @@ describe('ActualApi', () => {
         await expect(api.loadBudget('missing-budget')).rejects.toThrow(
             new RegExp(
                 `No Actual budget directory found for syncId 'missing-budget'\\. ` +
-                    `Checked directories under '${escapedRoot}': alpha, beta\\. ` +
-                    'Open the budget in Actual Desktop and sync it before retrying\\.'
+                    `Checked directories under '${escapedRoot}': alpha, beta\\. Metadata issues: ` +
+                    `.*groupId 'different-budget' does not match requested syncId 'missing-budget'.*` +
+                    ' Open the budget in Actual Desktop and sync it before retrying\\.'
             )
         );
-        expect(downloadBudgetMock).toHaveBeenCalledTimes(1);
-        expect(readdirMock).toHaveBeenCalledTimes(2);
+        expect(downloadBudgetMock).toHaveBeenCalledTimes(2);
+        expect(readdirMock.mock.calls.length).toBeGreaterThanOrEqual(4);
     });
 
     it('warns when scanning large Actual data directories', async () => {
@@ -800,10 +904,13 @@ describe('ActualApi', () => {
         readFileMock.mockImplementation(async (filePath: string) => {
             const directoryName = path.basename(path.dirname(filePath));
             if (directoryName === targetDirectory) {
-                return JSON.stringify({ groupId: 'budget' });
+                return JSON.stringify({ id: 'dir-first', groupId: 'budget' });
             }
 
-            return JSON.stringify({ groupId: 'other-budget' });
+            return JSON.stringify({
+                id: 'dir-other',
+                groupId: 'other-budget',
+            });
         });
 
         downloadBudgetMock.mockResolvedValue(undefined);
@@ -843,7 +950,9 @@ describe('ActualApi', () => {
         const api = new ActualApi(serverConfig, createLogger());
 
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'budget-dir', groupId: 'budget' })
+        );
         downloadBudgetMock.mockResolvedValue(undefined);
         loadBudgetMock.mockResolvedValue(undefined);
         syncMock.mockResolvedValue(undefined);
@@ -883,7 +992,9 @@ describe('ActualApi', () => {
         );
 
         readdirMock.mockResolvedValue([createDirent('budget-dir')]);
-        readFileMock.mockResolvedValue(JSON.stringify({ groupId: 'budget' }));
+        readFileMock.mockResolvedValue(
+            JSON.stringify({ id: 'budget-dir', groupId: 'budget' })
+        );
         downloadBudgetMock.mockResolvedValue(undefined);
         loadBudgetMock.mockResolvedValue(undefined);
         syncMock.mockResolvedValue(undefined);
@@ -937,13 +1048,19 @@ describe('ActualApi', () => {
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'dir-first', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'first-budget' });
+                return JSON.stringify({
+                    id: 'first-local-id',
+                    groupId: 'first-budget',
+                });
             }
             if (
                 filePath ===
                 path.join(DEFAULT_DATA_DIR, 'dir-second', 'metadata.json')
             ) {
-                return JSON.stringify({ groupId: 'second-budget' });
+                return JSON.stringify({
+                    id: 'second-local-id',
+                    groupId: 'second-budget',
+                });
             }
             throw new Error('unexpected file');
         });
@@ -957,10 +1074,26 @@ describe('ActualApi', () => {
         await api.loadBudget('second-budget');
 
         expect(logger.debug).toHaveBeenCalledWith(
-            'Using budget directory: dir-first for syncId first-budget'
+            'Using budget directory: dir-first for syncId first-budget',
+            expect.arrayContaining([
+                `Metadata path: ${path.join(
+                    DEFAULT_DATA_DIR,
+                    'dir-first',
+                    'metadata.json'
+                )}`,
+                'Local budget ID: first-local-id',
+            ])
         );
         expect(logger.debug).toHaveBeenCalledWith(
-            'Using budget directory: dir-second for syncId second-budget'
+            'Using budget directory: dir-second for syncId second-budget',
+            expect.arrayContaining([
+                `Metadata path: ${path.join(
+                    DEFAULT_DATA_DIR,
+                    'dir-second',
+                    'metadata.json'
+                )}`,
+                'Local budget ID: second-local-id',
+            ])
         );
 
         expect(initMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- resolve Actual budget directories via metadata IDs, retry downloads when local folders are missing, and guard shutdown against benign database errors
- improve logger hint handling so error stacks appear alongside contextual metadata
- update ActualApi tests to cover retry flows, metadata validation, and shutdown edge cases

## Testing
- npm test -- ActualApi

------
https://chatgpt.com/codex/tasks/task_e_68d83ea85350832f9a52dc49d9f97456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic retry (up to 2 attempts) when loading a budget, with a quiet shutdown between attempts.
  - Richer budget resolution: local budget identifier and metadata are surfaced in logs and used when loading before sync.
  - Improved log hint handling to show multi-line messages and error stacks.

- Bug Fixes
  - Validates and enforces metadata id/groupId consistency to prevent mismatches.
  - More informative diagnostic errors for missing/invalid budget metadata.
  - Graceful shutdown: benign shutdown errors are logged as warnings and suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->