### PR TITLE
fix: sync package version during release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,6 +16,16 @@
             }
         ],
         [
+            "@semantic-release/git",
+            {
+                "assets": [
+                    "package.json",
+                    "package-lock.json"
+                ],
+                "message": "chore(release): ${nextRelease.version}"
+            }
+        ],
+        [
             "@semantic-release/github",
             {
                 "assets": [


### PR DESCRIPTION
## Summary
- let semantic-release commit package.json and package-lock.json version bumps
- drop the dynamic CLI version resolver and rely on the packaged version again

## Testing
- npm run lint:eslint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d84aa273a4832f80b48d7153ec989f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.
- Bug Fixes
  - No user-facing fixes in this release.
- Chores
  - Improved release automation by committing versioned metadata during each publish with a standardised message.
  - Streamlines the release pipeline and increases visibility of version changes in the repository.
  - No action required from users; functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->