### PR TITLE
fix: merge CLI env overrides with defaults

### DIFF
--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -1,0 +1,165 @@
+import { spawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type CliSpawnOptions = Pick<SpawnOptions, 'cwd' | 'env'>;
+
+export interface CliRunOptions extends CliSpawnOptions {
+    readonly input?: string;
+    readonly timeoutMs?: number;
+}
+
+export interface CliRunResult {
+    readonly exitCode: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+const require = createRequire(import.meta.url);
+const typescriptCli = require.resolve('typescript/bin/tsc');
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const cliEntryPoint = path.join(repoRoot, 'dist', 'index.js');
+
+let buildPromise: Promise<void> | null = null;
+
+async function ensureCliBuilt(): Promise<void> {
+    if (!buildPromise) {
+        buildPromise = new Promise((resolve, reject) => {
+            const buildEnv = createCliEnv();
+
+            const buildProcess = spawn(
+                process.execPath,
+                [typescriptCli, '--project', 'tsconfig.json'],
+                {
+                    cwd: repoRoot,
+                    env: buildEnv,
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                }
+            );
+
+            let stderr = '';
+            let stdout = '';
+
+            buildProcess.stdout?.setEncoding('utf-8');
+            buildProcess.stderr?.setEncoding('utf-8');
+
+            buildProcess.stdout?.on('data', (chunk) => {
+                stdout += chunk;
+            });
+
+            buildProcess.stderr?.on('data', (chunk) => {
+                stderr += chunk;
+            });
+
+            buildProcess.on('error', (error) => {
+                buildPromise = null;
+                reject(error);
+            });
+
+            buildProcess.on('close', (exitCode) => {
+                if (exitCode === 0) {
+                    resolve();
+                    return;
+                }
+
+                buildPromise = null;
+                const error = new Error(
+                    `tsc exited with code ${exitCode}.\n${stdout}${stderr}`
+                );
+                reject(error);
+            });
+        });
+    }
+
+    await buildPromise;
+}
+
+export function createCliEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+        ...process.env,
+        NODE_ENV: 'test',
+        FORCE_COLOR: '0',
+        ...overrides,
+    };
+}
+
+export async function runCli(
+    args: readonly string[],
+    options: CliRunOptions = {}
+): Promise<CliRunResult> {
+    await ensureCliBuilt();
+
+    const baseEnv = createCliEnv();
+    const spawnOptions: SpawnOptions = {
+        cwd: options.cwd ?? repoRoot,
+        env: options.env ? { ...baseEnv, ...options.env } : baseEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+    };
+
+    const childProcess = spawn(process.execPath, [cliEntryPoint, ...args], spawnOptions);
+
+    if (options.input) {
+        childProcess.stdin?.write(options.input);
+    }
+    childProcess.stdin?.end();
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+
+    childProcess.stdout?.setEncoding('utf-8');
+    childProcess.stderr?.setEncoding('utf-8');
+
+    childProcess.stdout?.on('data', (chunk) => {
+        stdoutChunks.push(chunk);
+    });
+
+    childProcess.stderr?.on('data', (chunk) => {
+        stderrChunks.push(chunk);
+    });
+
+    return new Promise((resolve, reject) => {
+        let timedOut = false;
+        let timeout: NodeJS.Timeout | undefined;
+
+        if (typeof options.timeoutMs === 'number') {
+            timeout = setTimeout(() => {
+                timedOut = true;
+                childProcess.kill('SIGKILL');
+            }, options.timeoutMs);
+        }
+
+        childProcess.on('error', (error) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            reject(error);
+        });
+
+        childProcess.on('close', (exitCode, signal) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+
+            if (timedOut) {
+                reject(new Error('CLI process timed out'));
+                return;
+            }
+
+            resolve({
+                exitCode,
+                signal,
+                stdout: stdoutChunks.join(''),
+                stderr: stderrChunks.join(''),
+            });
+        });
+    });
+}
+
+export async function getCliEntrypoint(): Promise<string> {
+    await ensureCliBuilt();
+    return cliEntryPoint;
+}


### PR DESCRIPTION
## Summary
- merge CLI harness env overrides with the base test environment so PATH and other defaults remain intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8581d21e4832f891932c6767008bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Introduced a reusable test helper to build and run the CLI within test suites, improving determinism and reliability.
  - Added environment setup utilities for consistent CLI execution during tests.
  - Implemented output capture (stdout/stderr) and exit reporting to aid assertions and debugging.
  - Added optional input feeding and timeout handling to prevent hanging tests.
  - Ensures the CLI is built once per run and reused, reducing test flakiness and speeding up execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->