### PR TITLE
fix: harden CLI helper process handling

### DIFF
--- a/tests/helpers/cli.helper.test.ts
+++ b/tests/helpers/cli.helper.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { BufferEncoding } from 'node:buffer';
+import type { spawn as Spawn } from 'node:child_process';
+
+type MockStream = EventEmitter & {
+    setEncoding: (encoding: BufferEncoding) => void;
+};
+
+type MockChildProcess = EventEmitter & {
+    stdout: MockStream;
+    stderr: MockStream;
+    stdin: {
+        write: (input: string) => void;
+        end: () => void;
+    };
+    kill: (signal?: NodeJS.Signals) => void;
+};
+
+type SpawnParameters = Parameters<Spawn>;
+
+const spawnMock = vi.fn<MockChildProcess, SpawnParameters>();
+
+function createMockStream(): MockStream {
+    const stream = new EventEmitter() as MockStream;
+    stream.setEncoding = vi.fn();
+    return stream;
+}
+
+function createMockProcess(): MockChildProcess {
+    const child = new EventEmitter() as MockChildProcess;
+    (child as MockChildProcess).stdout = createMockStream();
+    (child as MockChildProcess).stderr = createMockStream();
+    (child as MockChildProcess).stdin = {
+        write: vi.fn(),
+        end: vi.fn(),
+    };
+    child.kill = vi.fn();
+
+    setImmediate(() => {
+        child.emit('close', 0, null);
+    });
+
+    return child;
+}
+
+vi.mock('node:child_process', async () => {
+    const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    return {
+        ...actual,
+        spawn: spawnMock,
+    };
+});
+
+beforeEach(async () => {
+    await vi.resetModules();
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(() => createMockProcess());
+});
+
+describe('createCliEnv', () => {
+    const overriddenKey = '__CLI_HELPER_TEST_OVERRIDE__';
+    const preservedKey = '__CLI_HELPER_TEST_PRESERVE__';
+
+    afterEach(() => {
+        delete process.env[overriddenKey];
+        delete process.env[preservedKey];
+    });
+
+    it('merges overrides into the base CLI environment', async () => {
+        process.env[overriddenKey] = 'base-value';
+        process.env[preservedKey] = 'base-preserved';
+        const { createCliEnv } = await import('./cli.ts');
+
+        const env = createCliEnv({
+            [overriddenKey]: 'override-value',
+            NODE_ENV: 'custom',
+            EXTRA: 'value',
+        });
+
+        expect(env).not.toBe(process.env);
+        expect(env[overriddenKey]).toBe('override-value');
+        expect(env[preservedKey]).toBe('base-preserved');
+        expect(env.EXTRA).toBe('value');
+        expect(env.NODE_ENV).toBe('custom');
+        expect(env.FORCE_COLOR).toBe('0');
+    });
+});
+
+describe('getCliEntrypoint', () => {
+    it('builds the CLI once and caches the entrypoint path', async () => {
+        const { getCliEntrypoint } = await import('./cli.ts');
+
+        const first = await getCliEntrypoint();
+        const second = await getCliEntrypoint();
+
+        expect(first).toBe(second);
+        expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/helpers/cli.ts
+++ b/tests/helpers/cli.ts
@@ -1,0 +1,177 @@
+import { spawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type CliSpawnOptions = Pick<SpawnOptions, 'cwd' | 'env'>;
+
+export interface CliRunOptions extends CliSpawnOptions {
+    readonly input?: string;
+    readonly timeoutMs?: number;
+}
+
+export interface CliRunResult {
+    readonly exitCode: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly stdout: string;
+    readonly stderr: string;
+}
+
+const require = createRequire(import.meta.url);
+const typescriptCli: string = require.resolve('typescript/bin/tsc');
+
+const repoRoot: string = fileURLToPath(new URL('../../', import.meta.url));
+const cliEntryPoint: string = path.join(repoRoot, 'dist', 'index.js');
+
+let buildPromise: Promise<void> | null = null;
+
+async function ensureCliBuilt(): Promise<void> {
+    if (!buildPromise) {
+        buildPromise = new Promise((resolve, reject) => {
+            const buildEnv = createCliEnv();
+
+            const buildProcess = spawn(
+                process.execPath,
+                [typescriptCli, '--project', 'tsconfig.json'],
+                {
+                    cwd: repoRoot,
+                    env: buildEnv,
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                }
+            );
+
+            let stderr = '';
+            let stdout = '';
+
+            buildProcess.stdout?.setEncoding('utf8');
+            buildProcess.stderr?.setEncoding('utf8');
+
+            buildProcess.stdout?.on('data', (chunk) => {
+                stdout += chunk;
+            });
+
+            buildProcess.stderr?.on('data', (chunk) => {
+                stderr += chunk;
+            });
+
+            buildProcess.on('error', (error) => {
+                buildPromise = null;
+                reject(error);
+            });
+
+            buildProcess.on('close', (exitCode) => {
+                if (exitCode === 0) {
+                    resolve();
+                    return;
+                }
+
+                buildPromise = null;
+                const error = new Error(
+                    `tsc exited with code ${exitCode}.\n${stdout}${stderr}`
+                );
+                reject(error);
+            });
+        });
+    }
+
+    await buildPromise;
+}
+
+export function createCliEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+        ...process.env,
+        NODE_ENV: 'test',
+        FORCE_COLOR: '0',
+        ...overrides,
+    };
+}
+
+export async function runCli(
+    args: readonly string[],
+    options: CliRunOptions = {}
+): Promise<CliRunResult> {
+    await ensureCliBuilt();
+
+    const baseEnv = createCliEnv();
+    const spawnOptions: SpawnOptions = {
+        cwd: options.cwd ?? repoRoot,
+        env: options.env ? { ...baseEnv, ...options.env } : baseEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+    };
+
+    const childProcess = spawn(process.execPath, [cliEntryPoint, ...args], spawnOptions);
+
+    if (options.input) {
+        childProcess.stdin?.write(options.input);
+    }
+    childProcess.stdin?.end();
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+
+    childProcess.stdout?.setEncoding('utf8');
+    childProcess.stderr?.setEncoding('utf8');
+
+    childProcess.stdout?.on('data', (chunk) => {
+        stdoutChunks.push(chunk);
+    });
+
+    childProcess.stderr?.on('data', (chunk) => {
+        stderrChunks.push(chunk);
+    });
+
+    return new Promise((resolve, reject) => {
+        let timedOut = false;
+        let timeout: NodeJS.Timeout | undefined;
+        let forceKill: NodeJS.Timeout | undefined;
+
+        if (typeof options.timeoutMs === 'number') {
+            timeout = setTimeout(() => {
+                timedOut = true;
+                // Try graceful shutdown first
+                childProcess.kill('SIGTERM');
+                // Escalate if the process refuses to die
+                forceKill = setTimeout(() => {
+                    childProcess.kill('SIGKILL');
+                }, 2000);
+            }, options.timeoutMs);
+        }
+
+        childProcess.on('error', (error) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            if (forceKill) {
+                clearTimeout(forceKill);
+            }
+            reject(error);
+        });
+
+        childProcess.on('close', (exitCode, signal) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            if (forceKill) {
+                clearTimeout(forceKill);
+            }
+
+            if (timedOut) {
+                reject(new Error('CLI process timed out'));
+                return;
+            }
+
+            resolve({
+                exitCode,
+                signal,
+                stdout: stdoutChunks.join(''),
+                stderr: stderrChunks.join(''),
+            });
+        });
+    });
+}
+
+export async function getCliEntrypoint(): Promise<string> {
+    await ensureCliBuilt();
+    return cliEntryPoint;
+}


### PR DESCRIPTION
## Summary
- ensure the CLI helper uses proper BufferEncoding values and typed constants
- escalate CLI timeouts with a SIGTERM grace period before SIGKILL
- add helper-focused tests covering environment merging and build caching

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8581d21e4832f891932c6767008bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a CLI testing toolkit to run the CLI in a controlled environment with input/output capture, timeout handling and graceful kill behaviour.
  - Added tests covering environment merging, entrypoint resolution and caching, process lifecycle (spawn/termination) and captured stdout/stderr.
  - Improves reliability and confidence in CLI behaviour, reducing risk of regressions for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->