### PR TITLE
test: assert CLI exits non-zero on importer failures

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -151,12 +151,10 @@
 
 ### Story 4.3 – Propagate CLI exit codes for importer failures
 - **Complexity:** 3 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** The CLI logs errors but lacks tests asserting non-zero exit codes when importer operations throw.
-- **Next Steps:**
-  - Add CLI harness coverage (once Story 4.1 lands) that forces importer failures and asserts `process.exitCode`.
-  - Ensure `run().catch` in `src/index.ts` remains the single error boundary setting exit codes.
-- **Key Files:** `src/index.ts`, `tests/commands`.
+- **Status:** ✅ Done
+- **Outcome:** CLI integration coverage now forces importer failures and verifies the process exits with code `1`, confirming the `run().catch` boundary surfaces errors to callers instead of silently logging them.
+- **Evidence:** `tests/commands/import.command.test.ts` asserts the mocked importer failure propagates to `stderr` and a non-zero exit code, while `tests/helpers/cli-mock-loader.mjs` records the synthetic crash for debugging.
+- **Follow-up:** None at this time.
 
 ## Epic 5: Observability and developer experience
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,13 +116,13 @@
 
 ## Epic 4: CLI usability and coverage
 
-- **Epic Assessment:** 🚧 In progress. Story 4.1’s harness and CLI import coverage landed, so follow-up work can assume end-to-end tests exist when refining options, exit codes, and UX.
+- **Epic Assessment:** ✅ Completed. Stories 4.1–4.3 shipped the harness, option validation, and failure propagation coverage, so downstream work can rely on end-to-end CLI tests being available.
 
 ### Story 4.1 – Establish CLI integration tests for `import`
 - **Complexity:** 8 pts
 - **Status:** ✅ Done
 - **Outcome:** CLI integration coverage now executes the compiled binary with a reusable harness. Tests simulate multiple servers, dry-run imports, and invalid account filters by injecting mock Actual/MoneyMoney layers via a custom loader.
-- **Evidence:** `tests/helpers/cli.ts` builds the CLI once per run, `tests/helpers/cli-mock-loader.mjs` records dependency usage, and `tests/commands/import.command.test.ts` asserts dry-run messaging, multi-budget imports, and error propagation.
+- **Evidence:** `tests/helpers/cli.ts` builds the CLI once per run, `tests/helpers/cli-mock-loader.ts` records dependency usage, and `tests/commands/import.command.test.ts` asserts dry-run messaging, multi-budget imports, and error propagation.
 - **Follow-up:** Future CLI stories can extend the harness with additional assertions (e.g., exit-code propagation, help output snapshots).
 
 #### Task 4.1a – Build CLI test harness
@@ -153,7 +153,7 @@
 - **Complexity:** 3 pts
 - **Status:** ✅ Done
 - **Outcome:** CLI integration coverage now forces importer failures and verifies the process exits with code `1`, confirming the `run().catch` boundary surfaces errors to callers instead of silently logging them.
-- **Evidence:** `tests/commands/import.command.test.ts` asserts the mocked importer failure propagates to `stderr` and a non-zero exit code, while `tests/helpers/cli-mock-loader.mjs` records the synthetic crash for debugging.
+- **Evidence:** `tests/commands/import.command.test.ts` asserts the mocked importer failure propagates to `stderr` and a non-zero exit code, while `tests/helpers/cli-mock-loader.ts` records the synthetic crash for debugging.
 - **Follow-up:** None at this time.
 
 ## Epic 5: Observability and developer experience

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -116,7 +116,7 @@
 
 ## Epic 4: CLI usability and coverage
 
-- **Epic Assessment:** ✅ Completed. Stories 4.1–4.3 shipped the harness, option validation, and failure propagation coverage, so downstream work can rely on end-to-end CLI tests being available.
+**Epic Assessment:** ✅ Completed. Stories 4.1–4.3 shipped the harness, option validation, and failure propagation coverage, so downstream work can rely on end-to-end CLI tests being available.
 
 ### Story 4.1 – Establish CLI integration tests for `import`
 - **Complexity:** 8 pts

--- a/tests/commands/cli-options.command.test.ts
+++ b/tests/commands/cli-options.command.test.ts
@@ -227,7 +227,7 @@ describe('CLI global options', () => {
                     CLI_TEST_EVENTS_FILE: eventsFile,
                     NODE_NO_WARNINGS: '1',
                 },
-                nodeOptions: ['--loader', loaderPath],
+                nodeOptions: loaderNodeOptions,
                 timeoutMs: CLI_TIMEOUT_MS,
             });
 

--- a/tests/commands/cli-options.command.test.ts
+++ b/tests/commands/cli-options.command.test.ts
@@ -17,8 +17,14 @@ interface RecordedEvent {
 }
 
 const loaderPath = fileURLToPath(
-    new URL('../helpers/cli-mock-loader.mjs', import.meta.url)
+    new URL('../helpers/cli-mock-loader.ts', import.meta.url)
 );
+const loaderNodeOptions = [
+    '--loader',
+    'ts-node/esm',
+    '--loader',
+    loaderPath,
+] as const;
 
 const CLI_TIMEOUT_MS = 20000;
 
@@ -114,7 +120,7 @@ describe('CLI global options', () => {
                         CLI_TEST_EVENTS_FILE: eventsFile,
                         NODE_NO_WARNINGS: '1',
                     },
-                    nodeOptions: ['--loader', loaderPath],
+                    nodeOptions: loaderNodeOptions,
                     timeoutMs: CLI_TIMEOUT_MS,
                 }
             );
@@ -151,7 +157,7 @@ describe('CLI global options', () => {
                         CLI_TEST_EVENTS_FILE: eventsFile,
                         NODE_NO_WARNINGS: '1',
                     },
-                    nodeOptions: ['--loader', loaderPath],
+                    nodeOptions: loaderNodeOptions,
                     timeoutMs: CLI_TIMEOUT_MS,
                 }
             );
@@ -188,7 +194,7 @@ describe('CLI global options', () => {
                         CLI_TEST_EVENTS_FILE: eventsFile,
                         NODE_NO_WARNINGS: '1',
                     },
-                    nodeOptions: ['--loader', loaderPath],
+                    nodeOptions: loaderNodeOptions,
                     timeoutMs: CLI_TIMEOUT_MS,
                 }
             );

--- a/tests/commands/import.command.test.ts
+++ b/tests/commands/import.command.test.ts
@@ -11,6 +11,7 @@ interface CliTestContext {
     readonly importer?: {
         readonly failOnUnknownAccounts?: boolean;
         readonly knownAccounts?: readonly string[];
+        readonly failures?: Record<string, string>;
     };
     readonly accountMap?: unknown;
     readonly moneyMoney?: {

--- a/tests/commands/import.command.test.ts
+++ b/tests/commands/import.command.test.ts
@@ -25,8 +25,14 @@ interface RecordedEvent {
 }
 
 const loaderPath = fileURLToPath(
-    new URL('../helpers/cli-mock-loader.mjs', import.meta.url)
+    new URL('../helpers/cli-mock-loader.ts', import.meta.url)
 );
+const loaderNodeOptions = [
+    '--loader',
+    'ts-node/esm',
+    '--loader',
+    loaderPath,
+] as const;
 
 const CLI_TIMEOUT_MS = 20000;
 
@@ -153,7 +159,7 @@ describe('import command (CLI)', () => {
                     CLI_TEST_EVENTS_FILE: eventsFile,
                     NODE_NO_WARNINGS: '1',
                 },
-                nodeOptions: ['--loader', loaderPath],
+                nodeOptions: loaderNodeOptions,
             }
         );
 
@@ -232,7 +238,7 @@ describe('import command (CLI)', () => {
                     CLI_TEST_EVENTS_FILE: eventsFile,
                     NODE_NO_WARNINGS: '1',
                 },
-                nodeOptions: ['--loader', loaderPath],
+                nodeOptions: loaderNodeOptions,
             }
         );
 
@@ -311,7 +317,7 @@ describe('import command (CLI)', () => {
                     CLI_TEST_EVENTS_FILE: eventsFile,
                     NODE_NO_WARNINGS: '1',
                 },
-                nodeOptions: ['--loader', loaderPath],
+                nodeOptions: loaderNodeOptions,
             }
         );
 
@@ -386,7 +392,7 @@ describe('import command (CLI)', () => {
                     CLI_TEST_EVENTS_FILE: eventsFile,
                     NODE_NO_WARNINGS: '1',
                 },
-                nodeOptions: ['--loader', loaderPath],
+                nodeOptions: loaderNodeOptions,
             }
         );
 

--- a/tests/helpers/cli-mock-loader.mjs
+++ b/tests/helpers/cli-mock-loader.mjs
@@ -237,6 +237,13 @@ export default class Importer {
             },
         };
 
+        const failureMessage =
+            importerConfig.failures?.[this.budgetConfig.syncId];
+        if (typeof failureMessage === 'string' && failureMessage.length > 0) {
+            recordEvent({ ...eventBase, error: failureMessage });
+            throw new Error(failureMessage);
+        }
+
         if (
             importerConfig.failOnUnknownAccounts &&
             Array.isArray(options.accountRefs)


### PR DESCRIPTION
## Summary
- add CLI integration coverage that forces importer crashes and checks the CLI exit code
- extend the CLI mock loader to simulate importer failures and capture the recorded event
- mark Story 4.3 complete in the backlog with links to the new coverage

## Testing
- npm test -- --run tests/commands/import.command.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d92604e538832fb3ce554900fa8e6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CLI now surfaces importer errors to stderr and exits with a non‑zero status when failures occur.
- Bug Fixes
  - Improved error propagation in CLI runs, preventing silent failures and ensuring callers receive errors.
- Documentation
  - Backlog updated to reflect completed work and corrected references.
- Tests
  - Added scenarios to verify non‑zero exit codes and error messaging on unexpected importer failures.
  - Standardised loader configuration across CLI tests for consistent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->