### PR TITLE
Add Node 24 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
                 node-version:
                     - 20
                     - 22
+                    - 24
                 task:
                     - lint
                     - typecheck


### PR DESCRIPTION
## Summary
- add Node.js 24 to the quality job matrix so the workflow covers the latest release

## Testing
- npm run lint:prettier
- npm run lint:eslint

------
https://chatgpt.com/codex/tasks/task_e_68d946ab31d0832fb2e60d38c9943014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded continuous integration environment to run on Node.js 24 for quality checks.
  - Broadened CI tasks to include build and test in addition to linting and type checking, with coverage across supported versions.
- Tests
  - Automated test suite now executed within CI alongside build, lint and type checks across the matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->