### PR TITLE
chore: enforce commit linting

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+npx --no -- commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,6 @@ surprises.
 - Start messages with a valid **type** (e.g., `feat`, `fix`, `docs`, `chore`)
   followed by an imperative subject (e.g., `fix: add budget syncing retries`).
 - Keep the subject under 72 characters and avoid ending it with a period.
+- Husky runs `npx --no commitlint --edit "$1"` via the `commit-msg` hook to
+  enforce the format locally. If the hook blocks a commit, fix the message and
+  recommit rather than bypassing the hook.


### PR DESCRIPTION
## Summary
- document the commit message linting expectations in the contributor guidelines
- add a Husky commit-msg hook that runs commitlint locally to enforce the format

## Testing
- npm run lint:prettier
- npm run lint:eslint
- npm run lint:complexity

------
https://chatgpt.com/codex/tasks/task_e_68d95d493f54832fa8dda554432bf768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Introduced automatic commit message linting during commits to enforce consistent message formats.

- Documentation
  - Updated contributor guidance to explain the commit message checks and how to resolve blocked commits by fixing the message and recommitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->