### PR TITLE
feat: add structured logging flag to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ actual-monmon validate
 
 You can increase or decrease CLI verbosity with `--logLevel` (`0 = ERROR`,
 `1 = WARN`, `2 = INFO`, `3 = DEBUG`). Combine it with `--config` to validate a
-different configuration file:
+different configuration file, and use `--structuredLogs` when you need
+machine-readable JSON output for log aggregation:
 
 ```bash
 actual-monmon validate --config ./config.toml --logLevel 3
@@ -265,6 +266,7 @@ You can limit the scope of an import with additional flags:
 - `--from YYYY-MM-DD` / `--to YYYY-MM-DD` – bound the transaction date range.
 - `--dry-run` – simulate the import without persisting any changes.
 - `--logLevel <0-3>` – control CLI verbosity (defaults to `2`, INFO).
+- `--structuredLogs` – emit JSON-formatted logs instead of coloured text.
 - `--config <path>` – load a configuration file from a custom path.
 
 ### Command Options

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -316,9 +316,9 @@ end-to-end CLI tests being available.
 
 ## Epic 6: Testing & Reliability
 
-- **Epic Assessment:** 🚧 In progress. Error-path fixtures and malformed export
-  protections now land via Story 6.1, but structured logging schema coverage
-  from Story 6.2 is still outstanding.
+- **Epic Assessment:** ✅ Completed. Error-path fixtures, malformed export
+  guards, and structured logging schemas now keep the CLI observable and
+  resilient under test.
 
 ### Story 6.1 – Expand error-path coverage
 
@@ -364,16 +364,21 @@ end-to-end CLI tests being available.
 ### Story 6.2 – Standardise debug log schema for observability
 
 - **Complexity:** 5 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** Logs across modules vary in structure; no schema
-  validation exists for tests to assert consistent JSON output.
-- **Next Steps:**
-  - Define a structured log shape (likely JSON objects) and update logger
-    helpers to emit accordingly when a `structuredLogs` flag is enabled.
-  - Update fixtures/tests to validate schema and ensure compatibility with
-    existing log consumers.
-- **Key Files:** `src/utils/Logger.ts`, `tests/` (log assertions), CI log
-  parsing if applicable.
+- **Status:** ✅ Done
+- **Outcome:** CLI callers can opt into structured JSON logs, ensuring
+  observability tools receive a consistent schema while keeping colourful text
+  output as the default experience.
+- **Evidence:**
+  - `src/utils/Logger.ts` accepts a `structuredLogs` flag and serialises
+    messages, timestamps, and normalised hints into JSON payloads.
+  - CLI global options expose `--structuredLogs`, flowing through
+    `src/index.ts`, command handlers, and CLI harness tests.
+  - `tests/utils/Logger.test.ts` asserts the JSON envelope while
+    `tests/commands/cli-options.command.test.ts` verifies the new CLI switch.
+- **Next Steps:** Monitor downstream tooling for additional fields (e.g.,
+  request identifiers) that might warrant schema extensions.
+- **Key Files:** `src/utils/Logger.ts`, `src/index.ts`,
+  `tests/utils/Logger.test.ts`, `tests/commands/cli-options.command.test.ts`.
 
 ## Epic 7: CLI UX
 

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -11,7 +11,8 @@ import { DATE_FORMAT } from '../utils/shared.js';
 
 const handleCommand = async (argv: ArgumentsCamelCase) => {
     const logLevel = (argv.logLevel ?? LogLevel.INFO) as number;
-    const logger = new Logger(logLevel);
+    const structuredLogs = Boolean(argv.structuredLogs);
+    const logger = new Logger(logLevel, { structuredLogs });
 
     const { config, defaultDecisions } = await loadConfig(argv);
 

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -11,7 +11,8 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
     const configPath = await getConfigFile(argv);
 
     const logLevel = (argv.logLevel ?? LogLevel.INFO) as number;
-    const logger = new Logger(logLevel);
+    const structuredLogs = Boolean(argv.structuredLogs);
+    const logger = new Logger(logLevel, { structuredLogs });
 
     logger.info(`Current configuration file: ${configPath}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ const logLevelEnumValues = Object.values(LogLevel).filter(
 const minLogLevel = Math.min(...logLevelEnumValues);
 const maxLogLevel = Math.max(...logLevelEnumValues);
 
+let structuredLogsEnabled = false;
+
 const parser: Argv<unknown> = yargs(hideBin(process.argv))
     .option('config', {
         type: 'string',
@@ -29,6 +31,11 @@ const parser: Argv<unknown> = yargs(hideBin(process.argv))
     .option('logLevel', {
         type: 'number',
         description: 'The log level to use (0-3)',
+    })
+    .option('structuredLogs', {
+        type: 'boolean',
+        description:
+            'Emit structured JSON logs instead of coloured text output',
     })
     .coerce('logLevel', (value: unknown): number | null | undefined => {
         if (value === undefined || value === null) {
@@ -55,6 +62,9 @@ const parser: Argv<unknown> = yargs(hideBin(process.argv))
     })
     .command(importCommand)
     .command(validateCommand)
+    .middleware((argv) => {
+        structuredLogsEnabled = Boolean(argv.structuredLogs);
+    })
     .showHelpOnFail(false)
     .fail((msg, err) => {
         if (err) {
@@ -69,7 +79,16 @@ const run = async (): Promise<void> => {
 };
 
 run().catch((error: unknown) => {
-    const logger = new Logger();
+    if (!structuredLogsEnabled) {
+        const rawArgs = process.argv.slice(2);
+        structuredLogsEnabled = rawArgs.some((arg) =>
+            ['--structuredLogs', '--structured-logs'].includes(arg)
+        );
+    }
+
+    const logger = new Logger(LogLevel.INFO, {
+        structuredLogs: structuredLogsEnabled,
+    });
 
     if (error instanceof Error) {
         logger.error(error.message);

--- a/tests/commands/cli-options.command.test.ts
+++ b/tests/commands/cli-options.command.test.ts
@@ -136,6 +136,7 @@ describe('CLI global options', () => {
                 {
                     type: 'Logger#constructor',
                     level: 3,
+                    structuredLogs: false,
                 },
             ]);
         },
@@ -173,6 +174,45 @@ describe('CLI global options', () => {
                 {
                     type: 'Logger#constructor',
                     level: 0,
+                    structuredLogs: false,
+                },
+            ]);
+        },
+        CLI_TIMEOUT_MS
+    );
+
+    it(
+        'enables structured logs when requested',
+        async () => {
+            const { contextDir, eventsFile } = await createContextDir({
+                config: createBaseConfig(),
+            });
+
+            const result = await runCli(
+                ['import', '--dry-run', '--structuredLogs'],
+                {
+                    env: {
+                        CLI_TEST_CONTEXT_DIR: contextDir,
+                        CLI_TEST_EVENTS_FILE: eventsFile,
+                        NODE_NO_WARNINGS: '1',
+                    },
+                    nodeOptions: loaderNodeOptions,
+                    timeoutMs: CLI_TIMEOUT_MS,
+                }
+            );
+
+            expect(result.exitCode).toBe(0);
+
+            const events = await readEvents(eventsFile);
+            const loggerEvents = events.filter(
+                (event) => event.type === 'Logger#constructor'
+            );
+
+            expect(loggerEvents).toEqual([
+                {
+                    type: 'Logger#constructor',
+                    level: LogLevel.INFO,
+                    structuredLogs: true,
                 },
             ]);
         },
@@ -231,21 +271,40 @@ describe('CLI global options', () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe('');
-            expect(result.stdout).toMatchInlineSnapshot(`
-              "index.js [command]
 
-              Commands:
-                index.js import    Import data from MoneyMoney
-                index.js validate  View information about and validate the current
-                                   configuration
+            const normalisedHelp = result.stdout
+                .split('\n')
+                .map((line) => {
+                    const trimmed = line.replace(/\s+$/u, '');
+                    if (trimmed.trim() === '[boolean]') {
+                        return '[boolean]';
+                    }
+                    return trimmed;
+                })
+                .join('\n');
 
-              Options:
-                --help      Show help                                                [boolean]
-                --version   Show version number                                      [boolean]
-                --config    Path to the configuration file                            [string]
-                --logLevel  The log level to use (0-3)                                [number]
-              "
-            `);
+            expect(normalisedHelp).toContain('index.js [command]');
+            expect(normalisedHelp).toContain(
+                'index.js import    Import data from MoneyMoney'
+            );
+            expect(normalisedHelp).toContain(
+                'index.js validate  View information about and validate the current'
+            );
+            expect(normalisedHelp).toMatch(
+                /--help\s+Show help[\s\S]*\[boolean\]/
+            );
+            expect(normalisedHelp).toMatch(
+                /--version\s+Show version number[\s\S]*\[boolean\]/
+            );
+            expect(normalisedHelp).toMatch(
+                /--config\s+Path to the configuration file[\s\S]*\[string\]/
+            );
+            expect(normalisedHelp).toMatch(
+                /--logLevel\s+The log level to use \(0-3\)[\s\S]*\[number\]/
+            );
+            expect(normalisedHelp).toMatch(
+                /--structuredLogs\s+Emit structured JSON logs instead of coloured text output[\s\S]*\[boolean\]/
+            );
         },
         CLI_TIMEOUT_MS
     );

--- a/tests/helpers/cli-mock-loader.ts
+++ b/tests/helpers/cli-mock-loader.ts
@@ -83,9 +83,14 @@ const LEVELS = ['ERROR', 'WARN', 'INFO', 'DEBUG'];
 export const LogLevel = { ERROR: 0, WARN: 1, INFO: 2, DEBUG: 3 };
 
 export default class Logger {
-    constructor(level = LogLevel.INFO) {
+    constructor(level = LogLevel.INFO, options = {}) {
         this.level = level;
-        recordEvent({ type: 'Logger#constructor', level });
+        this.structuredLogs = Boolean(options.structuredLogs);
+        recordEvent({
+            type: 'Logger#constructor',
+            level,
+            structuredLogs: this.structuredLogs,
+        });
     }
 
     getLevel() {

--- a/tests/utils/Logger.test.ts
+++ b/tests/utils/Logger.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Logger, { LogLevel } from '../../src/utils/Logger.js';
+
+const FIXED_DATE = new Date('2024-02-29T12:34:56.789Z');
+
+describe('Logger', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(FIXED_DATE);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('emits structured JSON logs when enabled', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+            // noop
+        });
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+            // noop
+        });
+
+        const logger = new Logger(LogLevel.DEBUG, { structuredLogs: true });
+
+        logger.info('Structured info message', ['first hint', 'second hint']);
+
+        expect(logSpy).toHaveBeenCalledWith(
+            JSON.stringify({
+                level: 'INFO',
+                timestamp: FIXED_DATE.toISOString(),
+                message: 'Structured info message',
+                hints: ['first hint', 'second hint'],
+            })
+        );
+        expect(errorSpy).not.toHaveBeenCalled();
+
+        logSpy.mockClear();
+
+        const error = new Error('kaboom');
+        error.stack = ['Error: kaboom', '    at fake.ts:1:1'].join('\n');
+
+        logger.error('Structured error message', error);
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            JSON.stringify({
+                level: 'ERROR',
+                timestamp: FIXED_DATE.toISOString(),
+                message: 'Structured error message',
+                hints: ['Error: kaboom', 'at fake.ts:1:1'],
+            })
+        );
+        expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('retains coloured output when structured logs are disabled', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {
+            // noop
+        });
+
+        const logger = new Logger(LogLevel.INFO);
+
+        logger.info('classic message', 'hint text');
+
+        expect(logSpy).toHaveBeenCalled();
+        const [firstArg, secondArg] = logSpy.mock.calls[0];
+        expect(String(firstArg)).toContain('[INFO]');
+        expect(String(secondArg)).toBe(`[${FIXED_DATE.toISOString()}]`);
+    });
+});


### PR DESCRIPTION
## Summary
- add a `--structuredLogs` global CLI option and plumb it into import/validate commands
- teach the logger to emit JSON payloads when structured logging is enabled and cover it with unit tests
- document the new capability and mark Story 6.2 as complete in the backlog

## Testing
- npm run lint:eslint
- npm run lint:complexity
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d980c88b20832fb16763c5cc6bb079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a structured logs flag (--structuredLogs) to output machine-readable JSON logs for improved integration and observability.

- Documentation
  - Updated README to describe using --structuredLogs in Validation and Import Transactions workflows.
  - CLI help now documents --structuredLogs as a boolean option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->