### PR TITLE
feat: normalize MoneyMoney transaction ordering

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -92,18 +92,15 @@
 ### Story 2.1 – Normalize MoneyMoney transactions before conversion
 
 - **Complexity:** 3 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** `Importer.importTransactions` consumes the raw array
-  from `moneymoney.getTransactions` without sorting. Deduplication relies on
-  iteration order, which remains implicit.
-- **Next Steps:**
-  - Sort the transaction list by `valueDate` and a stable identifier (e.g.,
-    `id`) immediately after fetching.
-  - Extend `tests/Importer.test.ts` with an unsorted fixture that verifies
-    deterministic ordering and downstream balance calculations.
-  - Confirm no regressions in synthetic starting-balance logic, especially
-    around earliest import dates.
-- **Key Files:** `src/utils/Importer.ts`, `tests/Importer.test.ts`.
+- **Status:** ✅ Done
+- **Context:** MoneyMoney transactions are now sorted by `valueDate` and a
+  deterministic tie-breaker before any importer filtering or conversion so the
+  downstream balance calculations and deduplication logic operate on a stable
+  sequence.
+- **Evidence:** Implemented in `src/utils/Importer.ts` with regression coverage
+  in `tests/Importer.test.ts` to confirm ordering and starting-balance
+  behaviour.
+- **Future Work:** None at this time.
 
 ### Story 2.2 – Extend starting balance coverage for missing booked transactions
 


### PR DESCRIPTION
## Summary
- sort MoneyMoney transactions by value date and id before importer conversion so balance calculations stay deterministic
- cover the deterministic ordering behaviour with a new unsorted MoneyMoney fixture in the importer tests
- mark Story 2.1 as complete in the backlog with updated context and evidence

## Testing
- npm run lint:eslint
- npm run lint:complexity
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d980cfb030832f8c362a17ba199fa3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deterministic ordering of imported MoneyMoney transactions by date with a stable tie-breaker, yielding predictable lists and start-entry placement.
- Bug Fixes
  - Resolves inconsistent transaction ordering that could affect balance calculations and deduplication.
- Tests
  - Added regression coverage to verify deterministic sorting and correct start-entry handling.
- Documentation
  - Backlog updated to reflect completion of deterministic transaction ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->