### PR TITLE
fix: heal OpenAI model cache corruption automatically

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -148,17 +148,17 @@
 ### Story 3.1 – Heal corrupt payee cache entries automatically
 
 - **Complexity:** 3 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** `PayeeTransformer` returns `null` if
-  `openai-model-cache.json` cannot be parsed but leaves the corrupt file in
-  place and provides no remediation logging.
-- **Next Steps:**
-  - When JSON parsing fails, delete the cache file and emit a warning noting the
-    reset.
-  - Add filesystem-mocked coverage to `tests/PayeeTransformer.test.ts` to ensure
-    repeated runs recover gracefully.
-- **Key Files:** `src/utils/PayeeTransformer.ts`,
-  `tests/PayeeTransformer.test.ts`.
+- **Status:** ✅ Done
+- **Context:** `PayeeTransformer` now detects JSON parse failures when loading
+  `openai-model-cache.json`, logs a warning that the cache was reset, and removes
+  the corrupt file before refetching the model list so subsequent runs receive a
+  fresh cache.
+- **Evidence:** The regression coverage in `tests/PayeeTransformer.test.ts`
+  stubs a corrupted cache file, asserts the warning, verifies the healed cache
+  contents, and confirms a follow-up run uses the regenerated file without
+  additional API calls.
+- **Future Work:** Consider treating structurally invalid cache payloads (e.g.,
+  missing fields) as corrupt to provide the same auto-healing behaviour.
 
 ### Story 3.2 – Short-circuit on malformed OpenAI payloads
 


### PR DESCRIPTION
## Summary
- reset the on-disk OpenAI model cache when JSON parsing fails and warn operators
- add regression coverage that stubs a corrupt cache and verifies healing across runs
- mark Story 3.1 as complete in the backlog with supporting context

## Testing
- npm run lint:eslint
- npm run lint:complexity
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d980e7c9fc832fb0008833fdb20083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Automatically detects and heals a corrupted model cache by resetting it and refetching models. Emits a clear one-time warning, preserves behaviour when no cache exists, and improves stability during payee transformations.

- Tests
  - Added coverage validating corrupted cache auto-healing and subsequent reuse of the regenerated cache without additional warnings.

- Documentation
  - Updated backlog entry for Story 3.1 with current behaviour, evidence, and future work; removed outdated remediation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->