### PR TITLE
test: extend starting balance coverage

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -105,17 +105,12 @@
 ### Story 2.2 – Extend starting balance coverage for missing booked transactions
 
 - **Complexity:** 2 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** The importer emits warnings when an Actual account
-  lacks MoneyMoney transactions, but tests only cover presence/absence of
-  transactions—not scenarios where MoneyMoney omits booked entries.
-- **Next Steps:**
-  - Add fixtures where MoneyMoney omits booked transactions but balances still
-    imply a starting transaction.
-  - Assert warning text, synthetic transaction amount, and generated memo
-    (`Starting balance`) in `tests/Importer.test.ts`.
-  - Ensure the logger hints align with contributor guidance
-    (`Extend the date range...`).
+- **Status:** ✅ Done
+- **Context:** Coverage now exercises importer behaviour when MoneyMoney omits
+  booked transactions, ensuring unchecked entries still produce a starting
+  balance while disabled unchecked imports surface actionable warnings.
+- **Evidence:** `tests/Importer.test.ts` asserts the warning text, hint, and
+  synthetic `Starting balance` memo/amount for unchecked-transaction scenarios.
 - **Key Files:** `src/utils/Importer.ts`, `tests/Importer.test.ts`.
 
 ### Story 2.3 – Fail imports when account mapping resolution breaks

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -108,7 +108,8 @@
 - **Status:** ✅ Done
 - **Context:** Coverage now exercises importer behaviour when MoneyMoney omits
   booked transactions, ensuring unchecked entries still produce a starting
-  balance while disabled unchecked imports surface actionable warnings.
+  balance while disabled unchecked imports continue to emit the generic
+  missing-transactions hint to extend the date range or review ignore patterns.
 - **Evidence:** `tests/Importer.test.ts` asserts the warning text, hint, and
   synthetic `Starting balance` memo/amount for unchecked-transaction scenarios.
 - **Key Files:** `src/utils/Importer.ts`, `tests/Importer.test.ts`.


### PR DESCRIPTION
## Summary
- add importer unit tests covering missing booked transactions and unchecked-only scenarios
- document completion of story 2.2 in the backlog with supporting context and evidence

## Testing
- npm run lint:eslint
- npm run lint:complexity
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98f733620832f9501d6daeb185a21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Marked backlog Story 2.2 as Done; clarified handling when booked transactions are missing and how unchecked entries can produce a starting balance, with test evidence for starting-balance memo/amount.

- Tests
  - Added tests for import behaviour with unchecked transactions:
    - No import and specific warning when importing unchecked transactions is disabled.
    - Creation of a starting balance (amount, notes, imported payee, cleared) when enabled.
    - Variant covering behaviour with an empty initial state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->