### PR TITLE
feat: fail imports when account mappings cannot be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,10 @@ Account mapping connects MoneyMoney accounts to Actual Budget accounts:
 1. UUID (from browser URL)
 1. Account name
 
-If multiple accounts have the same name, the first match will be used. Invalid
-mappings or additional accounts are ignored.
+If multiple accounts have the same name, the first match will be used. When an
+import runs without account filters, any mapping that cannot be resolved will
+fail the run so you can fix the configuration instead of importing a partial
+set of accounts.
 
 ## Troubleshooting
 
@@ -332,7 +334,9 @@ mappings or additional accounts are ignored.
 1. **Import failures**: Check your server URLs, passwords, and sync IDs
 1. **Payee transformation not working**: Verify your OpenAI API key and model
    settings
-1. **Account mapping issues**: Ensure account names/IDs match exactly
+1. **Account mapping issues**: Ensure account names/IDs match exactly. The
+   importer fails fast when a configured mapping cannot be resolved during an
+   unconstrained import.
 
 ### Getting Help
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -20,7 +20,7 @@
 | Order | Epic | State | Notes |
 | --- | --- | --- | --- |
 | 1 | **Epic 4 – CLI usability and coverage** | ✅ Done | The CLI harness, option validation, and failure propagation stories shipped, so downstream work can assume end-to-end coverage already exists for anything that touches the command surface. |
-| 2 | **Epic 2 – Importer determinism and guard rails** | 🚧 In progress (Story 2.3) | CLI coverage is in place and Stories 2.1–2.2 shipped; finishing the mapping failure guards in Story 2.3 will give downstream refactors a predictable foundation. |
+| 2 | **Epic 2 – Importer determinism and guard rails** | ✅ Done | CLI coverage and mapping failure guards ship together, so imports now fail fast when configuration drifts instead of proceeding with partial coverage. |
 | 3 | **Epic 6 – Testing & reliability** | ✅ Done | Error-path fixtures, malformed export guards, and structured logging are complete, keeping the CLI observable and resilient under test. |
 | 4 | **Epic 8 – Code quality and maintainability** | 🚧 Not started | Break up brittle flows such as `Importer.importTransactions` and `ActualApi.runActualRequest` once determinism and test scaffolding exist, reducing complexity before pursuing roadmap features. |
 | 5 | **Epic 5 – Observability and developer experience** | ✅ Done | Smoke coverage, default logging, and contributor docs are live, giving follow-on epics the observability and workflow guard rails they depend on. |
@@ -116,19 +116,19 @@
 ### Story 2.3 – Fail imports when account mapping resolution breaks
 
 - **Complexity:** 5 pts
-- **Status:** ⬜ Not started
-- **Current Behaviour:** `AccountMap.loadFromConfig` logs and skips unresolved
-  mappings rather than failing fast, so `import` can proceed silently with
-  partial coverage.
-- **Next Steps:**
-  - Make `loadFromConfig` throw when either side of a configured mapping cannot
-    be resolved during an unconstrained import.
-  - Add CLI-level tests (`tests/commands`) to assert the surfaced error message
-    when mappings fail.
-  - Document the failure mode in the README/backlog so operators know to fix
-    configuration.
-- **Key Files:** `src/utils/AccountMap.ts`,
-  `tests/commands/import.command.test.ts` (new).
+- **Status:** ✅ Done
+- **Outcome:** `AccountMap.loadFromConfig` now fails fast when configured
+  MoneyMoney or Actual references cannot be resolved during an unconstrained
+  import, while filtered runs can still skip unrelated mappings without
+  aborting work.
+- **Evidence:** Unit coverage in `tests/AccountMap.test.ts` asserts the failure
+  messaging and filtered behaviour; CLI integration coverage in
+  `tests/commands/import.command.test.ts` verifies the surfaced error message
+  and shutdown flow.
+- **Key Files:** `src/utils/AccountMap.ts`, `tests/AccountMap.test.ts`,
+  `tests/commands/import.command.test.ts`, `README.md`.
+- **Future Work:** None; configuration drift now halts imports with actionable
+  guidance.
 
 ## Epic 3: Payee transformer resilience
 

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -165,7 +165,7 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
                     logger,
                     actualApi
                 );
-                await accountMap.loadFromConfig();
+                await accountMap.loadFromConfig({ accountRefs });
 
                 const importer = new Importer(
                     config,

--- a/src/utils/AccountMap.ts
+++ b/src/utils/AccountMap.ts
@@ -19,6 +19,10 @@ interface ActualAccount {
     closed: boolean;
 }
 
+interface LoadFromConfigOptions {
+    readonly accountRefs?: ReadonlyArray<string>;
+}
+
 export class AccountMap {
     constructor(
         private budgetConfig: ActualBudgetConfig,
@@ -118,12 +122,18 @@ export class AccountMap {
         return matchingAccounts[0];
     }
 
-    async loadFromConfig() {
+    async loadFromConfig(options: LoadFromConfigOptions = {}) {
         if (this.mapping) return;
 
         const accountMapping = this.budgetConfig.accountMapping;
         const parsedAccountMapping: Map<MonMonAccount, ActualAccount> =
             new Map();
+
+        const accountRefsFilter =
+            options.accountRefs && options.accountRefs.length > 0
+                ? new Set(options.accountRefs)
+                : null;
+        const unresolvedErrors: string[] = [];
 
         this.moneyMoneyAccounts = await getAccounts();
         this.logger.debug(
@@ -147,15 +157,37 @@ export class AccountMap {
 
             const actualAccount = this.getActualAccountByRef(actualRef);
 
+            const requiresResolution =
+                accountRefsFilter === null ||
+                accountRefsFilter.has(moneyMoneyRef);
+
+            if (!moneyMoneyAccount) {
+                const message = `MoneyMoney account reference '${moneyMoneyRef}' did not match any MoneyMoney accounts.`;
+
+                if (requiresResolution) {
+                    this.logger.error(message);
+                    unresolvedErrors.push(message);
+                } else {
+                    this.logger.debug(
+                        `Skipping account mapping for MoneyMoney reference '${moneyMoneyRef}' because it is not part of the import filter.`
+                    );
+                }
+            }
+
             if (!actualAccount) {
-                this.logger.debug(
-                    `No Actual account found for reference '${actualRef}'. Skipping...`
-                );
-                continue;
-            } else if (!moneyMoneyAccount) {
-                this.logger.debug(
-                    `No MoneyMoney account found for reference '${moneyMoneyRef}'. Skipping...`
-                );
+                const message = `Actual account reference '${actualRef}' did not match any Actual accounts.`;
+
+                if (requiresResolution) {
+                    this.logger.error(message);
+                    unresolvedErrors.push(message);
+                } else {
+                    this.logger.debug(
+                        `Skipping account mapping for Actual reference '${actualRef}' because it is not part of the import filter.`
+                    );
+                }
+            }
+
+            if (!moneyMoneyAccount || !actualAccount) {
                 continue;
             }
 
@@ -164,6 +196,15 @@ export class AccountMap {
             );
 
             parsedAccountMapping.set(moneyMoneyAccount, actualAccount);
+        }
+
+        if (unresolvedErrors.length > 0) {
+            const header = `Failed to resolve account mapping for budget '${this.budgetConfig.syncId}'.`;
+            const details =
+                unresolvedErrors.length === 1
+                    ? ` ${unresolvedErrors[0]}`
+                    : `\n - ${unresolvedErrors.join('\n - ')}`;
+            throw new Error(`${header}${details}`);
         }
 
         this.logger.info('Parsed account mapping', [

--- a/tests/AccountMap.test.ts
+++ b/tests/AccountMap.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AccountMap } from '../src/utils/AccountMap.js';
+import type ActualApi from '../src/utils/ActualApi.js';
+import type { ActualBudgetConfig } from '../src/utils/config.js';
+import type Logger from '../src/utils/Logger.js';
+
+const { getAccountsMock } = vi.hoisted(() => ({
+    getAccountsMock: vi.fn(),
+}));
+
+vi.mock('moneymoney', () => ({
+    getAccounts: getAccountsMock,
+}));
+
+const createLogger = () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    getLevel: vi.fn().mockReturnValue(0),
+});
+
+const createTestLogger = () =>
+    createLogger() as unknown as Logger & ReturnType<typeof createLogger>;
+
+describe('AccountMap', () => {
+    beforeEach(() => {
+        getAccountsMock.mockReset();
+    });
+
+    const createBudgetConfig = (
+        accountMapping: Record<string, string>
+    ): ActualBudgetConfig => ({
+        syncId: 'budget-test',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: '' },
+        accountMapping,
+    });
+
+    const createActualApi = (
+        accounts: Array<{
+            id: string;
+            name: string;
+            type:
+                | 'checking'
+                | 'savings'
+                | 'credit'
+                | 'investment'
+                | 'mortgage'
+                | 'debt'
+                | 'other';
+            offbudget: boolean;
+            closed: boolean;
+        }>
+    ): ActualApi =>
+        ({
+            getAccounts: vi.fn().mockResolvedValue(accounts),
+        }) as unknown as ActualApi;
+
+    it('throws when a MoneyMoney account reference is unresolved without filters', async () => {
+        const budgetConfig = createBudgetConfig({
+            'missing-account': 'actual-existing',
+        });
+        getAccountsMock.mockResolvedValue([
+            {
+                uuid: 'another-account',
+                accountNumber: 'DE02',
+                name: 'Other Account',
+            },
+        ]);
+        const actualApi = createActualApi([
+            {
+                id: 'actual-existing',
+                name: 'Existing Actual',
+                type: 'checking',
+                offbudget: false,
+                closed: false,
+            },
+        ]);
+        const logger = createTestLogger();
+        const accountMap = new AccountMap(budgetConfig, logger, actualApi);
+
+        await expect(accountMap.loadFromConfig()).rejects.toThrow(
+            "Failed to resolve account mapping for budget 'budget-test'. MoneyMoney account reference 'missing-account' did not match any MoneyMoney accounts."
+        );
+        expect(logger.error).toHaveBeenCalledWith(
+            "MoneyMoney account reference 'missing-account' did not match any MoneyMoney accounts."
+        );
+    });
+
+    it('throws when an Actual account reference is unresolved without filters', async () => {
+        const budgetConfig = createBudgetConfig({
+            'known-account': 'missing-actual',
+        });
+        getAccountsMock.mockResolvedValue([
+            {
+                uuid: 'known-account',
+                accountNumber: 'DE03',
+                name: 'Known Account',
+            },
+        ]);
+        const actualApi = createActualApi([]);
+        const logger = createTestLogger();
+        const accountMap = new AccountMap(budgetConfig, logger, actualApi);
+
+        await expect(accountMap.loadFromConfig()).rejects.toThrow(
+            "Failed to resolve account mapping for budget 'budget-test'. Actual account reference 'missing-actual' did not match any Actual accounts."
+        );
+        expect(logger.error).toHaveBeenCalledWith(
+            "Actual account reference 'missing-actual' did not match any Actual accounts."
+        );
+    });
+
+    it('skips unresolved mappings outside the filtered account list', async () => {
+        const budgetConfig = createBudgetConfig({
+            'primary-account': 'actual-primary',
+            'secondary-account': 'actual-secondary',
+        });
+        const moneyMoneyPrimary = {
+            uuid: 'primary-account',
+            accountNumber: 'DE04',
+            name: 'Primary Account',
+        };
+        const moneyMoneySecondary = {
+            uuid: 'secondary-account',
+            accountNumber: 'DE05',
+            name: 'Secondary Account',
+        };
+        getAccountsMock.mockResolvedValue([
+            moneyMoneyPrimary,
+            moneyMoneySecondary,
+        ]);
+        const actualApi = createActualApi([
+            {
+                id: 'actual-primary',
+                name: 'Primary Actual',
+                type: 'checking',
+                offbudget: false,
+                closed: false,
+            },
+        ]);
+        const logger = createTestLogger();
+        const accountMap = new AccountMap(budgetConfig, logger, actualApi);
+
+        await accountMap.loadFromConfig({ accountRefs: ['primary-account'] });
+
+        const mapping = accountMap.getMap();
+        expect(mapping.size).toBe(1);
+        const [entry] = Array.from(mapping.entries());
+        expect(entry).toBeDefined();
+        if (!entry) {
+            throw new Error('Mapping entry missing');
+        }
+        const [monMonAccount, actualAccount] = entry;
+        expect(monMonAccount).toBe(moneyMoneyPrimary);
+        expect(actualAccount.id).toBe('actual-primary');
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+});

--- a/tests/commands/import.command.test.ts
+++ b/tests/commands/import.command.test.ts
@@ -358,6 +358,82 @@ describe('import command (CLI)', () => {
     );
 
     it(
+        'fails with an actionable error when account mapping cannot be resolved',
+        async () => {
+            const failureMessage =
+                "Failed to resolve account mapping for budget 'budget-broken'. MoneyMoney account reference 'missing-account' did not match any MoneyMoney accounts.";
+            const config = {
+                ...createBaseConfig(),
+                actualServers: [
+                    {
+                        serverUrl: 'https://server-broken.example.com',
+                        serverPassword: 'secret-broken',
+                        requestTimeoutMs: 45000,
+                        budgets: [
+                            {
+                                syncId: 'budget-broken',
+                                e2eEncryption: { enabled: false, password: '' },
+                                accountMapping: {
+                                    'missing-account': 'actual-present',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const { contextDir, eventsFile } = await createContextDir({
+                config,
+                accountMap: {
+                    failures: {
+                        'budget-broken': failureMessage,
+                    },
+                },
+            });
+
+            const result = await runCli(['import'], {
+                env: {
+                    CLI_TEST_CONTEXT_DIR: contextDir,
+                    CLI_TEST_EVENTS_FILE: eventsFile,
+                    NODE_NO_WARNINGS: '1',
+                },
+                nodeOptions: loaderNodeOptions,
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(failureMessage);
+
+            const events = await readEvents(eventsFile);
+            const accountMapEvents = events.filter(
+                (event) => event.type === 'AccountMap#loadFromConfig'
+            );
+            expect(accountMapEvents).toEqual([
+                {
+                    type: 'AccountMap#loadFromConfig',
+                    budgetSyncId: 'budget-broken',
+                    accountRefs: null,
+                },
+            ]);
+
+            const importerEvents = events.filter(
+                (event) => event.type === 'Importer#importTransactions'
+            );
+            expect(importerEvents).toHaveLength(0);
+
+            const shutdownEvents = events.filter(
+                (event) => event.type === 'ActualApi#shutdown'
+            );
+            expect(shutdownEvents).toEqual([
+                {
+                    type: 'ActualApi#shutdown',
+                    serverUrl: 'https://server-broken.example.com',
+                },
+            ]);
+        },
+        CLI_TIMEOUT_MS
+    );
+
+    it(
         'fails with a helpful error when account filters are unknown',
         async () => {
             const config = {

--- a/tests/helpers/cli-mock-loader.mjs
+++ b/tests/helpers/cli-mock-loader.mjs
@@ -221,10 +221,13 @@ export class AccountMap {
         });
     }
 
-    async loadFromConfig() {
+    async loadFromConfig(options = {}) {
         recordEvent({
             type: 'AccountMap#loadFromConfig',
             budgetSyncId: this.budgetConfig.syncId,
+            accountRefs: Array.isArray(options.accountRefs)
+                ? [...options.accountRefs]
+                : options.accountRefs ?? null,
         });
         const context = readContext();
         const failure = context.accountMap?.failures?.[this.budgetConfig.syncId];


### PR DESCRIPTION
## Summary
- fail AccountMap.loadFromConfig when mappings cannot be resolved during unconstrained imports while still supporting filtered runs
- surface the mapping failure at the CLI, extend the mock loader, and document the new guard rails
- add unit coverage for AccountMap and CLI integration coverage for the error path

## Testing
- npm run lint:eslint
- npm run lint:complexity
- npm run lint:prettier
- npm run typecheck
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9a8981ac4832f8522d7267d4b15aa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Importer supports filtering by specific account references to load only relevant mappings.
  - Unconstrained imports now fail fast if any configured account mapping cannot be resolved, preventing partial imports and prompting configuration fixes.

- Documentation
  - Updated README to reflect revised account-mapping behaviour and troubleshooting guidance for fail-fast imports without account filters.

- Tests
  - Added unit and CLI tests covering fail-fast behaviour, filtered imports, and actionable error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->