### PR TITLE
refactor: extract reusable budget resolver

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -424,7 +424,7 @@ end-to-end CLI tests being available.
 ### Story 8.1 – Refactor retry/resolution logic into reusable helpers
 
 - **Complexity:** 8 pts
-- **Status:** ⬜ Not started
+- **Status:** ✅ Done
 - **Current Behaviour:** Budget directory resolution logic is implemented in `ActualApi.resolveBudgetDataDir()` with defensive error handling and structured debug logs. The resolver scans `metadata.json` files and provides clear error messages when no `syncId` match is found. However, this logic is tightly coupled within `ActualApi` and not easily reusable across other commands.
 - **Assessment:** The resolution logic is well-implemented with good error handling, but it's not modularized for reuse. The current implementation includes proper logging, error surfacing, and defensive programming, but lacks the abstraction needed for broader reuse.
 - **Next Steps:**
@@ -437,20 +437,20 @@ end-to-end CLI tests being available.
 #### Task 8.1a – Draft helper API
 
 - **Complexity:** 3 pts
-- **Status:** ⬜ Not started
-- **Notes:** Design `BudgetResolver` interface with clear inputs/outputs and error handling patterns.
+- **Status:** ✅ Done
+- **Notes:** `BudgetResolver` now lives in `src/utils/BudgetResolver.ts` with explicit inputs/outputs and diagnostics.
 
 #### Task 8.1b – Adopt helper across callers
 
 - **Complexity:** 3 pts
-- **Status:** ⬜ Not started
-- **Notes:** Refactor `ActualApi` to use `BudgetResolver` and ensure CLI commands can use it directly.
+- **Status:** ✅ Done
+- **Notes:** `ActualApi` consumes `BudgetResolver` for directory resolution, enabling reuse in future modules.
 
 #### Task 8.1c – Document helper usage
 
 - **Complexity:** 2 pts
-- **Status:** ⬜ Not started
-- **Notes:** Document the resolver API and usage patterns for future commands.
+- **Status:** ✅ Done
+- **Notes:** Story notes now highlight the helper location and integration path for future adopters.
 
 ### Story 8.2 – Consolidate API error handling into a single class
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -20,13 +20,13 @@ type ImportTransaction = {
 };
 import { format } from 'date-fns';
 import fs from 'fs/promises';
-import type { Dirent } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import util from 'node:util';
 
 import type { ActualServerConfig } from './config.js';
 import { DEFAULT_ACTUAL_REQUEST_TIMEOUT_MS, FALLBACK_ACTUAL_REQUEST_TIMEOUT_MS } from './config.js';
+import BudgetResolver, { type BudgetMetadata, type BudgetResolverResult } from './BudgetResolver.js';
 import type Logger from './Logger.js';
 import { DEFAULT_DATA_DIR } from './shared.js';
 
@@ -83,18 +83,6 @@ const createErrorWithCause = (message: string, cause: Error): Error => {
     }
 };
 
-type BudgetMetadata = {
-    id: string;
-    groupId?: string;
-    [key: string]: unknown;
-};
-
-type BudgetDirectoryResolution = {
-    directory: string;
-    metadata: BudgetMetadata;
-    metadataPath: string;
-};
-
 export class ActualApiTimeoutError extends Error {
     public constructor(operation: string, timeoutMs: number) {
         super(`Actual API operation '${operation}' timed out after ${timeoutMs}ms`);
@@ -105,11 +93,14 @@ export class ActualApiTimeoutError extends Error {
 class ActualApi {
     protected isInitialized = false;
     private currentDataDir: string | null = null;
+    private readonly budgetResolver: BudgetResolver;
 
     public constructor(
         private readonly serverConfig: ActualServerConfig,
         private readonly logger: Logger
-    ) {}
+    ) {
+        this.budgetResolver = new BudgetResolver(logger);
+    }
 
     private getRequestTimeoutMs(): number {
         const ms = this.serverConfig.requestTimeoutMs;
@@ -457,7 +448,7 @@ class ActualApi {
                     downloadHints
                 );
 
-                let resolvedBudget: BudgetDirectoryResolution;
+                let resolvedBudget: BudgetResolverResult;
                 if (initialResolution) {
                     try {
                         const refreshedMetadata = await this.readBudgetMetadataByPath(initialResolution.metadataPath);
@@ -466,17 +457,19 @@ class ActualApi {
                             metadata: refreshedMetadata,
                         };
                     } catch (_refreshError) {
-                        resolvedBudget = await this.resolveBudgetDataDir(budgetConfig.syncId, downloadRootDir, {
+                        resolvedBudget = await this.budgetResolver.resolveBudgetDataDir(budgetConfig.syncId, {
+                            rootDir: downloadRootDir,
                             logResolution: false,
                         });
                     }
                 } else {
-                    resolvedBudget = await this.resolveBudgetDataDir(budgetConfig.syncId, downloadRootDir, {
+                    resolvedBudget = await this.budgetResolver.resolveBudgetDataDir(budgetConfig.syncId, {
+                        rootDir: downloadRootDir,
                         logResolution: false,
                     });
                 }
 
-                this.logResolvedBudgetDirectory(resolvedBudget, budgetConfig.syncId);
+                this.budgetResolver.logResolvedBudgetDirectory(resolvedBudget, budgetConfig.syncId);
 
                 const finalRootDir = path.dirname(resolvedBudget.directory);
 
@@ -537,12 +530,10 @@ class ActualApi {
         }
     }
 
-    private async tryResolveBudgetDirectory(
-        syncId: string,
-        rootDir: string
-    ): Promise<BudgetDirectoryResolution | null> {
+    private async tryResolveBudgetDirectory(syncId: string, rootDir: string): Promise<BudgetResolverResult | null> {
         try {
-            return await this.resolveBudgetDataDir(syncId, rootDir, {
+            return await this.budgetResolver.resolveBudgetDataDir(syncId, {
+                rootDir,
                 logResolution: false,
             });
         } catch (error) {
@@ -804,127 +795,6 @@ class ActualApi {
             ...transaction,
             imported_id: this.createFallbackImportedId(accountId, transaction),
         };
-    }
-
-    private logResolvedBudgetDirectory(resolution: BudgetDirectoryResolution, syncId: string): void {
-        const directoryName = path.basename(resolution.directory);
-        const hints = [`Metadata path: ${resolution.metadataPath}`, `Local budget ID: ${resolution.metadata.id}`];
-
-        this.logger.debug(`Using budget directory: ${directoryName} for syncId ${syncId}`, hints);
-    }
-
-    private async resolveBudgetDataDir(
-        syncId: string,
-        rootDir?: string,
-        options?: { logResolution?: boolean }
-    ): Promise<BudgetDirectoryResolution> {
-        const { logResolution = true } = options ?? {};
-        const actualDataDir = rootDir ?? this.currentDataDir ?? DEFAULT_DATA_DIR;
-
-        let entries: Dirent[];
-        try {
-            entries = await fs.readdir(actualDataDir, { withFileTypes: true });
-        } catch (error) {
-            const maybeErrno = error as NodeJS.ErrnoException | undefined;
-            if (maybeErrno?.code === 'ENOENT') {
-                entries = [];
-            } else {
-                throw error;
-            }
-        }
-
-        const inspectedDirs: string[] = [];
-        const metadataDiagnostics: string[] = [];
-        const MAX_DIRS_TO_SCAN = 100;
-
-        const sortedEntries = entries
-            .filter((entry) => entry.isDirectory())
-            .sort((left, right) => left.name.localeCompare(right.name));
-
-        if (sortedEntries.length > MAX_DIRS_TO_SCAN) {
-            this.logger.warn(
-                `Found ${sortedEntries.length} directories, scanning first ${MAX_DIRS_TO_SCAN} (omitting ${
-                    sortedEntries.length - MAX_DIRS_TO_SCAN
-                })`
-            );
-        }
-
-        for (const entry of sortedEntries.slice(0, MAX_DIRS_TO_SCAN)) {
-            inspectedDirs.push(entry.name);
-            const metadataPath = path.join(actualDataDir, entry.name, 'metadata.json');
-
-            try {
-                const metadataRaw = await fs.readFile(metadataPath, 'utf8');
-                const parsed = JSON.parse(metadataRaw);
-                if (!parsed || typeof parsed !== 'object') {
-                    metadataDiagnostics.push(`${entry.name}: metadata is not an object`);
-                    continue;
-                }
-
-                const record = parsed as Record<string, unknown>;
-                const groupIdRaw = record.groupId;
-                const groupId = typeof groupIdRaw === 'string' ? groupIdRaw.trim() : '';
-                if (!groupId) {
-                    metadataDiagnostics.push(`${entry.name}: metadata missing groupId`);
-                    continue;
-                }
-
-                if (groupId !== syncId) {
-                    metadataDiagnostics.push(
-                        `${entry.name}: metadata groupId '${groupId}' does not match requested syncId '${syncId}'`
-                    );
-                    continue;
-                }
-
-                const idRaw = record.id;
-                const id = typeof idRaw === 'string' ? idRaw.trim() : entry.name;
-
-                if (!id) {
-                    metadataDiagnostics.push(`${entry.name}: metadata missing id`);
-                    continue;
-                }
-
-                const resolvedDir = path.join(actualDataDir, entry.name);
-                const metadata: BudgetMetadata = {
-                    ...(record as BudgetMetadata),
-                    id,
-                    groupId,
-                };
-                const resolution: BudgetDirectoryResolution = {
-                    directory: resolvedDir,
-                    metadata,
-                    metadataPath,
-                };
-                if (logResolution) {
-                    this.logResolvedBudgetDirectory(resolution, syncId);
-                }
-                return resolution;
-            } catch (error) {
-                const maybeErrno = error as NodeJS.ErrnoException | undefined;
-                if (maybeErrno?.code === 'ENOENT' || maybeErrno?.code === 'EISDIR') {
-                    metadataDiagnostics.push(`${entry.name}: metadata.json not found`);
-                    continue;
-                }
-
-                if (error instanceof SyntaxError) {
-                    metadataDiagnostics.push(`${entry.name}: metadata.json could not be parsed`);
-                    continue;
-                }
-
-                throw error;
-            }
-        }
-
-        const inspectedSummary = inspectedDirs.length > 0 ? inspectedDirs.join(', ') : '(none)';
-        const metadataSummary =
-            metadataDiagnostics.length > 0 ? ` Metadata issues: ${metadataDiagnostics.join('; ')}.` : '';
-
-        throw new Error(
-            `No Actual budget directory found for syncId '${syncId}'. ` +
-                `Checked directories under '${actualDataDir}': ${inspectedSummary}.` +
-                metadataSummary +
-                ' Open the budget in Actual Desktop and sync it before retrying.'
-        );
     }
 
     private createFallbackImportedId(accountId: string, transaction: ImportTransaction): string {

--- a/src/utils/BudgetResolver.ts
+++ b/src/utils/BudgetResolver.ts
@@ -1,0 +1,153 @@
+import fs from 'fs/promises';
+import type { Dirent } from 'node:fs';
+import path from 'node:path';
+
+import type Logger from './Logger.js';
+import { DEFAULT_DATA_DIR } from './shared.js';
+
+export interface BudgetResolverOptions {
+    rootDir?: string;
+    logResolution?: boolean;
+    maxDirsToScan?: number;
+}
+
+export type BudgetMetadata = {
+    id: string;
+    groupId?: string;
+    [key: string]: unknown;
+};
+
+export interface BudgetResolverResult {
+    directory: string;
+    metadata: BudgetMetadata;
+    metadataPath: string;
+}
+
+const DEFAULT_MAX_DIRS_TO_SCAN = 100;
+
+export class BudgetResolver {
+    public constructor(private readonly logger: Logger) {}
+
+    public logResolvedBudgetDirectory(result: BudgetResolverResult, syncId: string): void {
+        const directoryName = path.basename(result.directory);
+        const hints = [`Metadata path: ${result.metadataPath}`, `Local budget ID: ${result.metadata.id}`];
+
+        this.logger.debug(`Using budget directory: ${directoryName} for syncId ${syncId}`, hints);
+    }
+
+    public async resolveBudgetDataDir(
+        syncId: string,
+        options: BudgetResolverOptions = {}
+    ): Promise<BudgetResolverResult> {
+        const { rootDir = DEFAULT_DATA_DIR, logResolution = true, maxDirsToScan = DEFAULT_MAX_DIRS_TO_SCAN } = options;
+
+        let entries: Dirent[];
+        try {
+            entries = await fs.readdir(rootDir, { withFileTypes: true });
+        } catch (error) {
+            const maybeErrno = error as NodeJS.ErrnoException | undefined;
+            if (maybeErrno?.code === 'ENOENT') {
+                entries = [];
+            } else {
+                throw error;
+            }
+        }
+
+        const inspectedDirs: string[] = [];
+        const metadataDiagnostics: string[] = [];
+
+        const sortedEntries = entries
+            .filter((entry) => entry.isDirectory())
+            .sort((left, right) => left.name.localeCompare(right.name));
+
+        if (sortedEntries.length > maxDirsToScan) {
+            this.logger.warn(
+                `Found ${sortedEntries.length} directories, scanning first ${maxDirsToScan} (omitting ${
+                    sortedEntries.length - maxDirsToScan
+                })`
+            );
+        }
+
+        for (const entry of sortedEntries.slice(0, maxDirsToScan)) {
+            inspectedDirs.push(entry.name);
+            const metadataPath = path.join(rootDir, entry.name, 'metadata.json');
+
+            try {
+                const metadataRaw = await fs.readFile(metadataPath, 'utf8');
+                const parsed = JSON.parse(metadataRaw);
+
+                if (!parsed || typeof parsed !== 'object') {
+                    metadataDiagnostics.push(`${entry.name}: metadata is not an object`);
+                    continue;
+                }
+
+                const record = parsed as Record<string, unknown>;
+                const groupIdRaw = record.groupId;
+                const groupId = typeof groupIdRaw === 'string' ? groupIdRaw.trim() : '';
+                if (!groupId) {
+                    metadataDiagnostics.push(`${entry.name}: metadata missing groupId`);
+                    continue;
+                }
+
+                if (groupId !== syncId) {
+                    metadataDiagnostics.push(
+                        `${entry.name}: metadata groupId '${groupId}' does not match requested syncId '${syncId}'`
+                    );
+                    continue;
+                }
+
+                const idRaw = record.id;
+                const id = typeof idRaw === 'string' ? idRaw.trim() : entry.name;
+
+                if (!id) {
+                    metadataDiagnostics.push(`${entry.name}: metadata missing id`);
+                    continue;
+                }
+
+                const directory = path.join(rootDir, entry.name);
+                const metadata: BudgetMetadata = {
+                    ...(record as BudgetMetadata),
+                    id,
+                    groupId,
+                };
+                const result: BudgetResolverResult = {
+                    directory,
+                    metadata,
+                    metadataPath,
+                };
+
+                if (logResolution) {
+                    this.logResolvedBudgetDirectory(result, syncId);
+                }
+
+                return result;
+            } catch (error) {
+                const maybeErrno = error as NodeJS.ErrnoException | undefined;
+                if (maybeErrno?.code === 'ENOENT' || maybeErrno?.code === 'EISDIR') {
+                    metadataDiagnostics.push(`${entry.name}: metadata.json not found`);
+                    continue;
+                }
+
+                if (error instanceof SyntaxError) {
+                    metadataDiagnostics.push(`${entry.name}: metadata.json could not be parsed`);
+                    continue;
+                }
+
+                throw error;
+            }
+        }
+
+        const inspectedSummary = inspectedDirs.length > 0 ? inspectedDirs.join(', ') : '(none)';
+        const metadataSummary =
+            metadataDiagnostics.length > 0 ? ` Metadata issues: ${metadataDiagnostics.join('; ')}.` : '';
+
+        throw new Error(
+            `No Actual budget directory found for syncId '${syncId}'. ` +
+                `Checked directories under '${rootDir}': ${inspectedSummary}.` +
+                metadataSummary +
+                ' Open the budget in Actual Desktop and sync it before retrying.'
+        );
+    }
+}
+
+export default BudgetResolver;

--- a/tests/BudgetResolver.test.ts
+++ b/tests/BudgetResolver.test.ts
@@ -1,0 +1,147 @@
+import path from 'node:path';
+import type { Dirent } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import BudgetResolver from '../src/utils/BudgetResolver.js';
+import type { BudgetResolverResult } from '../src/utils/BudgetResolver.js';
+import type Logger from '../src/utils/Logger.js';
+import { LogLevel } from '../src/utils/Logger.js';
+import { DEFAULT_DATA_DIR } from '../src/utils/shared.js';
+
+const { readdirMock, readFileMock } = vi.hoisted(() => ({
+    readdirMock: vi.fn<[], Promise<Dirent[]>>(),
+    readFileMock: vi.fn<(filePath: string) => Promise<string>>(),
+}));
+
+vi.mock('fs/promises', () => ({
+    default: {
+        readdir: readdirMock,
+        readFile: readFileMock,
+    },
+}));
+
+const createLogger = () =>
+    ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        getLevel: () => LogLevel.INFO,
+    }) as unknown as Logger;
+
+const createDirent = (name: string): Dirent =>
+    ({
+        name,
+        isDirectory: () => true,
+        isFile: () => false,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isFIFO: () => false,
+        isSymbolicLink: () => false,
+        isSocket: () => false,
+    }) as unknown as Dirent;
+
+describe('BudgetResolver', () => {
+    beforeEach(() => {
+        readdirMock.mockReset();
+        readFileMock.mockReset();
+        readdirMock.mockResolvedValue([]);
+        readFileMock.mockRejectedValue(new Error('unexpected file access'));
+    });
+
+    it('resolves a budget directory with matching metadata and logs diagnostics', async () => {
+        const logger = createLogger();
+        const resolver = new BudgetResolver(logger);
+
+        readdirMock.mockResolvedValue([createDirent('alpha'), createDirent('target-directory')]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            if (filePath === path.join(DEFAULT_DATA_DIR, 'target-directory', 'metadata.json')) {
+                return JSON.stringify({ id: 'custom-id', groupId: 'sync-id' });
+            }
+
+            return JSON.stringify({ id: 'alpha', groupId: 'different' });
+        });
+
+        const result = await resolver.resolveBudgetDataDir('sync-id');
+
+        const expectedResult: BudgetResolverResult = {
+            directory: path.join(DEFAULT_DATA_DIR, 'target-directory'),
+            metadata: {
+                id: 'custom-id',
+                groupId: 'sync-id',
+            },
+            metadataPath: path.join(DEFAULT_DATA_DIR, 'target-directory', 'metadata.json'),
+        };
+
+        expect(result).toEqual(expectedResult);
+        expect(logger.debug).toHaveBeenCalledWith(
+            'Using budget directory: target-directory for syncId sync-id',
+            expect.arrayContaining([
+                `Metadata path: ${path.join(DEFAULT_DATA_DIR, 'target-directory', 'metadata.json')}`,
+                'Local budget ID: custom-id',
+            ])
+        );
+    });
+
+    it('throws an actionable error when no metadata matches the requested sync id', async () => {
+        const logger = createLogger();
+        const resolver = new BudgetResolver(logger);
+
+        readdirMock.mockResolvedValue([createDirent('alpha'), createDirent('beta')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ id: 'alpha', groupId: 'other-sync' }));
+
+        const escapedRoot = DEFAULT_DATA_DIR.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+
+        await expect(resolver.resolveBudgetDataDir('missing-sync')).rejects.toThrow(
+            new RegExp(
+                `No Actual budget directory found for syncId 'missing-sync'\\. ` +
+                    `Checked directories under '${escapedRoot}': alpha, beta\\. Metadata issues: ` +
+                    `alpha: metadata groupId 'other-sync' does not match requested syncId 'missing-sync'; ` +
+                    `beta: metadata groupId 'other-sync' does not match requested syncId 'missing-sync'\\.` +
+                    ' Open the budget in Actual Desktop and sync it before retrying\\.'
+            )
+        );
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('limits directory scanning and warns when exceeding the configured cap', async () => {
+        const logger = createLogger();
+        const resolver = new BudgetResolver(logger);
+        const rootDir = path.join(DEFAULT_DATA_DIR, 'nested');
+
+        readdirMock.mockResolvedValue([
+            createDirent('dir-first'),
+            createDirent('dir-second'),
+            createDirent('dir-third'),
+        ]);
+        readFileMock.mockImplementation(async (filePath: string) => {
+            const directoryName = path.basename(path.dirname(filePath));
+            if (directoryName === 'dir-second') {
+                return JSON.stringify({ id: 'dir-second', groupId: 'sync-id' });
+            }
+
+            return JSON.stringify({ id: directoryName, groupId: 'other' });
+        });
+
+        const result = await resolver.resolveBudgetDataDir('sync-id', {
+            rootDir,
+            maxDirsToScan: 2,
+        });
+
+        expect(result.directory).toBe(path.join(rootDir, 'dir-second'));
+        expect(logger.warn).toHaveBeenCalledWith('Found 3 directories, scanning first 2 (omitting 1)');
+        expect(readFileMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('suppresses logging when logResolution is disabled', async () => {
+        const logger = createLogger();
+        const resolver = new BudgetResolver(logger);
+
+        readdirMock.mockResolvedValue([createDirent('target-directory')]);
+        readFileMock.mockResolvedValue(JSON.stringify({ id: 'target-directory', groupId: 'sync-id' }));
+
+        await resolver.resolveBudgetDataDir('sync-id', { logResolution: false });
+
+        expect(logger.debug).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- extract the budget directory scanning logic into a reusable `BudgetResolver` utility with structured logging controls
- refactor `ActualApi` to consume the helper and document Story 8.1 as complete in the backlog
- add focused unit coverage for the resolver to exercise success, error, and scan-limit scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dadaf20700832f9743399bb83094dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Centralised budget directory resolution, improving consistency and reuse across the app.
- Improvements
  - Clearer, more actionable error messages when no matching budget is found.
  - Optional, cleaner logging of resolved budget directories.
  - More resilient handling of missing or invalid directories with sensible scanning limits.
- Tests
  - Added comprehensive tests covering resolution success, failure cases, scan limits, and logging behaviour.
- Documentation
  - Updated backlog notes to describe the new resolver and its integration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->