### PR TITLE
fix: suppress noisy actual sdk console logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This fork includes significant enhancements over the upstream version:
   better error handling
 - **📊 Better Logging**: Structured logging with proper error reporting and debug
   information
+- **🔇 Smart Console Filtering**: Intelligent suppression of noisy Actual SDK output
+  with categorized debug logging
 - **🔄 Robust Imports**: Enhanced transaction deduplication and retry mechanisms
 - **⚙️ Advanced Configuration**: Extended TOML configuration with timeout and
   filtering options
@@ -277,6 +279,51 @@ You can limit the scope of an import with additional flags:
 - `--logLevel <0-3>` – control CLI verbosity (defaults to `2`, INFO).
 - `--structuredLogs` – emit JSON-formatted logs instead of coloured text.
 - `--config <path>` – load a configuration file from a custom path.
+
+### Console Output Filtering
+
+The CLI automatically filters noisy Actual SDK console output to provide a cleaner user experience. By default, common SDK messages like "Got messages from server", "Syncing since", and "Performing transaction reconciliation" are suppressed unless DEBUG logging is enabled.
+
+#### How Console Filtering Works
+
+- **Automatic Suppression**: Noisy Actual SDK output is automatically detected and suppressed
+- **Categorized Debug Logging**: When `--logLevel 3` (DEBUG) is enabled, suppressed messages are logged with categories:
+
+  - `[NETWORK:SYNC]` - Network synchronization messages
+  - `[DATA:BUDGET]` - Budget loading and saving operations
+  - `[DATA:RECONCILIATION]` - Transaction reconciliation processes
+  - `[DATA:MIGRATION]` - Database migration operations
+  - `[DATA:DEBUG]` - Debug data with structured JSON formatting
+
+#### Debug Data Processing
+
+When the Actual SDK emits "Debug data for the operations:" messages, the CLI:
+
+- Converts complex objects to properly formatted JSON
+- Handles circular references gracefully with fallback serialization
+- Adds metadata including timestamps and source information
+- Preserves all debug information in structured format
+
+#### Performance Optimization
+
+The console filtering system includes performance optimizations:
+
+- **Pattern Caching**: Repeated console output patterns are cached for faster processing
+- **Memory Management**: Cache size is limited to prevent memory leaks
+- **Efficient Regex Matching**: Optimized pattern matching for common SDK output
+
+#### Examples
+
+```bash
+# See all console output including filtered messages
+actual-monmon import --logLevel 3
+
+# Use structured JSON logs for log aggregation
+actual-monmon import --logLevel 3 --structuredLogs
+
+# Normal operation (filtered output)
+actual-monmon import
+```
 
 ### Command Options
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -378,6 +378,20 @@ end-to-end CLI tests being available.
 - **Key Files:** `src/utils/Logger.ts`, `src/index.ts`,
   `tests/utils/Logger.test.ts`, `tests/commands/cli-options.command.test.ts`.
 
+### Story 5.3 – Enhanced Console Output Filtering
+
+- **Complexity:** 5 pts
+- **Status:** ✅ Done
+- **Outcome:** Console filtering system now provides intelligent suppression of noisy Actual SDK output with categorized debug logging, performance optimizations, and comprehensive test coverage.
+- **Evidence:**
+  - `src/utils/ActualApi.ts` includes enhanced pattern matching with regex support, categorization, and performance caching
+  - Console interceptor supports granular log level control with category filtering
+  - Debug data processing handles complex objects with proper JSON serialization and circular reference handling
+  - Performance optimizations include pattern caching and memory management
+  - `tests/ActualApi.test.ts` includes comprehensive test coverage for edge cases, categorization, and performance scenarios
+- **Next Steps:** Monitor for additional SDK output patterns that may need filtering as the Actual SDK evolves.
+- **Key Files:** `src/utils/ActualApi.ts`, `tests/ActualApi.test.ts`, `README.md`.
+
 ## Epic 7: CLI UX
 
 - **Epic Assessment:** 🚧 Not started. User feedback still cites confusing

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -140,7 +140,7 @@ const evaluateActualConsoleOutput = (args: unknown[]): ConsoleNoiseDecision => {
     }
 
     // Handle edge cases for malformed console output
-    if (args.some((arg) => arg === null && typeof arg !== 'object')) {
+    if (args.some((arg) => arg === null || arg === undefined)) {
         return { action: 'passthrough' };
     }
 


### PR DESCRIPTION
## Summary
- suppress repetitive Actual SDK console chatter unless the logger is in DEBUG mode
- redirect "Debug data" payloads into structured debug hints with JSON formatting instead of `[object Object]`
- route the console monkey-patch through the project logger so filtered messages respect the configured verbosity

## Testing
- npm run lint:eslint *(warnings only, existing issues)*
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68db67ffda88832fbc1765ae8b6d0ab1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced Console Output Filtering to suppress noisy SDK messages and categorise console output by type and level.
  - Optional caching to improve performance of filtering.

- Bug Fixes
  - Graceful handling of malformed, empty or complex console output.
  - More robust warnings, timeout handling and lifecycle restoration of console behaviour.

- Documentation
  - Detailed guidance and examples added to Enhanced Features and Import Transactions.

- Tests
  - Expanded tests for filtering behaviour, log‑level control and complex debug data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->