### PR TITLE
docs: update Node.js version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The application will be accessible as a CLI tool with the name `actual-monmon`.
 
 ## Dependencies
 
-- Node.js **v20.9.0 or newer** (see `package.json` `engines` field)
+- Node.js **v24.0.0 or newer** (see `package.json` `engines` field)
 - A licensed copy of MoneyMoney on macOS to access the transaction database
 
 **Note on zod version**: This project must remain on zod v3 due to a peer
@@ -63,7 +63,7 @@ v4 once openai ships a compatible update.
 New to the project? Follow these steps to get your development environment
 ready:
 
-1. Confirm you are running Node.js **v20.9.0 or newer**.
+1. Confirm you are running Node.js **v24.0.0 or newer**.
 
 1. Install dependencies after cloning the repository:
 


### PR DESCRIPTION
## Summary
- update the README to document the Node.js v24.0.0 minimum requirement so it matches the package.json engines field

## Testing
- npm run lint:prettier:fix
- npm run lint:markdown:fix
- npm run lint:eslint
- npm run typecheck
- npm run test:typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df7a244d78832fa61c0be68e5f9768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated minimum Node.js requirement to v24.0.0 across setup and onboarding guides.
  * Clarified onboarding steps to reference Node.js v24+ for local development.
  * Added notes on current dependency constraints for a validation library, explaining why we remain on the current major version and outlining plans to upgrade when compatibility is available.
  * No functional, runtime, or API changes; these updates are informational to aid developers and contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->