### PR TITLE
feat: add scoped import filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can scope imports with the `--server`, `--budget`, and `--account` options o
 
 Examples:
 
-```
+```bash
 # Import only these accounts
 actual-monmon import -a "DKB Giro" -a "DKB Visa"
 actual-monmon import -a "DKB Giro,DKB Visa"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,24 @@ Once configured, importing is as simple as running `actual-monmon import`. Make 
 
 The importer will not track previous imports, so if you wait more than one month between imports, you might need to manually specify the last import date. Running the importer twice in the same month is no problem, as duplicate transactions will automatically be detected and skipped.
 
-You can import a specific account with the `--account` option on the import command. Specify it multiple times to import from multiple accounts at a time. For example, to import only transactions from the MoneyMoney account with the name Acc1 and the account with a specific IBAN, you can use: `actual-monmon import --account Acc1 --account DE01...52`. The resolution of an account name follows the same patterns as the configuration keys.
+You can scope imports with the `--server`, `--budget`, and `--account` options on the import command. Each flag is case-insensitive, can be repeated, and accepts comma-separated values. If no filters are provided, everything is imported (the previous default behaviour).
+
+Examples:
+
+```
+# Import only these accounts
+actual-monmon import -a "DKB Giro" -a "DKB Visa"
+actual-monmon import -a "DKB Giro,DKB Visa"
+
+# Restrict to a specific server
+actual-monmon import -s myServerA
+
+# Restrict to a server and budget
+actual-monmon import -s myServerA -b HomeBudget
+
+# Apply all filters at once
+actual-monmon import -s myServerA -b HomeBudget -a "Groceries,Utilities"
+```
 
 ## Advanced Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,19 @@ try {
     fs.mkdirSync(APPLICATION_DIRECTORY, { recursive: true });
 }
 
+const splitArgs = (values?: Array<string>): Array<string> | undefined => {
+    if (!values) {
+        return undefined;
+    }
+
+    const items = values
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+    return items.length > 0 ? items : undefined;
+};
+
 const _ = yargs(hideBin(process.argv))
     .option('config', {
         type: 'string',
@@ -22,6 +35,31 @@ const _ = yargs(hideBin(process.argv))
     .option('logLevel', {
         type: 'number',
         description: 'The log level to use (0-4)',
+    })
+    .option('server', {
+        alias: 's',
+        type: 'string',
+        array: true,
+        description: 'Limit to server name(s)',
+    })
+    .option('budget', {
+        alias: 'b',
+        type: 'string',
+        array: true,
+        description: 'Limit to budget id/name(s)',
+    })
+    .option('account', {
+        alias: 'a',
+        type: 'string',
+        array: true,
+        description: 'Limit to account name(s)',
+    })
+    .middleware((argv) => {
+        const scopedArgv = argv as Record<string, unknown>;
+
+        scopedArgv.server = splitArgs(argv.server as Array<string> | undefined);
+        scopedArgv.budget = splitArgs(argv.budget as Array<string> | undefined);
+        scopedArgv.account = splitArgs(argv.account as Array<string> | undefined);
     })
     .command(importCommand)
     .command(validateCommand)

--- a/src/utils/scope.ts
+++ b/src/utils/scope.ts
@@ -24,9 +24,7 @@ const matches = (matcher: Matcher, candidates: Array<string | undefined>) => {
         return true;
     }
 
-    return candidates.some(
-        (candidate) => candidate && matcher(candidate)
-    );
+    return candidates.some((candidate) => candidate && matcher(candidate));
 };
 
 const resolveServerCandidates = (server: ActualServerConfig) => {

--- a/src/utils/scope.ts
+++ b/src/utils/scope.ts
@@ -1,0 +1,73 @@
+import { ActualBudgetConfig, ActualServerConfig, Config } from './config.js';
+
+export type Scope = {
+    servers?: Array<string>;
+    budgets?: Array<string>;
+    accounts?: Array<string>;
+};
+
+const toKey = (value: string) => value.toLowerCase();
+
+type Matcher = ((value: string) => boolean) | null;
+
+const createMatcher = (values?: Array<string>): Matcher => {
+    if (!values || values.length === 0) {
+        return null;
+    }
+
+    const normalized = new Set(values.map((value) => toKey(value)));
+    return (value: string) => normalized.has(toKey(value));
+};
+
+const matches = (matcher: Matcher, candidates: Array<string | undefined>) => {
+    if (!matcher) {
+        return true;
+    }
+
+    return candidates.some(
+        (candidate) => candidate && matcher(candidate)
+    );
+};
+
+const resolveServerCandidates = (server: ActualServerConfig) => {
+    const { serverUrl } = server;
+    const name = (server as ActualServerConfig & { name?: string }).name;
+    return [name, serverUrl];
+};
+
+const resolveBudgetCandidates = (budget: ActualBudgetConfig) => {
+    const namedBudget = (budget as ActualBudgetConfig & { name?: string }).name;
+    const budgetId = (budget as ActualBudgetConfig & { id?: string }).id;
+
+    return [namedBudget, budgetId, budget.syncId];
+};
+
+export const applyScope = (config: Config, scope: Scope): Config => {
+    const wantServer = createMatcher(scope.servers);
+    const wantBudget = createMatcher(scope.budgets);
+
+    const servers = config.actualServers
+        .filter((server) =>
+            matches(wantServer, resolveServerCandidates(server))
+        )
+        .map((server) => {
+            const budgets = server.budgets.filter((budget) =>
+                matches(wantBudget, resolveBudgetCandidates(budget))
+            );
+
+            if (budgets.length === 0) {
+                return null;
+            }
+
+            return {
+                ...server,
+                budgets,
+            };
+        })
+        .filter((server): server is ActualServerConfig => server !== null);
+
+    return {
+        ...config,
+        actualServers: servers,
+    };
+};


### PR DESCRIPTION
## Summary
- add repeatable server, budget, and account scope flags with normalization in the CLI entrypoint
- filter the loaded configuration based on the requested scope and log an import summary before running
- document scoped import usage patterns in the README for quick reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e112040120832fa852e01ddc45a91a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI flags --server (-s), --budget (-b), and --account (-a) to scope imports by server, budget, and account.
  * Flags are case-insensitive, repeatable, and accept comma-separated values; when no filters are provided, import defaults to everything.
  * CLI shows a clear import scope summary and exits early with a message if no items match the selected scope.

* **Documentation**
  * Updated README with examples demonstrating combinations of flags and scoped import usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->