### PR TITLE
ci: avoid duplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: [push, pull_request]
+on:
+    pull_request:
+    push:
+        branches:
+            - main
 jobs:
     test:
         name: test


### PR DESCRIPTION
## Summary
- switch CI to run on pull requests plus pushes to `main` only
- avoid duplicate workflow runs on PR branch updates while keeping mainline validation

## Testing
- not run (workflow-only change)