### PR TITLE
chore: update publishing guidance and version metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Pull Request
 
-> **Note**: This template is for changes to this independently maintained fork of [NikxDa/actual-moneymoney](https://github.com/NikxDa/actual-moneymoney).
+> **Note**: This template is for changes to `actual-moneymoney-importer`.
 
 ## Description
 
@@ -22,6 +22,7 @@ Brief description of the changes and why they're needed.
 
 - [ ] Code follows project conventions
 - [ ] Documentation updated if needed
+- [ ] Release impact / breaking changes documented
 - [ ] No breaking changes (or clearly documented)
 - [ ] Ready for review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,13 @@ npm run build
 npm run test:cli
 ```
 
+## Release & Publishing
+
+- Stable releases are automated from `main` via GitHub Actions and `semantic-release`.
+- Releases publish to both GitHub Releases and npm.
+- Do not manually bump `package.json` version or publish locally for routine releases.
+- Keep `package.json`, `README.md`, and release workflow/config files in sync when changing the package name, CLI name, install instructions, or release flow.
+
 ## Coding Style & Naming Conventions
 
 Use strict TypeScript with ES modules. Formatting is enforced by Prettier (`.prettierrc.json`): 4 spaces, single quotes, semicolons, trailing commas (`es5`), `printWidth: 80`.
@@ -88,6 +95,8 @@ Do not mark work as complete without reporting what was verified.
 
 ## Commit & Pull Request Guidelines
 
+Conventional Commits are required because `semantic-release` uses them to determine version bumps and release notes.
+
 Commits must follow Conventional Commits (validated by commitlint), e.g.:
 
 - `feat: add budget filter for imports`
@@ -98,7 +107,8 @@ PRs should include:
 
 - Clear description of intent and scope
 - Bullet list of changes
+- Notes on release impact, including any breaking changes
 - Testing evidence (commands run, manual scenarios)
 - Notes on breaking changes or config impacts
 
-If contributing upstream, follow `.github/PULL_REQUEST_TEMPLATE.md`.
+If contributing to this repository, follow `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
     </a>
 </p>
 
-> Originally based on [NikxDa/actual-moneymoney](https://github.com/NikxDa/actual-moneymoney), `actual-moneymoney-importer` is maintained independently with added category sync, payee transformation, and richer import controls.
+> `actual-moneymoney-importer` started as a fork of [NikxDa/actual-moneymoney](https://github.com/NikxDa/actual-moneymoney) and is now actively maintained and published with added category sync, payee transformation, and richer import controls.
 
 ## Highlights
 
 - 🏷️ **Category sync** – map MoneyMoney categories to Actual automatically, with backfill and conflict resolution
 - 🗺️ **`categories map` CLI** – audit, plan, and write your category mapping from the terminal
-- 🔬 **Scoped imports** – filter by server, budget, or account with repeatable `-s`/`-b`/`-a` flags
 - ⚠️ **Auto-rule override detection** – get warned when Actual's rules silently change a synced category
+- 🔬 **Scoped imports** – filter by server, budget, or account with repeatable `-s`/`-b`/`-a` flags
 - 🤖 **AI payee transformation** – configurable prompt, latest OpenAI models (`gpt-5-nano` default), temperature, and error-handling policy
 - 💬 **Comment import** – carry MoneyMoney transaction comments into Actual notes (with configurable prefix)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "actual-moneymoney-importer",
-    "version": "2.20.0-fork.1",
+    "version": "2.20.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "actual-moneymoney-importer",
-            "version": "2.20.0-fork.1",
+            "version": "2.20.0",
             "license": "MIT",
             "dependencies": {
                 "@actual-app/api": "^26.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actual-moneymoney-importer",
-    "version": "2.20.0-fork.1",
+    "version": "2.20.0",
     "description": "An importer for syncing MoneyMoney accounts and transactions to Actual.",
     "scripts": {
         "build": "npx tsc",


### PR DESCRIPTION
## Summary
- add release/publishing guidance to AGENTS.md
- refresh the PR template and README wording for the published project
- normalize package version metadata away from the fork-era suffix

## Testing
- Not run (docs/metadata only)