### PR TITLE
ci: run full test suite in ci and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,15 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - uses: oven-sh/setup-bun@v2
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '25'
 
             - run: bun install
             - run: bun run lint:eslint
             - run: bun run lint:prettier
-            - run: bun run build
+            - name: Build & Test
+              run: npm test
 
     commitlint:
         permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
-            - uses: oven-sh/setup-bun@v2
             - uses: actions/setup-node@v4
               with:
                   node-version: '25'
 
-            - run: bun install
-            - run: bun run lint:eslint
-            - run: bun run lint:prettier
+            - run: npm ci
+            - run: npm run lint:eslint
+            - run: npm run lint:prettier
             - name: Build & Test
               run: npm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,8 @@ jobs:
             - name: Lint with Prettier
               run: npm run lint:prettier
 
-            - name: Build
-              run: npm run build
-
-            - name: Test CLI
-              run: npm run test:cli
+            - name: Build & Test
+              run: npm test
 
             - name: Semantic Release
               run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "scripts": {
         "build": "npx tsc",
         "start": "node dist/index.js",
-        "test": "npm run build && node --test test/cli/**/*.test.mjs test/unit/**/*.test.mjs",
-        "test:cli": "npm run build && node --test test/cli/**/*.test.mjs",
-        "test:unit": "npm run build && node --test test/unit/**/*.test.mjs",
+        "test": "npm run build && node --test \"test/cli/**/*.test.mjs\" \"test/unit/**/*.test.mjs\"",
+        "test:cli": "npm run build && node --test \"test/cli/**/*.test.mjs\"",
+        "test:unit": "npm run build && node --test \"test/unit/**/*.test.mjs\"",
         "lint:eslint": "eslint src",
         "lint:prettier": "prettier --check 'src/**/*.ts'",
         "lint:fix": "eslint src --fix && prettier --write 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "scripts": {
         "build": "npx tsc",
         "start": "node dist/index.js",
-        "test": "npm run test:cli",
+        "test": "npm run build && node --test test/cli/**/*.test.mjs test/unit/**/*.test.mjs",
         "test:cli": "npm run build && node --test test/cli/**/*.test.mjs",
+        "test:unit": "npm run build && node --test test/unit/**/*.test.mjs",
         "lint:eslint": "eslint src",
         "lint:prettier": "prettier --check 'src/**/*.ts'",
         "lint:fix": "eslint src --fix && prettier --write 'src/**/*.ts'",


### PR DESCRIPTION
# Pull Request

> **Note**: This template is for changes to `actual-moneymoney-importer`.

## Description

Run the full built test suite by default in CI and release so unit tests are covered alongside the CLI tests.

## Changes Made

- [x] Updated `npm test` to run build + CLI + unit tests
- [x] Updated CI to run Node 25 and execute the full test suite
- [x] Updated release workflow to use the same full test gate
- [x] Renamed workflow steps to `Build & Test` for clarity

## Testing

- [x] Tested with existing functionality
- [x] Added new tests if applicable
- [x] Verified no regressions

Verification:
- `npm test`
- `bun run lint:eslint`
- `bun run lint:prettier`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] Release impact / breaking changes documented
- [x] No breaking changes (or clearly documented)
- [x] Ready for review

## Additional Notes

No product behavior changes; this is test/CI plumbing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test automation workflow to consolidate build and test operations.
  * Enhanced test script organization to include both CLI and unit tests in the primary test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->