### PR TITLE
fix: include january 2000 in actual history lookup

### DIFF
--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -20,13 +20,19 @@ type GetUserFilesResponse = {
     data: Array<UserFile>;
 };
 
+const ACTUAL_TRANSACTION_HISTORY_START_DATE = format(
+    new Date(2000, 0, 1),
+    'yyyy-MM-dd'
+);
+
 class ActualApi {
     protected isInitialized = false;
     // private _api: typeof actual | null = null;
 
     constructor(
         private serverConfig: ActualServerConfig,
-        private logger: Logger
+        private logger: Logger,
+        private actualApi = actual
     ) {}
 
     async init() {
@@ -116,11 +122,11 @@ class ActualApi {
     }
 
     getTransactions(accountId: string) {
-        const startDate = format(new Date(2000, 1, 1), 'yyyy-MM-dd');
+        const startDate = ACTUAL_TRANSACTION_HISTORY_START_DATE;
         const endDate = format(new Date(), 'yyyy-MM-dd');
 
         return this.withLogControl(() =>
-            actual.getTransactions(accountId, startDate, endDate)
+            this.actualApi.getTransactions(accountId, startDate, endDate)
         );
     }
 

--- a/test/unit/actual-api.test.mjs
+++ b/test/unit/actual-api.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import ActualApi from '../../dist/utils/ActualApi.js';
+
+const makeLogger = () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+});
+
+test('ActualApi.getTransactions starts on 2000-01-01', async () => {
+    const getTransactions = mock.fn(() => []);
+    const api = new ActualApi(
+        {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'pw',
+            budgets: [],
+        },
+        makeLogger(),
+        {
+            getTransactions,
+        }
+    );
+
+    await api.getTransactions('acct-1');
+
+    assert.equal(getTransactions.mock.callCount(), 1);
+    const [accountId, startDate, endDate] = getTransactions.mock.calls[0].arguments;
+
+    assert.equal(accountId, 'acct-1');
+    assert.equal(startDate, '2000-01-01');
+    assert.match(endDate, /^\d{4}-\d{2}-\d{2}$/);
+});


### PR DESCRIPTION
# Pull Request

> **Note**: This template is for changes to `actual-moneymoney-importer`.

## Description

Fix the Actual transaction history lookback start date so it begins on January 1st, 2000 instead of February 1st, 2000.

## Changes Made

- [x] Corrected the Actual API transaction history start date
- [x] Added a regression test for the start date passed to `getTransactions()`
- [x] Kept the change scoped to the date bug only

## Testing

- [x] Tested with existing functionality
- [x] Added new tests if applicable
- [x] Verified no regressions

Verification:
- `npm test`
- `npm run lint:eslint`
- `npm run lint:prettier`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] Release impact / breaking changes documented
- [x] No breaking changes (or clearly documented)
- [x] Ready for review

## Additional Notes

This PR is based on the updated `main` branch after PR1 landed.