### PR TITLE
fix: handle actual api http failures

### DIFF
--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -32,7 +32,8 @@ class ActualApi {
     constructor(
         private serverConfig: ActualServerConfig,
         private logger: Logger,
-        private actualApi = actual
+        private actualApi = actual,
+        private fetchImpl = fetch
     ) {}
 
     async init() {
@@ -191,7 +192,9 @@ class ActualApi {
     }
 
     private async getUserToken() {
-        const response = await fetch(
+        const responseData = await this.fetchJson<{
+            data: { token: string | null };
+        }>(
             `${this.serverConfig.serverUrl}/account/login`,
             {
                 method: 'POST',
@@ -201,12 +204,9 @@ class ActualApi {
                 body: JSON.stringify({
                     password: this.serverConfig.serverPassword,
                 }),
-            }
+            },
+            'Could not get user token'
         );
-
-        const responseData = (await response.json()) as {
-            data: { token: string | null };
-        };
 
         const userToken = responseData.data?.token;
 
@@ -222,18 +222,49 @@ class ActualApi {
     async getUserFiles() {
         const userToken = await this.getUserToken();
 
-        const response = await fetch(
+        const responseData = await this.fetchJson<GetUserFilesResponse>(
             `${this.serverConfig.serverUrl}/sync/list-user-files`,
             {
                 headers: {
                     'X-Actual-Token': userToken,
                 },
-            }
+            },
+            'Could not get user files'
         );
 
-        const responseData = (await response.json()) as GetUserFilesResponse;
-
         return responseData.data.filter((f) => f.deleted === 0);
+    }
+
+    private async fetchJson<T>(
+        url: string,
+        init: Parameters<typeof fetch>[1],
+        context: string
+    ): Promise<T> {
+        const response = await this.fetchImpl(url, init);
+
+        if (!response.ok) {
+            throw new Error(
+                `${context}: HTTP ${response.status} ${response.statusText}.`
+            );
+        }
+
+        try {
+            return (await response.json()) as T;
+        } catch (error) {
+            if (
+                error instanceof SyntaxError ||
+                (typeof error === 'object' &&
+                    error !== null &&
+                    'name' in error &&
+                    error.name === 'SyntaxError')
+            ) {
+                throw new Error(`${context}: Server returned invalid JSON.`, {
+                    cause: error,
+                });
+            }
+
+            throw error;
+        }
     }
 
     private async withLogControl<T>(callback: () => T | Promise<T>) {

--- a/test/unit/actual-api.test.mjs
+++ b/test/unit/actual-api.test.mjs
@@ -9,26 +9,176 @@ const makeLogger = () => ({
     error: () => {},
 });
 
+const makeServerConfig = () => ({
+    serverUrl: 'http://localhost:5006',
+    serverPassword: 'pw',
+    budgets: [],
+});
+
+const makeResponse = ({
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    json,
+}) => ({
+    ok,
+    status,
+    statusText,
+    json: json ?? mock.fn(async () => ({})),
+});
+
 test('ActualApi.getTransactions starts on 2000-01-01', async () => {
     const getTransactions = mock.fn(() => []);
-    const api = new ActualApi(
-        {
-            serverUrl: 'http://localhost:5006',
-            serverPassword: 'pw',
-            budgets: [],
-        },
-        makeLogger(),
-        {
-            getTransactions,
-        }
-    );
+    const api = new ActualApi(makeServerConfig(), makeLogger(), {
+        getTransactions,
+    });
 
     await api.getTransactions('acct-1');
 
     assert.equal(getTransactions.mock.callCount(), 1);
-    const [accountId, startDate, endDate] = getTransactions.mock.calls[0].arguments;
+    const [accountId, startDate, endDate] =
+        getTransactions.mock.calls[0].arguments;
 
     assert.equal(accountId, 'acct-1');
     assert.equal(startDate, '2000-01-01');
     assert.match(endDate, /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test('ActualApi.getUserFiles surfaces login HTTP failures', async () => {
+    const loginJson = mock.fn(async () => ({}));
+    const fetchImpl = mock.fn(async () =>
+        makeResponse({
+            ok: false,
+            status: 401,
+            statusText: 'Unauthorized',
+            json: loginJson,
+        })
+    );
+    const api = new ActualApi(
+        makeServerConfig(),
+        makeLogger(),
+        undefined,
+        fetchImpl
+    );
+
+    await assert.rejects(
+        () => api.getUserFiles(),
+        /Could not get user token: HTTP 401 Unauthorized\./
+    );
+
+    assert.equal(fetchImpl.mock.callCount(), 1);
+    assert.equal(loginJson.mock.callCount(), 0);
+});
+
+test('ActualApi.getUserFiles surfaces invalid login JSON', async () => {
+    const loginJson = mock.fn(async () => {
+        throw new SyntaxError('Unexpected token < in JSON at position 0');
+    });
+    const fetchImpl = mock.fn(async () =>
+        makeResponse({
+            ok: true,
+            json: loginJson,
+        })
+    );
+    const api = new ActualApi(
+        makeServerConfig(),
+        makeLogger(),
+        undefined,
+        fetchImpl
+    );
+
+    await assert.rejects(
+        () => api.getUserFiles(),
+        /Could not get user token: Server returned invalid JSON\./
+    );
+
+    assert.equal(fetchImpl.mock.callCount(), 1);
+    assert.equal(loginJson.mock.callCount(), 1);
+});
+
+test('ActualApi.getUserFiles surfaces files HTTP failures', async () => {
+    const loginJson = mock.fn(async () => ({
+        data: { token: 'token-1' },
+    }));
+    const filesJson = mock.fn(async () => ({}));
+    const responses = [
+        makeResponse({ json: loginJson }),
+        makeResponse({
+            ok: false,
+            status: 502,
+            statusText: 'Bad Gateway',
+            json: filesJson,
+        }),
+    ];
+    const fetchImpl = mock.fn(async () => responses.shift());
+    const api = new ActualApi(
+        makeServerConfig(),
+        makeLogger(),
+        undefined,
+        fetchImpl
+    );
+
+    await assert.rejects(
+        () => api.getUserFiles(),
+        /Could not get user files: HTTP 502 Bad Gateway\./
+    );
+
+    assert.equal(fetchImpl.mock.callCount(), 2);
+    assert.equal(loginJson.mock.callCount(), 1);
+    assert.equal(filesJson.mock.callCount(), 0);
+});
+
+test('ActualApi.getUserFiles surfaces invalid files JSON', async () => {
+    const loginJson = mock.fn(async () => ({
+        data: { token: 'token-1' },
+    }));
+    const filesJson = mock.fn(async () => {
+        throw new SyntaxError('Unexpected token < in JSON at position 0');
+    });
+    const responses = [
+        makeResponse({ json: loginJson }),
+        makeResponse({ json: filesJson }),
+    ];
+    const fetchImpl = mock.fn(async () => responses.shift());
+    const api = new ActualApi(
+        makeServerConfig(),
+        makeLogger(),
+        undefined,
+        fetchImpl
+    );
+
+    await assert.rejects(
+        () => api.getUserFiles(),
+        /Could not get user files: Server returned invalid JSON\./
+    );
+
+    assert.equal(fetchImpl.mock.callCount(), 2);
+    assert.equal(loginJson.mock.callCount(), 1);
+    assert.equal(filesJson.mock.callCount(), 1);
+});
+
+test('ActualApi.getUserFiles preserves non-JSON body errors', async () => {
+    const loginJson = mock.fn(async () => ({
+        data: { token: 'token-1' },
+    }));
+    const filesJson = mock.fn(async () => {
+        throw new Error('socket hang up');
+    });
+    const responses = [
+        makeResponse({ json: loginJson }),
+        makeResponse({ json: filesJson }),
+    ];
+    const fetchImpl = mock.fn(async () => responses.shift());
+    const api = new ActualApi(
+        makeServerConfig(),
+        makeLogger(),
+        undefined,
+        fetchImpl
+    );
+
+    await assert.rejects(() => api.getUserFiles(), /socket hang up/);
+
+    assert.equal(fetchImpl.mock.callCount(), 2);
+    assert.equal(loginJson.mock.callCount(), 1);
+    assert.equal(filesJson.mock.callCount(), 1);
 });


### PR DESCRIPTION
## Description
Improve Actual API HTTP error handling so non-2xx and invalid JSON responses fail with clearer errors instead of low-signal parse failures.

## Changes Made

- [x] Added an HTTP-aware fetch helper in `ActualApi`
- [x] Surface clear errors for login/file-list HTTP failures
- [x] Preserve non-JSON body/read errors
- [x] Added regression tests for login and file-list failure cases

## Testing

- [x] Tested with existing functionality
- [x] Added new tests if applicable
- [x] Verified no regressions

Verification:
- `npm test`
- `npm run lint:eslint`
- `npm run lint:prettier`
- `node --test test/unit/actual-api.test.mjs`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] Release impact / breaking changes documented
- [x] No breaking changes (or clearly documented)
- [x] Ready for review