### PR TITLE
fix: create parent directories for validate config

### DIFF
--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -2,6 +2,7 @@ import toml from 'toml';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { configSchema, getConfigFile } from '../utils/config.js';
 import fs from 'fs/promises';
+import path from 'path';
 import Logger, { LogLevel } from '../utils/Logger.js';
 import { z } from 'zod';
 import { EXAMPLE_CONFIG } from '../utils/shared.js';
@@ -23,7 +24,8 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
 
     if (!configFileExists) {
         // Create path to file and file itself if it doesn't exist
-        await fs.writeFile(configPath, EXAMPLE_CONFIG);
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(configPath, EXAMPLE_CONFIG, 'utf8');
 
         logger.warn('Configuration file not found.');
         logger.info(

--- a/test/cli/validate.test.mjs
+++ b/test/cli/validate.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const cliPath = path.resolve(__dirname, '../../dist/index.js');
+
+const runCli = (args = []) => {
+    const result = spawnSync(process.execPath, [cliPath, ...args], {
+        encoding: 'utf8',
+    });
+
+    return {
+        ...result,
+        output: `${result.stdout}${result.stderr}`,
+    };
+};
+
+test('validate creates nested config directories when missing', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-validate-')
+    );
+    const configPath = path.join(tempRoot, 'deep', 'nested', 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    const firstRun = runCli(['validate', '--config', configPath]);
+
+    assert.equal(firstRun.status, 0);
+    assert.match(firstRun.output, /Configuration file not found\./);
+    assert.match(firstRun.output, /Created default configuration file at:/);
+
+    const createdConfig = await readFile(configPath, 'utf8');
+    assert.match(createdConfig, /\[payeeTransformation\]/);
+
+    const secondRun = runCli(['validate', '--config', configPath]);
+
+    assert.equal(secondRun.status, 0);
+    assert.match(secondRun.output, /Configuration file is valid\./);
+});


### PR DESCRIPTION
## Description

Make `validate --config <nested/path>` create missing parent directories before writing the example config, matching the command's intended behavior.

## Changes Made

- [x] Create missing parent directories before writing a new config file
- [x] Add a CLI regression test for nested config paths
- [x] Keep the fix scoped to the validate bootstrap flow

## Testing

- [x] Tested with existing functionality
- [x] Added new tests if applicable
- [x] Verified no regressions

Verification:
- `npm test`
- `npm run lint:eslint`
- `npm run lint:prettier`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] Release impact / breaking changes documented
- [x] No breaking changes (or clearly documented)
- [x] Ready for review