### PR TITLE
fix: return non-zero for unsafe category writes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-# Pull Request
-
-> **Note**: This template is for changes to `actual-moneymoney-importer`.
-
 ## Description
 
 Brief description of the changes and why they're needed.
@@ -25,7 +21,3 @@ Brief description of the changes and why they're needed.
 - [ ] Release impact / breaking changes documented
 - [ ] No breaking changes (or clearly documented)
 - [ ] Ready for review
-
-## Additional Notes
-
-Any additional context or considerations for the reviewer or maintainer.

--- a/src/commands/categories.command.ts
+++ b/src/commands/categories.command.ts
@@ -43,6 +43,18 @@ const printFallbackSnippet = (
     );
 };
 
+export const handleUnsafeWriteConfigFailure = (
+    logger: Logger,
+    entries: CanonicalMappingEntry[],
+    reason: string
+) => {
+    logger.error(
+        `Could not safely write category mapping to config: ${reason}`
+    );
+    printFallbackSnippet(logger, entries);
+    return 1 as const;
+};
+
 const handleMapCommand = async (argv: ArgumentsCamelCase) => {
     const config = await getConfig(argv);
     const configPath = getConfigFile(argv);
@@ -143,11 +155,13 @@ const handleMapCommand = async (argv: ArgumentsCamelCase) => {
     const configText = await fs.readFile(configPath, 'utf8');
 
     if (getBudgetBlocks(configText).length === 0) {
-        logger.error(
-            `Could not safely write category mapping to config: no budget blocks found.`
+        process.exit(
+            handleUnsafeWriteConfigFailure(
+                logger,
+                report.canonicalMappingEntries,
+                'no budget blocks found.'
+            )
         );
-        printFallbackSnippet(logger, report.canonicalMappingEntries);
-        process.exit(0);
     }
 
     logger.warn(
@@ -161,11 +175,13 @@ const handleMapCommand = async (argv: ArgumentsCamelCase) => {
     );
 
     if (!writeResult.ok) {
-        logger.error(
-            `Could not safely write category mapping to config: ${writeResult.reason}`
+        process.exit(
+            handleUnsafeWriteConfigFailure(
+                logger,
+                report.canonicalMappingEntries,
+                writeResult.reason
+            )
         );
-        printFallbackSnippet(logger, report.canonicalMappingEntries);
-        process.exit(0);
     }
 
     const parsedAfterWrite = toml.parse(writeResult.content);

--- a/test/unit/categories-map-output.test.mjs
+++ b/test/unit/categories-map-output.test.mjs
@@ -10,6 +10,7 @@ import {
     formatTomlReport,
     formatUnresolvedMoneyMoneySection,
     formatUnusedActualSection,
+    handleUnsafeWriteConfigFailure,
 } from '../../dist/commands/categories.command.js';
 
 const makeReport = ({
@@ -144,6 +145,33 @@ test('table report includes sections in expected order', () => {
     assert.ok(unusedIdx > unresolvedIdx);
     assert.ok(warningsIdx > unusedIdx);
     assert.ok(actionsIdx > warningsIdx);
+});
+
+test('unsafe write failures return a non-zero exit code', () => {
+    const calls = {
+        error: [],
+        info: [],
+    };
+    const logger = {
+        error: (...args) => calls.error.push(args),
+        info: (...args) => calls.info.push(args),
+    };
+
+    const exitCode = handleUnsafeWriteConfigFailure(
+        logger,
+        [],
+        'no budget blocks found.'
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(calls.error, [
+        ['Could not safely write category mapping to config: no budget blocks found.'],
+    ]);
+    assert.equal(calls.info.length, 1);
+    assert.deepEqual(calls.info[0][1], [
+        '[actualServers.budgets.categoryMapping]',
+        '# No mappings generated.',
+    ]);
 });
 
 test('next actions prioritizes invalid mappings over unresolved categories', () => {


### PR DESCRIPTION
## Description

Make `categories map --write-config` exit non-zero when it cannot safely update the config, so scripts and CI can detect the failure.

## Changes Made

- [x] Return exit code 1 for unsafe write-config fallback paths
- [x] Preserve the existing fallback snippet output for manual copying
- [x] Add a regression test for the unsafe write-config helper
- [x] Include the updated PR template changes in this PR

## Testing

- [x] Tested with existing functionality
- [x] Added new tests if applicable
- [x] Verified no regressions

Verification:
- `npm test`
- `npm run lint:eslint`
- `npm run lint:prettier`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] Release impact / breaking changes documented
- [x] No breaking changes (or clearly documented)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for category configuration write operations with standardized error messages and exit codes when writes fail.

* **Chores**
  * Updated PR template structure.
  * Enhanced test coverage for error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->