### PR TITLE
chore: sync admin guidance and formatting scope

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,14 +10,22 @@ Brief description of the changes and why they're needed.
 
 ## Testing
 
-- [ ] Tested with existing functionality
-- [ ] Added new tests if applicable
-- [ ] Verified no regressions
+- [ ] Commands run (one or more of the following, as applicable):
+    - `npm test`
+    - `npm run test:cli`
+    - `npm run test:unit`
+    - `npm run lint:eslint`
+    - `npm run lint:prettier`
+- [ ] Manual verification (if applicable)
+
+## Release / Config Impact
+
+- [ ] None
+- [ ] Describe any release, config, or user-visible impact
 
 ## Checklist
 
 - [ ] Code follows project conventions
 - [ ] Documentation updated if needed
-- [ ] Release impact / breaking changes documented
 - [ ] No breaking changes (or clearly documented)
 - [ ] Ready for review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ The project is a TypeScript CLI importer. Main source lives in `src/`:
 - `src/commands/`: command handlers (`import`, `validate`).
 - `src/utils/`: integration and domain logic (Actual API, importer flow, config, logging, mapping).
 - `src/types/`: local type declarations.
+- `test/cli/`: CLI integration tests for parsing, exit codes, and end-to-end flows.
+- `test/unit/`: focused unit tests for helpers, adapters, output formatting, and error handling.
 
 Build output is written to `dist/` (generated). Static assets are in `assets/`. CI and release automation are under `.github/workflows/`.
 
@@ -16,10 +18,12 @@ Build output is written to `dist/` (generated). Static assets are in `assets/`. 
 - `npm install` or `bun install`: install dependencies.
 - `npm run build`: compile TypeScript to `dist/` using `tsc`.
 - `npm run start`: run built CLI (`node dist/index.js`).
-- `npm run test` or `npm run test:cli`: run CLI integration tests.
+- `npm run test`: compile TypeScript and run the full automated suite (`test/cli` + `test/unit`).
+- `npm run test:cli`: compile TypeScript and run CLI integration tests.
+- `npm run test:unit`: compile TypeScript and run unit tests.
 - `npm run lint:eslint`: run ESLint on `src/`.
-- `npm run lint:prettier`: check formatting for `src/**/*.ts`.
-- `npm run lint:fix`: auto-fix lint and formatting issues.
+- `npm run lint:prettier`: check formatting for `src/**/*.ts`, `test/**/*.mjs`, `*.md`, `.github/**/*.md`, and `package.json`.
+- `npm run lint:fix`: auto-fix lint and formatting issues in the same file sets.
 
 Example local validation flow:
 
@@ -27,7 +31,7 @@ Example local validation flow:
 npm run lint:eslint
 npm run lint:prettier
 npm run build
-npm run test:cli
+npm run test
 ```
 
 ## Release & Publishing
@@ -50,14 +54,15 @@ Follow existing naming patterns:
 
 ## Testing Guidelines
 
-CLI parser behavior is covered by integration tests in `test/cli/`.
+CLI parser and end-to-end command behavior is covered by integration tests in `test/cli/`.
+Focused helpers, API wrappers, output formatters, and error handling belong in `test/unit/`.
 
 For behavior changes, run:
 
 1. `npm run build`
-2. `npm run test:cli`
-3. `actual-monmon validate` with a real config
-4. `actual-monmon import --from=YYYY-MM-DD` against a safe test budget/server when possible
+2. `npm run test` or the targeted subset(s) (`npm run test:cli` / `npm run test:unit`)
+3. `node dist/index.js validate` with a real config
+4. `node dist/index.js import --from=YYYY-MM-DD` against a safe test budget/server when possible
 
 Document manual verification steps in PR descriptions.
 
@@ -87,7 +92,7 @@ Do not block on minor stylistic ambiguity; follow existing repository convention
 
 Every non-trivial code change must include verification evidence:
 
-- automated tests (`npm run test:cli`) and/or
+- automated tests (`npm run test`, `npm run test:cli`, or `npm run test:unit`) and/or
 - lint/build results and
 - manual scenario checks for integrations that cannot be fully automated.
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
         "test:cli": "npm run build && node --test \"test/cli/**/*.test.mjs\"",
         "test:unit": "npm run build && node --test \"test/unit/**/*.test.mjs\"",
         "lint:eslint": "eslint src",
-        "lint:prettier": "prettier --check 'src/**/*.ts'",
-        "lint:fix": "eslint src --fix && prettier --write 'src/**/*.ts'",
+        "lint:prettier": "prettier --check 'src/**/*.ts' 'test/**/*.mjs' '*.md' '.github/**/*.md' 'package.json'",
+        "lint:fix": "eslint src --fix && prettier --write 'src/**/*.ts' 'test/**/*.mjs' '*.md' '.github/**/*.md' 'package.json'",
         "prepare": "husky"
     },
     "type": "module",
@@ -72,6 +72,18 @@
     "lint-staged": {
         "src/**/*.ts": [
             "eslint --fix",
+            "prettier --write"
+        ],
+        "test/**/*.mjs": [
+            "prettier --write"
+        ],
+        "*.md": [
+            "prettier --write"
+        ],
+        ".github/**/*.md": [
+            "prettier --write"
+        ],
+        "package.json": [
             "prettier --write"
         ]
     }

--- a/test/cli/parsing.test.mjs
+++ b/test/cli/parsing.test.mjs
@@ -84,20 +84,13 @@ test('shows short aliases for root and import options in help', () => {
     assert.match(result.output, /-a,\s*--account/i);
     assert.match(result.output, /-s,\s*--server/i);
     assert.match(result.output, /-b,\s*--budget/i);
-    assert.match(
-        result.output,
-        /-C,\s*--category-sync-on-existing/i
-    );
+    assert.match(result.output, /-C,\s*--category-sync-on-existing/i);
     assert.match(result.output, /-f,\s*--from/i);
     assert.match(result.output, /-t,\s*--to/i);
 });
 
 test('fails for invalid category sync policy value', () => {
-    const result = runCli([
-        'import',
-        '--category-sync-on-existing',
-        'invalid',
-    ]);
+    const result = runCli(['import', '--category-sync-on-existing', 'invalid']);
 
     assert.equal(result.status, 1);
     assert.match(result.output, /Invalid values/i);

--- a/test/unit/categories-config-write.test.mjs
+++ b/test/unit/categories-config-write.test.mjs
@@ -98,14 +98,18 @@ syncId = "budget-a"
 "A" = "B"
 `;
 
-    const result = replaceCategoryMappingInConfig(withFollowingSection, 'budget-a', [
-        makeEntry({
-            sourceUuid: 'new-mm',
-            targetId: 'new-actual',
-            sourcePath: 'X > Y',
-            targetPath: 'Z > Q',
-        }),
-    ]);
+    const result = replaceCategoryMappingInConfig(
+        withFollowingSection,
+        'budget-a',
+        [
+            makeEntry({
+                sourceUuid: 'new-mm',
+                targetId: 'new-actual',
+                sourcePath: 'X > Y',
+                targetPath: 'Z > Q',
+            }),
+        ]
+    );
 
     assert.equal(result.ok, true);
     if (!result.ok) {
@@ -146,14 +150,18 @@ test('replaceCategoryMappingInConfig updates only target budget in multi-budget 
 });
 
 test('replaceCategoryMappingInConfig fails safely for missing syncId', () => {
-    const result = replaceCategoryMappingInConfig(BASE_CONFIG, 'does-not-exist', [
-        makeEntry({
-            sourceUuid: 'mm-a',
-            targetId: 'actual-a',
-            sourcePath: 'M > A',
-            targetPath: 'T > A',
-        }),
-    ]);
+    const result = replaceCategoryMappingInConfig(
+        BASE_CONFIG,
+        'does-not-exist',
+        [
+            makeEntry({
+                sourceUuid: 'mm-a',
+                targetId: 'actual-a',
+                sourcePath: 'M > A',
+                targetPath: 'T > A',
+            }),
+        ]
+    );
 
     assert.equal(result.ok, false);
     if (result.ok) {

--- a/test/unit/categories-map-output.test.mjs
+++ b/test/unit/categories-map-output.test.mjs
@@ -115,15 +115,30 @@ test('formatters include expected headers and rows', () => {
     const unresolvedLines = formatUnresolvedMoneyMoneySection(report, 120);
     const unusedLines = formatUnusedActualSection(report, 120);
 
-    assert.equal(configuredLines.some((line) => line.includes('╔')), true);
+    assert.equal(
+        configuredLines.some((line) => line.includes('╔')),
+        true
+    );
     assert.equal(
         configuredLines.some((line) => line.includes('MoneyMoney Path')),
         true
     );
-    assert.equal(invalidLines.some((line) => line.includes('Reason')), true);
-    assert.equal(suggestionsLines.some((line) => line.includes('Actual Path')), true);
-    assert.equal(unresolvedLines.some((line) => line.includes('UUID')), true);
-    assert.equal(unusedLines.some((line) => line.includes('ID')), true);
+    assert.equal(
+        invalidLines.some((line) => line.includes('Reason')),
+        true
+    );
+    assert.equal(
+        suggestionsLines.some((line) => line.includes('Actual Path')),
+        true
+    );
+    assert.equal(
+        unresolvedLines.some((line) => line.includes('UUID')),
+        true
+    );
+    assert.equal(
+        unusedLines.some((line) => line.includes('ID')),
+        true
+    );
 });
 
 test('table report includes sections in expected order', () => {
@@ -165,7 +180,9 @@ test('unsafe write failures return a non-zero exit code', () => {
 
     assert.equal(exitCode, 1);
     assert.deepEqual(calls.error, [
-        ['Could not safely write category mapping to config: no budget blocks found.'],
+        [
+            'Could not safely write category mapping to config: no budget blocks found.',
+        ],
     ]);
     assert.equal(calls.info.length, 1);
     assert.deepEqual(calls.info[0][1], [
@@ -176,7 +193,9 @@ test('unsafe write failures return a non-zero exit code', () => {
 
 test('next actions prioritizes invalid mappings over unresolved categories', () => {
     const report = makeReport({
-        invalidMappings: [{ sourceRef: 'a', targetRef: 'b', reason: 'invalid' }],
+        invalidMappings: [
+            { sourceRef: 'a', targetRef: 'b', reason: 'invalid' },
+        ],
         unresolvedMoneyMoneyCategories: [{ uuid: 'u', path: 'P > Q' }],
     });
 

--- a/test/unit/category-map.test.mjs
+++ b/test/unit/category-map.test.mjs
@@ -43,7 +43,11 @@ test('loadFromData resolves canonical mapping by UUID', () => {
         },
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
@@ -78,7 +82,11 @@ test('uncategorized default category is excluded from unmapped requirements', ()
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [
@@ -108,7 +116,11 @@ test('emoji-prefixed Actual category name is normalized for suggestions', () => 
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-tank', name: 'Tanken' })],
@@ -144,7 +156,11 @@ test('ambiguous name matches do not produce suggestions', () => {
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
@@ -189,7 +205,11 @@ test('getCanonicalMapping excludes suggestions when includeSuggestions is false'
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
@@ -232,7 +252,11 @@ test('getCanonicalMappingEntries exposes origin and optional reason', () => {
         },
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
 
     map.loadFromData(
         [
@@ -262,7 +286,9 @@ test('getCanonicalMappingEntries exposes origin and optional reason', () => {
         ]
     );
 
-    const entries = map.getCanonicalMappingEntries({ includeSuggestions: true });
+    const entries = map.getCanonicalMappingEntries({
+        includeSuggestions: true,
+    });
     assert.equal(entries.length, 2);
     assert.equal(entries[0]?.origin, 'configured');
     assert.equal(entries[1]?.origin, 'suggested');
@@ -281,7 +307,11 @@ test('getCanonicalMappingEntries sorts by sourcePath then sourceUuid', () => {
         },
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
     map.loadFromData(
         [
             makeMonMonCategory({ uuid: 'mm-a', name: 'Same' }),
@@ -328,7 +358,11 @@ test('report exposes planning fields and omits legacy report keys', () => {
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
         [
@@ -371,7 +405,11 @@ test('unusedActualCategories excludes configured and suggested target categories
         },
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
     map.loadFromData(
         [
             makeMonMonCategory({ uuid: 'mm-food', name: 'Food' }),
@@ -421,7 +459,11 @@ test('planningWarnings include exact messages when unresolved or unused categori
         categoryMapping: {},
     };
 
-    const map = new CategoryMap(budgetConfig, makeActualApiStub(), makeLogger());
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
     map.loadFromData(
         [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
         [

--- a/test/unit/cli-args.test.mjs
+++ b/test/unit/cli-args.test.mjs
@@ -9,7 +9,11 @@ test('toRefList returns undefined for empty input', () => {
 
 test('toRefList splits comma-separated and trims values', () => {
     assert.deepEqual(toRefList(' one, two ,three '), ['one', 'two', 'three']);
-    assert.deepEqual(toRefList(['one,two', ' three ']), ['one', 'two', 'three']);
+    assert.deepEqual(toRefList(['one,two', ' three ']), [
+        'one',
+        'two',
+        'three',
+    ]);
 });
 
 test('includesRef defaults to true for undefined refs', () => {

--- a/test/unit/importer-category-sync-flow.test.mjs
+++ b/test/unit/importer-category-sync-flow.test.mjs
@@ -22,14 +22,14 @@ const makeLogger = () => {
             infos.push({ message, hints: toHintArray(hint) }),
         warn: (message, hint) =>
             warnings.push({ message, hints: toHintArray(hint) }),
-        error: () => { },
+        error: () => {},
     };
 };
 
 const makeImporter = ({
     mappingByUuid = {},
     policy = 'ask',
-    updateTransaction = async () => { },
+    updateTransaction = async () => {},
 } = {}) => {
     const logger = makeLogger();
     const actualApi = {
@@ -317,10 +317,7 @@ test('buildAccountTransactionBuckets warns for suspicious duplicate groups', () 
 
     assert.equal(logger.infos.length, 0);
     assert.equal(logger.warnings.length, 1);
-    assert.match(
-        logger.warnings[0]?.message ?? '',
-        /1 group\(s\) need review/
-    );
+    assert.match(logger.warnings[0]?.message ?? '', /1 group\(s\) need review/);
     assert.equal(logger.debugs.length, 1);
     assert.match(
         logger.debugs[0]?.hints[0] ?? '',

--- a/test/unit/text-table.test.mjs
+++ b/test/unit/text-table.test.mjs
@@ -58,7 +58,10 @@ test('renderTextTable respects truncation priority', () => {
     });
 
     const table = lines.join('\n');
-    assert.equal(table.includes('This path should truncate before the id does'), false);
+    assert.equal(
+        table.includes('This path should truncate before the id does'),
+        false
+    );
     assert.equal(table.includes('id-1234567890'), true);
 });
 


### PR DESCRIPTION
## Description

Sync the repo admin guidance with the current workflow after the recent PR sequence.

## Changes Made

- [x] Updated AGENTS.md for the current test/layout workflow (`test/unit`, `npm test`, repo-local manual commands)
- [x] Expanded Prettier/lint-staged coverage in package.json to include tests and admin/docs files
- [x] Refreshed the PR template to capture testing commands and release/config impact more clearly
- [x] Reformatted the affected test files so they comply with the expanded formatting scope

## Testing

- [x] Commands run:
  - `npm run lint:prettier`
  - `npm test`
- [x] Manual verification (if applicable)

## Release / Config Impact

- [x] None

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
- [x] Ready for review