### PR TITLE
fix(deps): refresh release tooling lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-            "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+            "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -64,9 +64,9 @@
             }
         },
         "node_modules/@actions/http-client": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-            "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+            "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/@actions/http-client/node_modules/undici": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -143,19 +143,6 @@
                 "google-protobuf": "^3.12.0-rc.1",
                 "murmurhash": "^2.0.1",
                 "uuid": "^9.0.0"
-            }
-        },
-        "node_modules/@actual-app/crdt/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -573,9 +560,9 @@
             }
         },
         "node_modules/@conventional-changelog/git-client": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.6.0.tgz",
-            "integrity": "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+            "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -588,7 +575,7 @@
             },
             "peerDependencies": {
                 "conventional-commits-filter": "^5.0.0",
-                "conventional-commits-parser": "^6.3.0"
+                "conventional-commits-parser": "^6.4.0"
             },
             "peerDependenciesMeta": {
                 "conventional-commits-filter": {
@@ -741,25 +728,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -856,9 +857,9 @@
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-            "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -908,9 +909,9 @@
             }
         },
         "node_modules/@octokit/plugin-retry": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.3.tgz",
-            "integrity": "sha512-vKGx1i3MC0za53IzYBSBXcrhmd+daQDzuZfYDd52X5S0M2otf3kVZTVP8bLA3EkU0lTvd1WEC2OlNNa4G+dohA==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+            "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -943,16 +944,17 @@
             }
         },
         "node_modules/@octokit/request": {
-            "version": "10.0.7",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
-            "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+            "version": "10.0.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+            "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/endpoint": "^11.0.2",
+                "@octokit/endpoint": "^11.0.3",
                 "@octokit/request-error": "^7.0.2",
                 "@octokit/types": "^16.0.0",
                 "fast-content-type-parse": "^3.0.0",
+                "json-with-bigint": "^3.5.3",
                 "universal-user-agent": "^7.0.2"
             },
             "engines": {
@@ -1083,9 +1085,9 @@
             }
         },
         "node_modules/@semantic-release/github": {
-            "version": "12.0.3",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.3.tgz",
-            "integrity": "sha512-pod3AVGVVVk2rUczMBL4+gfY7hP7A9YYOwjpxVFSusF+pDbFOYBzFRQcHjv1H3IntQyB/Noxzx8LUZ/iwAQQeQ==",
+            "version": "12.0.6",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.6.tgz",
+            "integrity": "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1404,14 +1406,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.2.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-            "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -1669,12 +1671,12 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.13",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
             "license": "MIT",
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.6"
             }
         },
         "node_modules/absurd-sql": {
@@ -1709,9 +1711,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+            "version": "8.3.5",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1775,9 +1777,9 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2322,14 +2324,14 @@
             }
         },
         "node_modules/cli-truncate": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-            "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+            "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "slice-ansi": "^7.1.0",
-                "string-width": "^8.0.0"
+                "slice-ansi": "^8.0.0",
+                "string-width": "^8.2.0"
             },
             "engines": {
                 "node": ">=20"
@@ -2455,9 +2457,9 @@
             "license": "ISC"
         },
         "node_modules/conventional-changelog-angular": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
-            "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2468,9 +2470,9 @@
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
-            "integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+            "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2481,12 +2483,13 @@
             }
         },
         "node_modules/conventional-changelog-writer": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
-            "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
                 "conventional-commits-filter": "^5.0.0",
                 "handlebars": "^4.7.7",
                 "meow": "^13.0.0",
@@ -2510,9 +2513,9 @@
             }
         },
         "node_modules/conventional-commits-parser": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-            "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3123,9 +3126,9 @@
             }
         },
         "node_modules/eslint/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3309,9 +3312,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -3324,6 +3327,24 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/fetch-blob": {
             "version": "3.2.0",
@@ -3494,9 +3515,9 @@
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+            "version": "11.3.4",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+            "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3568,16 +3589,6 @@
                 "stream-combiner2": "~1.1.1",
                 "through2": "~2.0.0",
                 "traverse": "0.6.8"
-            }
-        },
-        "node_modules/git-log-parser/node_modules/split2": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
-            "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "through2": "~2.0.0"
             }
         },
         "node_modules/git-raw-commits": {
@@ -3712,9 +3723,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-            "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4087,9 +4098,9 @@
             "license": "ISC"
         },
         "node_modules/issue-parser": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-            "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+            "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4178,10 +4189,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-with-bigint": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jsonfile": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4244,19 +4262,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/lint-staged"
-            }
-        },
-        "node_modules/lint-staged/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/listr2": {
@@ -4450,25 +4455,42 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
         "node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }
         },
         "node_modules/make-asynchronous": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.0.1.tgz",
-            "integrity": "sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-event": "^6.0.0",
                 "type-fest": "^4.6.0",
-                "web-worker": "1.2.0"
+                "web-worker": "^1.5.0"
             },
             "engines": {
                 "node": ">=18"
@@ -4571,6 +4593,19 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/mime": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
@@ -4626,13 +4661,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -4723,9 +4758,9 @@
             "license": "MIT"
         },
         "node_modules/node-abi": {
-            "version": "3.90.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
-            "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+            "version": "3.91.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.91.0.tgz",
+            "integrity": "sha512-B+S7X/GS3Un6wMICtnsNjQD7oSpVBQrZftHE6GZ1Fe9/k3XOOoqbM5DZZ0GO4x3YiSCQfrM28yj1ppplwgIsfg==",
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
@@ -4817,9 +4852,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "11.12.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-            "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+            "version": "11.13.0",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+            "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -4898,7 +4933,7 @@
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.4.3",
                 "@npmcli/config": "^10.8.1",
                 "@npmcli/fs": "^5.0.0",
                 "@npmcli/map-workspaces": "^5.0.3",
@@ -4920,24 +4955,24 @@
                 "hosted-git-info": "^9.0.2",
                 "ini": "^6.0.0",
                 "init-package-json": "^8.2.5",
-                "is-cidr": "^6.0.3",
+                "is-cidr": "^6.0.4",
                 "json-parse-even-better-errors": "^5.0.0",
                 "libnpmaccess": "^10.0.3",
-                "libnpmdiff": "^8.1.5",
-                "libnpmexec": "^10.2.5",
-                "libnpmfund": "^7.0.19",
+                "libnpmdiff": "^8.1.6",
+                "libnpmexec": "^10.2.6",
+                "libnpmfund": "^7.0.20",
                 "libnpmorg": "^8.0.1",
-                "libnpmpack": "^9.1.5",
+                "libnpmpack": "^9.1.6",
                 "libnpmpublish": "^11.1.3",
                 "libnpmsearch": "^9.0.1",
                 "libnpmteam": "^8.0.2",
                 "libnpmversion": "^8.0.3",
                 "make-fetch-happen": "^15.0.5",
-                "minimatch": "^10.2.4",
+                "minimatch": "^10.2.5",
                 "minipass": "^7.1.3",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^12.2.0",
+                "node-gyp": "^12.3.0",
                 "nopt": "^9.0.0",
                 "npm-audit-report": "^7.0.0",
                 "npm-install-checks": "^8.0.0",
@@ -4956,7 +4991,7 @@
                 "spdx-expression-parse": "^4.0.0",
                 "ssri": "^13.0.1",
                 "supports-color": "^10.2.2",
-                "tar": "^7.5.11",
+                "tar": "^7.5.13",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^2.0.2",
                 "treeverse": "^3.0.0",
@@ -5045,7 +5080,7 @@
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "9.4.2",
+            "version": "9.4.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5296,7 +5331,7 @@
             }
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.5.0",
+            "version": "0.5.1",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -5438,7 +5473,7 @@
             }
         },
         "node_modules/npm/node_modules/brace-expansion": {
-            "version": "5.0.4",
+            "version": "5.0.5",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -5507,7 +5542,7 @@
             }
         },
         "node_modules/npm/node_modules/cidr-regex": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -5563,7 +5598,7 @@
             }
         },
         "node_modules/npm/node_modules/diff": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
@@ -5739,12 +5774,12 @@
             }
         },
         "node_modules/npm/node_modules/is-cidr": {
-            "version": "6.0.3",
+            "version": "6.0.4",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "cidr-regex": "^5.0.1"
+                "cidr-regex": "^5.0.4"
             },
             "engines": {
                 "node": ">=20"
@@ -5812,12 +5847,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "8.1.5",
+            "version": "8.1.6",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.4.3",
                 "@npmcli/installed-package-contents": "^4.0.0",
                 "binary-extensions": "^3.0.0",
                 "diff": "^8.0.2",
@@ -5831,13 +5866,13 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "10.2.5",
+            "version": "10.2.6",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@gar/promise-retry": "^1.0.0",
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.4.3",
                 "@npmcli/package-json": "^7.0.0",
                 "@npmcli/run-script": "^10.0.0",
                 "ci-info": "^4.0.0",
@@ -5854,12 +5889,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "7.0.19",
+            "version": "7.0.20",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2"
+                "@npmcli/arborist": "^9.4.3"
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
@@ -5879,12 +5914,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "9.1.5",
+            "version": "9.1.6",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/arborist": "^9.4.3",
                 "@npmcli/run-script": "^10.0.0",
                 "npm-package-arg": "^13.0.0",
                 "pacote": "^21.0.2"
@@ -5954,7 +5989,7 @@
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "11.2.7",
+            "version": "11.3.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -5986,12 +6021,12 @@
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "10.2.4",
+            "version": "10.2.5",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -6039,34 +6074,16 @@
             }
         },
         "node_modules/npm/node_modules/minipass-flush": {
-            "version": "1.0.5",
+            "version": "1.0.6",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minipass": "^3.0.0"
+                "minipass": "^7.1.3"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/npm/node_modules/minipass-pipeline": {
             "version": "1.2.4",
@@ -6147,7 +6164,7 @@
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "12.2.0",
+            "version": "12.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6155,12 +6172,12 @@
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^15.0.0",
                 "nopt": "^9.0.0",
                 "proc-log": "^6.0.0",
                 "semver": "^7.3.5",
                 "tar": "^7.5.4",
                 "tinyglobby": "^0.2.12",
+                "undici": "^6.25.0",
                 "which": "^6.0.0"
             },
             "bin": {
@@ -6607,7 +6624,7 @@
             }
         },
         "node_modules/npm/node_modules/tar": {
-            "version": "7.5.11",
+            "version": "7.5.13",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -6635,13 +6652,13 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tinyglobby": {
-            "version": "0.2.15",
+            "version": "0.2.16",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -6668,7 +6685,7 @@
             }
         },
         "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
+            "version": "4.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6700,6 +6717,15 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/undici": {
+            "version": "6.25.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/npm/node_modules/util-deprecate": {
@@ -7220,13 +7246,13 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -7320,12 +7346,12 @@
             }
         },
         "node_modules/plist": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-            "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+            "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
             "license": "MIT",
             "dependencies": {
-                "@xmldom/xmldom": "^0.8.8",
+                "@xmldom/xmldom": "^0.9.10",
                 "base64-js": "^1.5.1",
                 "xmlbuilder": "^15.1.1"
             },
@@ -7470,15 +7496,6 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "license": "ISC"
         },
-        "node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/read-package-up": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
@@ -7498,17 +7515,17 @@
             }
         },
         "node_modules/read-pkg": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
-            "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+            "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.4",
                 "normalize-package-data": "^8.0.0",
                 "parse-json": "^8.3.0",
-                "type-fest": "^5.2.0",
-                "unicorn-magic": "^0.3.0"
+                "type-fest": "^5.4.4",
+                "unicorn-magic": "^0.4.0"
             },
             "engines": {
                 "node": ">=20"
@@ -7543,6 +7560,19 @@
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg/node_modules/unicorn-magic": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7710,9 +7740,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -7933,17 +7963,17 @@
             }
         },
         "node_modules/slice-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+            "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "is-fullwidth-code-point": "^5.0.0"
+                "ansi-styles": "^6.2.3",
+                "is-fullwidth-code-point": "^5.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -7995,11 +8025,21 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
+        },
+        "node_modules/split2": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+            "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "through2": "~2.0.0"
+            }
         },
         "node_modules/stream-combiner2": {
             "version": "1.1.1",
@@ -8048,12 +8088,12 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -8083,6 +8123,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/super-regex": {
@@ -8198,9 +8247,9 @@
             }
         },
         "node_modules/tempy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.2.tgz",
-            "integrity": "sha512-pD3+21EbFZFBKDnVztX32wU6IBwkalOduWdx1OKvB5y6y1f2Xn8HU/U6o9EmlfdSyUYe9IybirmYPj/7rilA6Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+            "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8299,9 +8348,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8309,51 +8358,20 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tinyglobby/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/to-regex-range": {
@@ -8484,9 +8502,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
-            "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -8886,9 +8904,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.2",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
-            "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8896,9 +8914,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -8985,6 +9003,20 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -9022,9 +9054,9 @@
             }
         },
         "node_modules/web-worker": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
-            "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -9156,9 +9188,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+            "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
             "dev": true,
             "license": "ISC",
             "bin": {


### PR DESCRIPTION
## Summary
- Refresh the dependency lockfile to pick up patched release-tooling transitive packages.
- Update bundled npm to 11.13.0, which clears the picomatch Dependabot alert.
- Keep application runtime unchanged; this only affects dev/release tooling.

## Testing
- `npm test`
- Verified open Dependabot alerts are now cleared on GitHub.

## Notes
- `npm audit` still reports the bundled `ip-address` finding, but it is limited to dev-only release tooling and is dismissed in Dependabot as tolerable risk.