### PR TITLE
chore(ci): make release workflow manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: release
 on:
-    push:
-        branches:
-            - main
+    workflow_dispatch:
 jobs:
     release:
         permissions:


### PR DESCRIPTION
## Summary
- Switch the release workflow from push-triggered to manual execution only.
- Keep semantic-release and the existing release checks unchanged.

## Testing
- npx prettier --check ".github/workflows/release.yml"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow trigger mechanism from automatic push-based triggering to manual triggering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->