### PR TITLE
ci: restore CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+    schedule:
+        - cron: '0 3 * * 1'
+
+jobs:
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+
+        strategy:
+            fail-fast: false
+            matrix:
+                language: [javascript-typescript]
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Restore the missing CodeQL workflow so GitHub code scanning can run again.
- Run CodeQL on PRs into `main`, pushes to `main`, and a weekly schedule.

## Verification
- `git diff --check`
- Confirmed the workflow file exists at `.github/workflows/codeql.yml`