### PR TITLE
chore(ci): group Dependabot Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
           - dependency-name: zod
             update-types: ["version-update:semver-major"]
             versions: [">=4.0.0"]
+    - package-ecosystem: github-actions
+      directory: '/'
+      schedule:
+          interval: weekly
+      groups:
+          actions:
+              patterns:
+                  - '*'


### PR DESCRIPTION
## Summary
- Group Dependabot GitHub Actions updates into a single PR.
- Keep npm dependency updates unchanged.

## Testing
- Verified the updated `.github/dependabot.yml` contents.

## Release impact
- No runtime impact; CI configuration only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated checking and grouping of GitHub Actions dependency updates on a weekly schedule.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/218)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->