### PR TITLE
fix(release): promote Dependabot API bumps

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,19 @@
 {
     "branches": ["main"],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "releaseRules": [
+                    {
+                        "type": "chore",
+                        "scope": "deps",
+                        "subject": "bump @actual-app/api from *",
+                        "release": "patch"
+                    }
+                ]
+            }
+        ],
         "@semantic-release/release-notes-generator",
         "@semantic-release/npm",
         [

--- a/test/unit/release-config.test.mjs
+++ b/test/unit/release-config.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const releaseConfig = JSON.parse(
+    readFileSync(new URL('../../.releaserc.json', import.meta.url), 'utf8')
+);
+
+test('semantic-release promotes Dependabot API bumps', () => {
+    const commitAnalyzer = releaseConfig.plugins.find((plugin) => {
+        return (
+            Array.isArray(plugin) &&
+            plugin[0] === '@semantic-release/commit-analyzer'
+        );
+    });
+
+    assert.ok(commitAnalyzer, 'commit analyzer plugin is configured');
+
+    const [, options] = commitAnalyzer;
+    assert.ok(Array.isArray(options.releaseRules));
+    assert.ok(
+        options.releaseRules.some(
+            ({ type, scope, subject, release }) =>
+                type === 'chore' &&
+                scope === 'deps' &&
+                subject === 'bump @actual-app/api from *' &&
+                release === 'patch'
+        )
+    );
+});


### PR DESCRIPTION
## Summary
- Treat Dependabot bumps of `@actual-app/api` as release-worthy so manual semantic-release runs publish a version.
- Add a regression test to lock the release rule in place.

## Testing
- `npm run lint:prettier`
- `npm test`

## Release impact
- This ensures changes to a main public API dependency trigger a patch release instead of being skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified release versioning configuration to treat dependency update commits as patch releases.

* **Tests**
  * Added test coverage to verify dependency update handling in release configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->