### PR TITLE
feat: add automatic transfer seeding for imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ categorySyncOnExisting = "ask" # ask|new|always
 importComments = false # Optional: Import MoneyMoney comments into Actual
 commentPrefix = "MoneyMoney Comment: " # Optional: Set a prefix for MoneyMoney comments inside the notes
 
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 5
+
 # Actual servers, you can add multiple servers
 [[actualServers]]
 serverUrl = "http://localhost:5006"
@@ -131,6 +136,23 @@ The AI receives existing payees from your budget to prefer matching over creatin
 | `categorySyncOnExisting`      | `ask`                    | Policy for existing transactions: `ask`, `new`, or `always` |
 | `importComments`              | `false`                  | Import MoneyMoney comments into Actual notes                |
 | `commentPrefix`               | `"MoneyMoney Comment: "` | Prefix added to imported comments                           |
+
+#### Automatic transfers
+
+Enable `[import.transfers]` to seed Actual transfers from MoneyMoney transactions when the source-side booking carries a configured transfer category and its `accountNumber` points to another mapped MoneyMoney account.
+
+| Option            | Default | Description                                                                 |
+| ----------------- | ------- | --------------------------------------------------------------------------- |
+| `enabled`         | `false` | Enable automatic transfer seeding                                           |
+| `categoryRefs`    | `[]`    | MoneyMoney transfer categories by UUID, full path, or exact leaf name       |
+| `matchWindowDays` | `5`     | Date window used to detect a same-run counterpart in another mapped account |
+
+Notes:
+
+- `categoryRefs` must be non-empty when `enabled = true`
+- If only one side is present, the importer seeds a transfer on the recognized side and lets a later import update the generated counterpart
+- If both sides are present in the same run and the counterpart match is unique, the importer suppresses the second plain import and stamps the generated transfer counterpart with the second `imported_id`
+- If the target account cannot be identified confidently, the transaction is imported normally
 
 ### Comment import
 

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -158,7 +158,10 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
                         actualApi,
                         logger
                     );
-                    if (config.import.synchronizeCategories) {
+                    if (
+                        config.import.synchronizeCategories ||
+                        config.import.transfers.enabled
+                    ) {
                         await categoryMap.load();
                     }
 

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -150,11 +150,6 @@ class ActualApi {
         return this.withLogControl(() => (actual as any).getPayees());
     }
 
-    async getTransferPayeeForAccount(accountId: string) {
-        const payees = await this.getPayees();
-        return payees.find((payee) => payee.transfer_acct === accountId);
-    }
-
     async getCategories(): Promise<Category[]> {
         await this.ensureInitialization();
         const categoryItems = await this.withLogControl(() =>

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -150,6 +150,11 @@ class ActualApi {
         return this.withLogControl(() => (actual as any).getPayees());
     }
 
+    async getTransferPayeeForAccount(accountId: string) {
+        const payees = await this.getPayees();
+        return payees.find((payee) => payee.transfer_acct === accountId);
+    }
+
     async getCategories(): Promise<Category[]> {
         await this.ensureInitialization();
         const categoryItems = await this.withLogControl(() =>

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -573,16 +573,14 @@ class CategoryMap {
         reason?: string;
     } {
         const byUuid = this.monMonCategoryInfos.get(ref);
-        if (byUuid && !byUuid.isGroup) {
+        if (byUuid) {
             return { info: byUuid };
         }
 
         const normalizedRef = this.normalizeCategoryName(ref);
-        const leafCategories = Array.from(
-            this.monMonCategoryInfos.values()
-        ).filter((category) => !category.isGroup);
+        const categories = Array.from(this.monMonCategoryInfos.values());
 
-        const byPath = leafCategories.filter((category) => {
+        const byPath = categories.filter((category) => {
             const normalizedPath = this.normalizeCategoryName(
                 category.path.join(DEFAULT_CATEGORY_PATH_SEPARATOR)
             );
@@ -603,7 +601,7 @@ class CategoryMap {
             };
         }
 
-        const byName = leafCategories.filter((category) => {
+        const byName = categories.filter((category) => {
             return this.normalizeCategoryName(category.name) === normalizedRef;
         });
 

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -401,6 +401,20 @@ class CategoryMap {
                 continue;
             }
 
+            if (sourceResolution.info.isGroup) {
+                this.invalidMappings.push({
+                    sourceRef,
+                    targetRef,
+                    status: 'invalid',
+                    reason: 'MoneyMoney category groups cannot be mapped; use a leaf category instead',
+                    sourceUuid: sourceResolution.info.uuid,
+                    sourcePath: sourceResolution.info.path.join(
+                        DEFAULT_CATEGORY_PATH_SEPARATOR
+                    ),
+                });
+                continue;
+            }
+
             if (!targetResolution.info) {
                 this.invalidMappings.push({
                     sourceRef,

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -187,6 +187,42 @@ class CategoryMap {
         return category.path.join(DEFAULT_CATEGORY_PATH_SEPARATOR);
     }
 
+    resolveMoneyMoneyCategoryRefs(refs: string[]): {
+        resolvedUuids: Set<string>;
+        invalidRefs: Array<{ ref: string; reason: string }>;
+    } {
+        const resolvedUuids = new Set<string>();
+        const invalidRefs: Array<{ ref: string; reason: string }> = [];
+
+        for (const ref of refs) {
+            const resolution = this.resolveMoneyMoneyCategoryRef(ref);
+            if (!resolution.info) {
+                invalidRefs.push({
+                    ref,
+                    reason:
+                        resolution.reason ??
+                        `MoneyMoney category ref '${ref}' not found.`,
+                });
+                continue;
+            }
+
+            if (resolution.info.isGroup) {
+                invalidRefs.push({
+                    ref,
+                    reason: `MoneyMoney category ref '${ref}' resolved to a category group. Use a leaf category instead.`,
+                });
+                continue;
+            }
+
+            resolvedUuids.add(resolution.info.uuid);
+        }
+
+        return {
+            resolvedUuids,
+            invalidRefs,
+        };
+    }
+
     getReport(): CategoryMapReport {
         const unresolvedMoneyMoneyCategories = this.getUnmappedCategories();
         const unusedActualCategories = this.computeUnusedActualCategories();

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -89,6 +89,7 @@ type PlannedTransferSeed = {
 type PlannedTransferCounterpart = {
     importedId: string;
     importedPayee: string;
+    date: string;
     notes?: string;
     cleared?: boolean;
 };
@@ -1462,6 +1463,7 @@ class Importer {
                     sameRunCounterpart: {
                         importedId: counterpartImportedId,
                         importedPayee: sameRunCounterpart.name ?? '',
+                        date: format(sameRunCounterpart.valueDate, DATE_FORMAT),
                         notes:
                             this.buildTransactionNotes(sameRunCounterpart) ||
                             '',
@@ -1613,6 +1615,7 @@ class Importer {
             const counterpartUpdate: Partial<UpdateTransaction> = {
                 imported_id: plannedSeed.sameRunCounterpart.importedId,
                 imported_payee: plannedSeed.sameRunCounterpart.importedPayee,
+                date: plannedSeed.sameRunCounterpart.date,
                 notes: plannedSeed.sameRunCounterpart.notes ?? '',
             };
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -362,16 +362,19 @@ class Importer {
             {} as Record<string, MonMonTransaction[]>
         );
 
-        const fullAccountMapping = this.accountMap.getMap();
+        const transfersEnabled = this.config.import.transfers.enabled;
+        const fullAccountMapping = transfersEnabled
+            ? this.accountMap.getMap()
+            : undefined;
         const accountMapping = accountRefs
             ? this.accountMap.getMap(accountRefs)
-            : fullAccountMapping;
+            : (fullAccountMapping ?? this.accountMap.getMap());
         const existingActualTransactionsByAccountId = new Map<
             string,
             ReadTransaction[]
         >();
 
-        for (const [, actualAccount] of fullAccountMapping) {
+        for (const [, actualAccount] of fullAccountMapping ?? accountMapping) {
             existingActualTransactionsByAccountId.set(
                 actualAccount.id,
                 await this.actualApi.getTransactions(actualAccount.id)
@@ -379,8 +382,7 @@ class Importer {
         }
 
         let existingPayeeNames: string[] = [];
-        const shouldLoadPayeesForTransfers =
-            this.config.import.transfers.enabled;
+        const shouldLoadPayeesForTransfers = transfersEnabled;
         const existingPayees =
             (this.payeeTransformer && !isDryRun) || shouldLoadPayeesForTransfers
                 ? await this.actualApi.getPayees()
@@ -433,9 +435,9 @@ class Importer {
             }
         );
 
-        const transferPlan = this.config.import.transfers.enabled
+        const transferPlan = transfersEnabled
             ? this.buildTransferPlan({
-                  fullAccountMapping,
+                  fullAccountMapping: fullAccountMapping!,
                   accountStates,
                   monMonTransactionMap,
                   existingActualTransactionsByAccountId,
@@ -531,7 +533,15 @@ class Importer {
                     createTransactions.push(createTransaction);
                 }
 
-                if (existingActualTransactions.length === 0) {
+                const effectiveExistingActualTransactions =
+                    await this.getExistingTransactionsForStartBalanceCheck({
+                        actualAccountId: actualAccount.id,
+                        existingActualTransactions,
+                        transfersEnabled,
+                        isDryRun,
+                    });
+
+                if (effectiveExistingActualTransactions.length === 0) {
                     const startTransaction: CreateTransaction = {
                         date: format(
                             accountTransactions.length > 0
@@ -654,12 +664,16 @@ class Importer {
                             ]
                         );
 
+                        const importedTransactions =
+                            result.added.length > 0 || result.updated.length > 0
+                                ? await this.actualApi.getTransactionsByIds(
+                                      actualAccount.id,
+                                      [...result.added, ...result.updated]
+                                  )
+                                : [];
+
                         await this.applyTransferCounterpartUpdates({
-                            actualAccount,
-                            importedTransactionIds: [
-                                ...result.added,
-                                ...result.updated,
-                            ],
+                            importedTransactions,
                             transferPlan,
                         });
 
@@ -669,9 +683,9 @@ class Importer {
                         ) {
                             const overrideCount =
                                 await this.detectAndWarnAutoRuleOverrides({
-                                    actualAccountId: actualAccount.id,
                                     actualAccountName: actualAccount.name,
                                     addedIds: result.added,
+                                    importedTransactions,
                                     intendedCategoryByImportedId,
                                 });
                             runMetrics.totalAutoRuleOverrides += overrideCount;
@@ -807,19 +821,19 @@ class Importer {
     }
 
     async detectAndWarnAutoRuleOverrides({
-        actualAccountId,
         actualAccountName,
         addedIds,
+        importedTransactions,
         intendedCategoryByImportedId,
     }: {
-        actualAccountId: string;
         actualAccountName: string;
         addedIds: string[];
+        importedTransactions: ReadTransaction[];
         intendedCategoryByImportedId: Map<string, string>;
     }): Promise<number> {
-        const freshTransactions = await this.actualApi.getTransactionsByIds(
-            actualAccountId,
-            addedIds
+        const addedIdSet = new Set(addedIds);
+        const freshTransactions = importedTransactions.filter((transaction) =>
+            addedIdSet.has(transaction.id)
         );
 
         let overrideCount = 0;
@@ -1551,23 +1565,38 @@ class Importer {
         });
     }
 
-    private async applyTransferCounterpartUpdates({
-        actualAccount,
-        importedTransactionIds,
-        transferPlan,
+    private async getExistingTransactionsForStartBalanceCheck({
+        actualAccountId,
+        existingActualTransactions,
+        transfersEnabled,
+        isDryRun,
     }: {
-        actualAccount: Account;
-        importedTransactionIds: string[];
-        transferPlan: TransferPlan;
-    }) {
-        if (importedTransactionIds.length === 0) {
-            return;
+        actualAccountId: string;
+        existingActualTransactions: ReadTransaction[];
+        transfersEnabled: boolean;
+        isDryRun: boolean;
+    }): Promise<ReadTransaction[]> {
+        if (
+            existingActualTransactions.length > 0 ||
+            !transfersEnabled ||
+            isDryRun
+        ) {
+            return existingActualTransactions;
         }
 
-        const importedTransactions = await this.actualApi.getTransactionsByIds(
-            actualAccount.id,
-            importedTransactionIds
-        );
+        return this.actualApi.getTransactions(actualAccountId);
+    }
+
+    private async applyTransferCounterpartUpdates({
+        importedTransactions,
+        transferPlan,
+    }: {
+        importedTransactions: ReadTransaction[];
+        transferPlan: TransferPlan;
+    }) {
+        if (importedTransactions.length === 0) {
+            return;
+        }
 
         for (const transaction of importedTransactions) {
             if (!transaction.imported_id) {

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1,4 +1,4 @@
-import { format, subMonths } from 'date-fns';
+import { differenceInCalendarDays, format, subMonths } from 'date-fns';
 import chalk from 'chalk';
 import { stdin, stdout } from 'node:process';
 import { createInterface } from 'node:readline/promises';
@@ -74,6 +74,32 @@ type DuplicateImportedIdGroup = {
     representativeTransaction: ReadTransaction;
     normalizedPayee: string;
     isLikelySplit: boolean;
+};
+type TransferPlan = {
+    seedByImportedId: Map<string, PlannedTransferSeed>;
+    suppressedImportedIds: Set<string>;
+};
+type PlannedTransferSeed = {
+    importedId: string;
+    transferPayeeId: string;
+    targetActualAccountId: string;
+    targetActualAccountName: string;
+    sameRunCounterpart?: PlannedTransferCounterpart;
+};
+type PlannedTransferCounterpart = {
+    importedId: string;
+    importedPayee: string;
+    notes?: string;
+    cleared?: boolean;
+};
+type TransferPlanningCandidate = {
+    transaction: MonMonTransaction;
+    importedId: string;
+    sourceMonMonAccount: MonMonAccount;
+    sourceActualAccount: Account;
+    targetMonMonAccount: MonMonAccount;
+    targetActualAccount: Account;
+    transferPayeeId: string;
 };
 
 export const classifyCategoryUpdate = ({
@@ -336,11 +362,30 @@ class Importer {
             {} as Record<string, MonMonTransaction[]>
         );
 
-        const accountMapping = this.accountMap.getMap(accountRefs);
+        const fullAccountMapping = this.accountMap.getMap();
+        const accountMapping = accountRefs
+            ? this.accountMap.getMap(accountRefs)
+            : fullAccountMapping;
+        const existingActualTransactionsByAccountId = new Map<
+            string,
+            ReadTransaction[]
+        >();
+
+        for (const [, actualAccount] of fullAccountMapping) {
+            existingActualTransactionsByAccountId.set(
+                actualAccount.id,
+                await this.actualApi.getTransactions(actualAccount.id)
+            );
+        }
 
         let existingPayeeNames: string[] = [];
+        const shouldLoadPayeesForTransfers =
+            this.config.import.transfers.enabled;
+        const existingPayees =
+            (this.payeeTransformer && !isDryRun) || shouldLoadPayeesForTransfers
+                ? await this.actualApi.getPayees()
+                : [];
         if (this.payeeTransformer && !isDryRun) {
-            const existingPayees = await this.actualApi.getPayees();
             existingPayeeNames = existingPayees
                 .filter(
                     (p: { name: string; transfer_acct?: string }) =>
@@ -353,8 +398,55 @@ class Importer {
             );
         }
 
-        const unmappedCategoryWarnings = new Set<string>();
+        const transferPayeeIdByAccountId = new Map(
+            existingPayees
+                .filter((payee) => payee.transfer_acct)
+                .map((payee) => [payee.transfer_acct as string, payee.id])
+        );
         const shouldSyncCategories = this.config.import.synchronizeCategories;
+
+        const accountStates = Array.from(accountMapping.entries()).map(
+            ([monMonAccount, actualAccount]) => {
+                const accountTransactions =
+                    monMonTransactionMap[monMonAccount.uuid] ?? [];
+                const existingActualTransactions =
+                    existingActualTransactionsByAccountId.get(
+                        actualAccount.id
+                    ) ?? [];
+                const { newMonMonTransactions, existingPairs } =
+                    this.buildAccountTransactionBuckets({
+                        monMonAccount,
+                        accountTransactions,
+                        existingActualTransactions,
+                        actualAccountName: actualAccount.name,
+                        shouldSyncCategories,
+                    });
+
+                return {
+                    monMonAccount,
+                    actualAccount,
+                    accountTransactions,
+                    existingActualTransactions,
+                    newMonMonTransactions,
+                    existingPairs,
+                };
+            }
+        );
+
+        const transferPlan = this.config.import.transfers.enabled
+            ? this.buildTransferPlan({
+                  fullAccountMapping,
+                  accountStates,
+                  monMonTransactionMap,
+                  existingActualTransactionsByAccountId,
+                  transferPayeeIdByAccountId,
+              })
+            : {
+                  seedByImportedId: new Map<string, PlannedTransferSeed>(),
+                  suppressedImportedIds: new Set<string>(),
+              };
+
+        const unmappedCategoryWarnings = new Set<string>();
         const runMetrics: ImportRunMetrics = {
             accountsScanned: 0,
             accountsWithImportActivity: 0,
@@ -375,30 +467,35 @@ class Importer {
         const promptState: PromptState = { mode: 'prompt' };
 
         try {
-            for (const [monMonAccount, actualAccount] of accountMapping) {
+            for (const {
+                monMonAccount,
+                actualAccount,
+                accountTransactions,
+                existingActualTransactions,
+                newMonMonTransactions,
+                existingPairs,
+            } of accountStates) {
                 runMetrics.accountsScanned++;
-                const accountTransactions =
-                    monMonTransactionMap[monMonAccount.uuid] ?? [];
-
-                const existingActualTransactions =
-                    await this.actualApi.getTransactions(actualAccount.id);
-                const { newMonMonTransactions, existingPairs } =
-                    this.buildAccountTransactionBuckets({
-                        monMonAccount,
-                        accountTransactions,
-                        existingActualTransactions,
-                        actualAccountName: actualAccount.name,
-                        shouldSyncCategories,
-                    });
 
                 const createTransactions: CreateTransaction[] = [];
                 // Maps imported_id → intended category ID (for auto-rule override detection).
                 const intendedCategoryByImportedId = new Map<string, string>();
                 for (const transaction of newMonMonTransactions) {
-                    const createTransaction =
-                        await this.convertToActualTransaction(transaction);
+                    const importedId =
+                        this.getIdForMoneyMoneyTransaction(transaction);
+                    if (transferPlan.suppressedImportedIds.has(importedId)) {
+                        continue;
+                    }
 
-                    if (shouldSyncCategories) {
+                    const plannedTransfer =
+                        transferPlan.seedByImportedId.get(importedId);
+                    const createTransaction =
+                        await this.convertToActualTransaction(
+                            transaction,
+                            plannedTransfer
+                        );
+
+                    if (shouldSyncCategories && !plannedTransfer) {
                         const categoryResolution =
                             this.categoryMap.getMappedActualCategoryId(
                                 transaction.categoryUuid
@@ -462,9 +559,9 @@ class Importer {
                     );
 
                     if (this.payeeTransformer && !isDryRun) {
-                        const transactionPayees = createTransactions.map(
-                            (t) => t.imported_payee as string
-                        );
+                        const transactionPayees = createTransactions
+                            .filter((t) => !t.payee)
+                            .map((t) => t.imported_payee as string);
                         const uniquePayees = [
                             ...new Set(transactionPayees),
                         ].filter((p) => p && p.trim());
@@ -481,6 +578,9 @@ class Importer {
 
                         if (transformedPayees !== null) {
                             createTransactions.forEach((t) => {
+                                if (t.payee) {
+                                    return;
+                                }
                                 t.payee_name =
                                     transformedPayees[
                                         t.imported_payee as string
@@ -504,11 +604,17 @@ class Importer {
                             );
 
                             createTransactions.forEach((t) => {
+                                if (t.payee) {
+                                    return;
+                                }
                                 t.payee_name = t.imported_payee ?? '';
                             });
                         }
                     } else {
                         createTransactions.forEach((t) => {
+                            if (t.payee) {
+                                return;
+                            }
                             t.payee_name = t.imported_payee ?? '';
                         });
                     }
@@ -547,6 +653,15 @@ class Importer {
                                 `Updated ${result.updated.length} existing transaction.`,
                             ]
                         );
+
+                        await this.applyTransferCounterpartUpdates({
+                            actualAccount,
+                            importedTransactionIds: [
+                                ...result.added,
+                                ...result.updated,
+                            ],
+                            transferPlan,
+                        });
 
                         if (
                             intendedCategoryByImportedId.size > 0 &&
@@ -1133,6 +1248,361 @@ class Importer {
         );
     }
 
+    private buildTransferPlan({
+        fullAccountMapping,
+        accountStates,
+        monMonTransactionMap,
+        existingActualTransactionsByAccountId,
+        transferPayeeIdByAccountId,
+    }: {
+        fullAccountMapping: Map<MonMonAccount, Account>;
+        accountStates: Array<{
+            monMonAccount: MonMonAccount;
+            actualAccount: Account;
+            newMonMonTransactions: MonMonTransaction[];
+        }>;
+        monMonTransactionMap: Record<string, MonMonTransaction[]>;
+        existingActualTransactionsByAccountId: Map<string, ReadTransaction[]>;
+        transferPayeeIdByAccountId: Map<string, string>;
+    }): TransferPlan {
+        const emptyPlan: TransferPlan = {
+            seedByImportedId: new Map<string, PlannedTransferSeed>(),
+            suppressedImportedIds: new Set<string>(),
+        };
+
+        const transferConfig = this.config.import.transfers;
+        if (
+            !transferConfig.enabled ||
+            transferConfig.categoryRefs.length === 0
+        ) {
+            return emptyPlan;
+        }
+
+        const { resolvedUuids, invalidRefs } =
+            this.categoryMap.resolveMoneyMoneyCategoryRefs(
+                transferConfig.categoryRefs
+            );
+
+        if (invalidRefs.length > 0) {
+            throw new Error(
+                `Invalid transfer category refs: ${invalidRefs
+                    .map(({ ref, reason }) => `${ref} (${reason})`)
+                    .join('; ')}`
+            );
+        }
+
+        if (resolvedUuids.size === 0) {
+            return emptyPlan;
+        }
+
+        const mappedAccounts = Array.from(fullAccountMapping.entries()).map(
+            ([monMonAccount, actualAccount]) => ({
+                monMonAccount,
+                actualAccount,
+            })
+        );
+        const newTransactionsByAccountUuid = Object.fromEntries(
+            accountStates.map(({ monMonAccount, newMonMonTransactions }) => [
+                monMonAccount.uuid,
+                newMonMonTransactions,
+            ])
+        ) as Record<string, MonMonTransaction[]>;
+        const mappedByAccountNumber = new Map<
+            string,
+            Array<{
+                monMonAccount: MonMonAccount;
+                actualAccount: Account;
+            }>
+        >();
+        for (const entry of mappedAccounts) {
+            const accountNumber = entry.monMonAccount.accountNumber;
+            if (!accountNumber) {
+                continue;
+            }
+
+            const entries = mappedByAccountNumber.get(accountNumber) ?? [];
+            entries.push(entry);
+            mappedByAccountNumber.set(accountNumber, entries);
+        }
+        const ambiguousMappedAccountNumbers = new Set(
+            Array.from(mappedByAccountNumber.entries())
+                .filter(([, entries]) => entries.length > 1)
+                .map(([accountNumber]) => accountNumber)
+        );
+        for (const accountNumber of ambiguousMappedAccountNumbers) {
+            this.logger.warn(
+                `Automatic transfer detection is disabled for mapped account number '${accountNumber}' because it resolves to multiple MoneyMoney accounts.`
+            );
+        }
+
+        const candidates: TransferPlanningCandidate[] = [];
+
+        for (const { monMonAccount, actualAccount } of mappedAccounts) {
+            const accountTransactions =
+                newTransactionsByAccountUuid[monMonAccount.uuid] ?? [];
+
+            for (const transaction of accountTransactions) {
+                if (!resolvedUuids.has(transaction.categoryUuid)) {
+                    continue;
+                }
+
+                if (!transaction.accountNumber) {
+                    continue;
+                }
+
+                if (
+                    ambiguousMappedAccountNumbers.has(transaction.accountNumber)
+                ) {
+                    continue;
+                }
+
+                const target = mappedByAccountNumber.get(
+                    transaction.accountNumber
+                )?.[0];
+
+                if (
+                    !target ||
+                    target.monMonAccount.uuid === monMonAccount.uuid
+                ) {
+                    continue;
+                }
+
+                const transferPayeeId = transferPayeeIdByAccountId.get(
+                    target.actualAccount.id
+                );
+                if (!transferPayeeId) {
+                    continue;
+                }
+
+                candidates.push({
+                    transaction,
+                    importedId: this.getIdForMoneyMoneyTransaction(transaction),
+                    sourceMonMonAccount: monMonAccount,
+                    sourceActualAccount: actualAccount,
+                    targetMonMonAccount: target.monMonAccount,
+                    targetActualAccount: target.actualAccount,
+                    transferPayeeId,
+                });
+            }
+        }
+
+        candidates.sort((a, b) => a.importedId.localeCompare(b.importedId));
+
+        const seedByImportedId = new Map<string, PlannedTransferSeed>();
+        const suppressedImportedIds = new Set<string>();
+        const claimedCounterpartIds = new Set<string>();
+
+        for (const candidate of candidates) {
+            if (suppressedImportedIds.has(candidate.importedId)) {
+                continue;
+            }
+
+            const matchingCounterparts = this.findMatchingTransferCounterparts({
+                candidate,
+                monMonTransactionMap: newTransactionsByAccountUuid,
+                matchWindowDays: transferConfig.matchWindowDays,
+            });
+
+            if (matchingCounterparts.length > 1) {
+                this.logger.debug(
+                    `Skipping automatic transfer for '${candidate.importedId}' because multiple same-run counterpart candidates were found.`
+                );
+                continue;
+            }
+
+            const sameRunCounterpart = matchingCounterparts[0];
+            if (sameRunCounterpart) {
+                const counterpartImportedId =
+                    this.getIdForMoneyMoneyTransaction(sameRunCounterpart);
+                if (claimedCounterpartIds.has(counterpartImportedId)) {
+                    this.logger.debug(
+                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${counterpartImportedId}' was already claimed by another transfer seed.`
+                    );
+                    continue;
+                }
+
+                const existingTargetTransactions =
+                    existingActualTransactionsByAccountId.get(
+                        candidate.targetActualAccount.id
+                    ) ?? [];
+                if (
+                    existingTargetTransactions.some(
+                        (transaction) =>
+                            transaction.imported_id === counterpartImportedId
+                    )
+                ) {
+                    this.logger.debug(
+                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${counterpartImportedId}' already exists in Actual.`
+                    );
+                    continue;
+                }
+
+                suppressedImportedIds.add(counterpartImportedId);
+                claimedCounterpartIds.add(counterpartImportedId);
+
+                seedByImportedId.set(candidate.importedId, {
+                    importedId: candidate.importedId,
+                    transferPayeeId: candidate.transferPayeeId,
+                    targetActualAccountId: candidate.targetActualAccount.id,
+                    targetActualAccountName: candidate.targetActualAccount.name,
+                    sameRunCounterpart: {
+                        importedId: counterpartImportedId,
+                        importedPayee: sameRunCounterpart.name ?? '',
+                        notes:
+                            this.buildTransactionNotes(sameRunCounterpart) ||
+                            '',
+                        ...(this.config.import.synchronizeClearedStatus
+                            ? { cleared: sameRunCounterpart.booked }
+                            : {}),
+                    },
+                });
+                continue;
+            }
+
+            const existingCounterparts = this.findMatchingTransferCounterparts({
+                candidate,
+                monMonTransactionMap,
+                matchWindowDays: transferConfig.matchWindowDays,
+            });
+            if (existingCounterparts.length > 1) {
+                this.logger.debug(
+                    `Skipping automatic transfer for '${candidate.importedId}' because multiple historical counterpart candidates were found.`
+                );
+                continue;
+            }
+
+            const existingCounterpart = existingCounterparts[0];
+            if (existingCounterpart) {
+                const existingCounterpartImportedId =
+                    this.getIdForMoneyMoneyTransaction(existingCounterpart);
+                const existingTargetTransactions =
+                    existingActualTransactionsByAccountId.get(
+                        candidate.targetActualAccount.id
+                    ) ?? [];
+                if (
+                    existingTargetTransactions.some(
+                        (transaction) =>
+                            transaction.imported_id ===
+                            existingCounterpartImportedId
+                    )
+                ) {
+                    this.logger.debug(
+                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${existingCounterpartImportedId}' was already imported in an earlier run.`
+                    );
+                    continue;
+                }
+            }
+
+            seedByImportedId.set(candidate.importedId, {
+                importedId: candidate.importedId,
+                transferPayeeId: candidate.transferPayeeId,
+                targetActualAccountId: candidate.targetActualAccount.id,
+                targetActualAccountName: candidate.targetActualAccount.name,
+            });
+        }
+
+        this.logger.debug(
+            `Automatic transfer planning: seeds=${seedByImportedId.size}, suppressedCounterparts=${suppressedImportedIds.size}`
+        );
+
+        return {
+            seedByImportedId,
+            suppressedImportedIds,
+        };
+    }
+
+    private findMatchingTransferCounterparts({
+        candidate,
+        monMonTransactionMap,
+        matchWindowDays,
+    }: {
+        candidate: TransferPlanningCandidate;
+        monMonTransactionMap: Record<string, MonMonTransaction[]>;
+        matchWindowDays: number;
+    }): MonMonTransaction[] {
+        const targetTransactions =
+            monMonTransactionMap[candidate.targetMonMonAccount.uuid] ?? [];
+        const sourceAmount = Math.round(candidate.transaction.amount * 100);
+
+        return targetTransactions.filter((transaction) => {
+            const candidateImportedId =
+                this.getIdForMoneyMoneyTransaction(transaction);
+            const hasMatchingPurpose =
+                !!candidate.transaction.purpose &&
+                !!transaction.purpose &&
+                candidate.transaction.purpose === transaction.purpose;
+            const hasReciprocalAccountNumber =
+                !!transaction.accountNumber &&
+                !!candidate.sourceMonMonAccount.accountNumber &&
+                transaction.accountNumber ===
+                    candidate.sourceMonMonAccount.accountNumber;
+
+            return (
+                candidateImportedId !== candidate.importedId &&
+                Math.round(transaction.amount * 100) === -sourceAmount &&
+                (hasMatchingPurpose || hasReciprocalAccountNumber) &&
+                Math.abs(
+                    differenceInCalendarDays(
+                        transaction.valueDate,
+                        candidate.transaction.valueDate
+                    )
+                ) <= matchWindowDays
+            );
+        });
+    }
+
+    private async applyTransferCounterpartUpdates({
+        actualAccount,
+        importedTransactionIds,
+        transferPlan,
+    }: {
+        actualAccount: Account;
+        importedTransactionIds: string[];
+        transferPlan: TransferPlan;
+    }) {
+        if (importedTransactionIds.length === 0) {
+            return;
+        }
+
+        const importedTransactions = await this.actualApi.getTransactionsByIds(
+            actualAccount.id,
+            importedTransactionIds
+        );
+
+        for (const transaction of importedTransactions) {
+            if (!transaction.imported_id) {
+                continue;
+            }
+
+            const plannedSeed = transferPlan.seedByImportedId.get(
+                transaction.imported_id
+            );
+            if (!plannedSeed?.sameRunCounterpart || !transaction.transfer_id) {
+                continue;
+            }
+
+            const counterpartUpdate: Partial<UpdateTransaction> = {
+                imported_id: plannedSeed.sameRunCounterpart.importedId,
+                imported_payee: plannedSeed.sameRunCounterpart.importedPayee,
+                notes: plannedSeed.sameRunCounterpart.notes ?? '',
+            };
+
+            if (plannedSeed.sameRunCounterpart.cleared !== undefined) {
+                counterpartUpdate.cleared =
+                    plannedSeed.sameRunCounterpart.cleared;
+            }
+
+            await this.actualApi.updateTransaction(
+                transaction.transfer_id,
+                counterpartUpdate
+            );
+
+            this.logger.debug(
+                `Stamped generated transfer counterpart '${transaction.transfer_id}' in '${plannedSeed.targetActualAccountName}' with imported_id '${plannedSeed.sameRunCounterpart.importedId}'.`
+            );
+        }
+    }
+
     private async promptForConflictDecision(
         promptInterface: ReturnType<typeof createInterface>,
         pair: ExistingTransactionPair,
@@ -1163,16 +1633,10 @@ class Importer {
     }
 
     private async convertToActualTransaction(
-        transaction: MonMonTransaction
+        transaction: MonMonTransaction,
+        plannedTransfer?: PlannedTransferSeed
     ): Promise<CreateTransaction> {
-        const transactionNotes = [
-            transaction.purpose,
-            transaction.comment && this.config.import.importComments
-                ? `${this.config.import.commentPrefix}${transaction.comment}`
-                : undefined,
-        ]
-            .filter(Boolean)
-            .join(' | ');
+        const transactionNotes = this.buildTransactionNotes(transaction);
 
         const createTransaction: CreateTransaction = {
             date: format(transaction.valueDate, 'yyyy-MM-dd'),
@@ -1180,6 +1644,10 @@ class Importer {
             imported_id: this.getIdForMoneyMoneyTransaction(transaction),
             imported_payee: transaction.name ?? '',
         };
+
+        if (plannedTransfer) {
+            createTransaction.payee = plannedTransfer.transferPayeeId;
+        }
 
         if (this.config.import.synchronizeClearedStatus) {
             createTransaction.cleared = transaction.booked;
@@ -1190,6 +1658,17 @@ class Importer {
         }
 
         return createTransaction;
+    }
+
+    private buildTransactionNotes(transaction: MonMonTransaction): string {
+        return [
+            transaction.purpose,
+            transaction.comment && this.config.import.importComments
+                ? `${this.config.import.commentPrefix}${transaction.comment}`
+                : undefined,
+        ]
+            .filter(Boolean)
+            .join(' | ');
     }
 
     private getIdForMoneyMoneyTransaction(transaction: MonMonTransaction) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,6 +57,7 @@ const transferImportSchema = z.object({
     categoryRefs: z.array(z.string()).default([]),
     matchWindowDays: z.number().int().min(0).default(5),
 });
+const defaultTransferImportConfig = transferImportSchema.parse({});
 
 export const configSchema = z
     .object({
@@ -70,11 +71,9 @@ export const configSchema = z
                 .default('ask'),
             importComments: z.boolean().default(false),
             commentPrefix: z.string().default('MoneyMoney Comment: '),
-            transfers: transferImportSchema.default({
-                enabled: false,
-                categoryRefs: [],
-                matchWindowDays: 5,
-            }),
+            transfers: transferImportSchema.default(
+                defaultTransferImportConfig
+            ),
             ignorePatterns: z
                 .object({
                     commentPatterns: z.array(z.string()).optional(),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -52,6 +52,12 @@ const payeeTransformationSchema = z.object({
     prompt: z.string().optional(),
 });
 
+const transferImportSchema = z.object({
+    enabled: z.boolean().default(false),
+    categoryRefs: z.array(z.string()).default([]),
+    matchWindowDays: z.number().int().min(0).default(5),
+});
+
 export const configSchema = z
     .object({
         payeeTransformation: payeeTransformationSchema,
@@ -64,6 +70,11 @@ export const configSchema = z
                 .default('ask'),
             importComments: z.boolean().default(false),
             commentPrefix: z.string().default('MoneyMoney Comment: '),
+            transfers: transferImportSchema.default({
+                enabled: false,
+                categoryRefs: [],
+                matchWindowDays: 5,
+            }),
             ignorePatterns: z
                 .object({
                     commentPatterns: z.array(z.string()).optional(),
@@ -84,6 +95,18 @@ export const configSchema = z
                 code: 'custom',
                 message:
                     'OpenAI key must not be empty if payeeTransformation is enabled',
+            });
+        }
+
+        if (
+            val.import.transfers.enabled &&
+            val.import.transfers.categoryRefs.length === 0
+        ) {
+            ctx.addIssue({
+                code: 'custom',
+                message:
+                    'At least one transfer category ref must be configured if automatic transfers are enabled',
+                path: ['import', 'transfers', 'categoryRefs'],
             });
         }
     });

--- a/test/unit/category-map.test.mjs
+++ b/test/unit/category-map.test.mjs
@@ -196,6 +196,100 @@ test('ambiguous name matches do not produce suggestions', () => {
     assert.equal(report.safeSuggestions.length, 0);
 });
 
+test('resolveMoneyMoneyCategoryRefs accepts UUID, path, and leaf name refs', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-root',
+                name: 'Umbuchungen',
+                group: true,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer',
+                name: 'Echte Umbuchungen',
+                indentation: 1,
+            }),
+        ],
+        [],
+        []
+    );
+
+    const resolved = map.resolveMoneyMoneyCategoryRefs([
+        'mm-transfer',
+        'Umbuchungen > Echte Umbuchungen',
+        'Echte Umbuchungen',
+    ]);
+
+    assert.deepEqual([...resolved.resolvedUuids], ['mm-transfer']);
+    assert.deepEqual(resolved.invalidRefs, []);
+});
+
+test('resolveMoneyMoneyCategoryRefs reports ambiguous leaf name refs', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-root-a',
+                name: 'A',
+                group: true,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-root-b',
+                name: 'B',
+                group: true,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer-a',
+                name: 'Transfer',
+                indentation: 1,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer-b',
+                name: 'Transfer',
+                indentation: 1,
+            }),
+        ],
+        [],
+        []
+    );
+
+    const resolved = map.resolveMoneyMoneyCategoryRefs(['Transfer']);
+
+    assert.deepEqual([...resolved.resolvedUuids], []);
+    assert.equal(resolved.invalidRefs.length, 1);
+    assert.match(
+        resolved.invalidRefs[0]?.reason ?? '',
+        /Ambiguous MoneyMoney category ref 'Transfer'/
+    );
+});
+
 test('getCanonicalMapping excludes suggestions when includeSuggestions is false', () => {
     const budgetConfig = {
         syncId: 'sync-id',

--- a/test/unit/category-map.test.mjs
+++ b/test/unit/category-map.test.mjs
@@ -238,6 +238,48 @@ test('resolveMoneyMoneyCategoryRefs accepts UUID, path, and leaf name refs', () 
     assert.deepEqual(resolved.invalidRefs, []);
 });
 
+test('resolveMoneyMoneyCategoryRefs rejects refs that resolve to a category group', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-root',
+                name: 'Umbuchungen',
+                group: true,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer',
+                name: 'Echte Umbuchungen',
+                indentation: 1,
+            }),
+        ],
+        [],
+        []
+    );
+
+    const resolved = map.resolveMoneyMoneyCategoryRefs(['Umbuchungen']);
+
+    assert.deepEqual([...resolved.resolvedUuids], []);
+    assert.equal(resolved.invalidRefs.length, 1);
+    assert.match(
+        resolved.invalidRefs[0]?.reason ?? '',
+        /resolved to a category group/
+    );
+});
+
 test('resolveMoneyMoneyCategoryRefs reports ambiguous leaf name refs', () => {
     const budgetConfig = {
         syncId: 'sync-id',

--- a/test/unit/category-map.test.mjs
+++ b/test/unit/category-map.test.mjs
@@ -280,6 +280,62 @@ test('resolveMoneyMoneyCategoryRefs rejects refs that resolve to a category grou
     );
 });
 
+test('configured categoryMapping rejects MoneyMoney category groups', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {
+            Umbuchungen: 'actual-transfer',
+        },
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-root',
+                name: 'Umbuchungen',
+                group: true,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer',
+                name: 'Echte Umbuchungen',
+                indentation: 1,
+            }),
+        ],
+        [
+            {
+                id: 'actual-transfer',
+                name: 'Transfer',
+                group_id: 'group-expenses',
+                is_income: false,
+            },
+        ],
+        [
+            {
+                id: 'group-expenses',
+                name: 'Expenses',
+                is_income: false,
+            },
+        ]
+    );
+
+    const report = map.getReport();
+    assert.equal(report.configuredMappings.length, 0);
+    assert.equal(report.invalidMappings.length, 1);
+    assert.match(
+        report.invalidMappings[0]?.reason ?? '',
+        /category groups cannot be mapped/
+    );
+});
+
 test('resolveMoneyMoneyCategoryRefs reports ambiguous leaf name refs', () => {
     const budgetConfig = {
         syncId: 'sync-id',

--- a/test/unit/config-defaults.test.mjs
+++ b/test/unit/config-defaults.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { ZodError } from 'zod';
 import { configSchema } from '../../dist/utils/config.js';
 
 test('config defaults synchronizeCategories to false when omitted', () => {
@@ -28,4 +29,47 @@ test('config defaults synchronizeCategories to false when omitted', () => {
     });
 
     assert.equal(parsed.import.synchronizeCategories, false);
+    assert.equal(parsed.import.transfers.enabled, false);
+    assert.deepEqual(parsed.import.transfers.categoryRefs, []);
+    assert.equal(parsed.import.transfers.matchWindowDays, 5);
+});
+
+test('automatic transfers require at least one category ref when enabled', () => {
+    assert.throws(
+        () =>
+            configSchema.parse({
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                    transfers: {
+                        enabled: true,
+                        categoryRefs: [],
+                    },
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'pw',
+                        budgets: [
+                            {
+                                syncId: 'budget-id',
+                                e2eEncryption: {
+                                    enabled: false,
+                                },
+                                accountMapping: {},
+                            },
+                        ],
+                    },
+                ],
+            }),
+        (error) =>
+            error instanceof ZodError &&
+            error.issues.some((issue) =>
+                issue.message.includes(
+                    'At least one transfer category ref must be configured'
+                )
+            )
+    );
 });

--- a/test/unit/importer-category-sync-flow.test.mjs
+++ b/test/unit/importer-category-sync-flow.test.mjs
@@ -483,21 +483,19 @@ test('detectAndWarnAutoRuleOverrides warns when stored category differs from int
         mappingByUuid: {},
     });
 
-    importer.actualApi.getTransactionsByIds = async (_accountId, _ids) => [
-        {
-            id: 'actual-imp-1',
-            imported_id: 'imp-1',
-            imported_payee: 'Amazon',
-            category: 'cat-auto-rule',
-            date: '2026-02-23',
-            amount: -500,
-        },
-    ];
-
     const overrideCount = await importer.detectAndWarnAutoRuleOverrides({
-        actualAccountId: 'acc-1',
         actualAccountName: 'Checking',
         addedIds: ['actual-imp-1'],
+        importedTransactions: [
+            {
+                id: 'actual-imp-1',
+                imported_id: 'imp-1',
+                imported_payee: 'Amazon',
+                category: 'cat-auto-rule',
+                date: '2026-02-23',
+                amount: -500,
+            },
+        ],
         intendedCategoryByImportedId: new Map([['imp-1', 'cat-intended']]),
     });
 
@@ -514,21 +512,19 @@ test('detectAndWarnAutoRuleOverrides warns when stored category differs from int
 test('detectAndWarnAutoRuleOverrides is silent when stored category matches intended', async () => {
     const { importer, logger } = makeImporter();
 
-    importer.actualApi.getTransactionsByIds = async (_accountId, _ids) => [
-        {
-            id: 'actual-imp-1',
-            imported_id: 'imp-1',
-            imported_payee: 'Rewe',
-            category: 'cat-intended',
-            date: '2026-02-23',
-            amount: -200,
-        },
-    ];
-
     const overrideCount = await importer.detectAndWarnAutoRuleOverrides({
-        actualAccountId: 'acc-1',
         actualAccountName: 'Checking',
         addedIds: ['actual-imp-1'],
+        importedTransactions: [
+            {
+                id: 'actual-imp-1',
+                imported_id: 'imp-1',
+                imported_payee: 'Rewe',
+                category: 'cat-intended',
+                date: '2026-02-23',
+                amount: -200,
+            },
+        ],
         intendedCategoryByImportedId: new Map([['imp-1', 'cat-intended']]),
     });
 
@@ -539,22 +535,20 @@ test('detectAndWarnAutoRuleOverrides is silent when stored category matches inte
 test('detectAndWarnAutoRuleOverrides ignores transactions not in the intended-category map', async () => {
     const { importer, logger } = makeImporter();
 
-    importer.actualApi.getTransactionsByIds = async (_accountId, _ids) => [
-        {
-            id: 'actual-imp-2',
-            imported_id: 'imp-2',
-            imported_payee: 'Dm',
-            category: 'cat-whatever',
-            date: '2026-02-23',
-            amount: -100,
-        },
-    ];
-
     // intendedCategoryByImportedId only has 'imp-1', not 'imp-2'
     const overrideCount = await importer.detectAndWarnAutoRuleOverrides({
-        actualAccountId: 'acc-1',
         actualAccountName: 'Checking',
         addedIds: ['actual-imp-2'],
+        importedTransactions: [
+            {
+                id: 'actual-imp-2',
+                imported_id: 'imp-2',
+                imported_payee: 'Dm',
+                category: 'cat-whatever',
+                date: '2026-02-23',
+                amount: -100,
+            },
+        ],
         intendedCategoryByImportedId: new Map([['imp-1', 'cat-intended']]),
     });
 

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -310,6 +310,7 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
         accountUuid: targetMonMon.uuid,
         amount: 1440,
         categoryUuid: 'mm-uncategorized',
+        valueDate: '2026-04-23',
         name: 'Einzahlung',
         purpose: 'Ruecklagen',
         comment: 'memo',
@@ -351,6 +352,7 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
     assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
     assert.equal(counterpart?.importedId, 'mm-target-200');
     assert.equal(counterpart?.importedPayee, 'Einzahlung');
+    assert.equal(counterpart?.date, '2026-04-23');
     assert.equal(counterpart?.notes, 'Ruecklagen | Comment: memo');
     assert.equal(counterpart?.cleared, true);
 });
@@ -738,6 +740,7 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
                         sameRunCounterpart: {
                             importedId: 'mm-target-200',
                             importedPayee: 'Einzahlung',
+                            date: '2026-04-23',
                             notes: 'Ruecklagen',
                             cleared: true,
                         },
@@ -754,6 +757,7 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
         {
             imported_id: 'mm-target-200',
             imported_payee: 'Einzahlung',
+            date: '2026-04-23',
             notes: 'Ruecklagen',
             cleared: true,
         },

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -1,0 +1,689 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import Importer from '../../dist/utils/Importer.js';
+
+const makeLogger = () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+});
+
+const makeMonMonAccount = ({ uuid, name, accountNumber }) => ({
+    uuid,
+    name,
+    accountNumber,
+    balance: [[0]],
+});
+
+const makeActualAccount = ({ id, name }) => ({
+    id,
+    name,
+    type: 'checking',
+    offbudget: false,
+});
+
+const makeFullAccountMapping = (entries) => new Map(entries);
+
+const makeTransaction = ({
+    id,
+    accountUuid,
+    amount,
+    categoryUuid = 'mm-transfer',
+    accountNumber,
+    valueDate = '2026-04-21',
+    booked = true,
+    name = 'Txn',
+    purpose = 'Purpose',
+    comment,
+}) => ({
+    id,
+    accountUuid,
+    amount,
+    categoryUuid,
+    accountNumber,
+    valueDate: new Date(valueDate),
+    bookingDate: new Date(valueDate),
+    booked,
+    name,
+    purpose,
+    comment,
+});
+
+const makeImporter = ({
+    synchronizeClearedStatus = true,
+    importComments = true,
+    resolvedTransferCategoryUuids = new Set(['mm-transfer']),
+    invalidTransferRefs = [],
+    getTransactionsByIds = async () => [],
+    updateTransaction = async () => {},
+} = {}) => {
+    const logger = makeLogger();
+    const actualApi = {
+        getTransactionsByIds,
+        updateTransaction,
+    };
+    const categoryMap = {
+        resolveMoneyMoneyCategoryRefs: () => ({
+            resolvedUuids: resolvedTransferCategoryUuids,
+            invalidRefs: invalidTransferRefs,
+        }),
+        getActualCategoryPath: (categoryId) => categoryId,
+    };
+    const config = {
+        import: {
+            synchronizeClearedStatus,
+            synchronizeCategories: false,
+            categorySyncOnExisting: 'new',
+            importComments,
+            commentPrefix: 'Comment: ',
+            transfers: {
+                enabled: true,
+                categoryRefs: ['Transfer'],
+                matchWindowDays: 5,
+            },
+        },
+        payeeTransformation: {
+            enabled: false,
+        },
+    };
+
+    return new Importer(
+        config,
+        {},
+        actualApi,
+        logger,
+        { getMap: () => new Map() },
+        categoryMap
+    );
+};
+
+test('buildTransferPlan creates delayed transfer seed from hard target account match', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        name: 'Jens Bergmann',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.transferPayeeId,
+        'payee-target'
+    );
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
+        undefined
+    );
+});
+
+test('buildTransferPlan can seed transfer when only source account is selected', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        name: 'Jens Bergmann',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.targetActualAccountId,
+        'actual-target'
+    );
+});
+
+test('buildTransferPlan skips automatic transfer when mapped account numbers are ambiguous', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMonA = makeMonMonAccount({
+        uuid: 'mm-target-a',
+        name: 'Target A',
+        accountNumber: 'DE-TARGET',
+    });
+    const targetMonMonB = makeMonMonAccount({
+        uuid: 'mm-target-b',
+        name: 'Target B',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActualA = makeActualAccount({
+        id: 'actual-target-a',
+        name: 'B',
+    });
+    const targetActualB = makeActualAccount({
+        id: 'actual-target-b',
+        name: 'C',
+    });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: 'DE-TARGET',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMonA, targetActualA],
+            [targetMonMonB, targetActualB],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMonA.uuid]: [],
+            [targetMonMonB.uuid]: [],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActualA.id, []],
+            [targetActualB.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActualA.id, 'payee-a'],
+            [targetActualB.id, 'payee-b'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+});
+
+test('buildTransferPlan suppresses unique same-run counterpart and carries metadata', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        name: 'Jens Bergmann',
+        purpose: 'Ruecklagen',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        name: 'Einzahlung',
+        purpose: 'Ruecklagen',
+        comment: 'memo',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    const counterpart =
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart;
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
+    assert.equal(counterpart?.importedId, 'mm-target-200');
+    assert.equal(counterpart?.importedPayee, 'Einzahlung');
+    assert.equal(counterpart?.notes, 'Ruecklagen | Comment: memo');
+    assert.equal(counterpart?.cleared, true);
+});
+
+test('buildTransferPlan does not suppress unrelated same-amount target transaction with different purpose', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Salary bonus',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
+        undefined
+    );
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+});
+
+test('buildTransferPlan skips ambiguous same-run counterpart matches', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+    });
+    const targetTxA = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+    });
+    const targetTxB = makeTransaction({
+        id: '201',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTxA, targetTxB],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTxA, targetTxB],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+});
+
+test('buildTransferPlan skips automatic transfer when counterpart already exists in Actual', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, [{ imported_id: 'mm-target-200' }]],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+});
+
+test('buildTransferPlan does not suppress delayed counterpart when source side is no longer new', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+});
+
+test('convertToActualTransaction uses transfer payee for planned seed', async () => {
+    const importer = makeImporter();
+    const transaction = makeTransaction({
+        id: '100',
+        accountUuid: 'mm-source',
+        amount: -1440,
+        accountNumber: 'DE-TARGET',
+        name: 'Jens Bergmann',
+        purpose: 'Ruecklagen',
+        comment: 'memo',
+    });
+
+    const converted = await importer.convertToActualTransaction(transaction, {
+        importedId: 'mm-source-100',
+        transferPayeeId: 'transfer-payee',
+        targetActualAccountId: 'actual-target',
+        targetActualAccountName: 'Target',
+    });
+
+    assert.equal(converted.payee, 'transfer-payee');
+    assert.equal(converted.imported_id, 'mm-source-100');
+    assert.equal(converted.imported_payee, 'Jens Bergmann');
+    assert.equal(converted.notes, 'Ruecklagen | Comment: memo');
+    assert.equal(converted.cleared, true);
+});
+
+test('applyTransferCounterpartUpdates stamps generated counterpart with second imported id', async () => {
+    const getTransactionsByIds = mock.fn(async () => [
+        {
+            id: 'source-tx',
+            imported_id: 'mm-source-100',
+            transfer_id: 'counterpart-tx',
+        },
+    ]);
+    const updateTransaction = mock.fn(async () => {});
+    const importer = makeImporter({
+        getTransactionsByIds,
+        updateTransaction,
+    });
+
+    await importer.applyTransferCounterpartUpdates({
+        actualAccount: makeActualAccount({ id: 'actual-source', name: 'A' }),
+        importedTransactionIds: ['source-tx'],
+        transferPlan: {
+            seedByImportedId: new Map([
+                [
+                    'mm-source-100',
+                    {
+                        importedId: 'mm-source-100',
+                        transferPayeeId: 'payee-target',
+                        targetActualAccountId: 'actual-target',
+                        targetActualAccountName: 'Target',
+                        sameRunCounterpart: {
+                            importedId: 'mm-target-200',
+                            importedPayee: 'Einzahlung',
+                            notes: 'Ruecklagen',
+                            cleared: true,
+                        },
+                    },
+                ],
+            ]),
+            suppressedImportedIds: new Set(['mm-target-200']),
+        },
+    });
+
+    assert.equal(getTransactionsByIds.mock.callCount(), 1);
+    assert.equal(updateTransaction.mock.callCount(), 1);
+    assert.deepEqual(updateTransaction.mock.calls[0].arguments, [
+        'counterpart-tx',
+        {
+            imported_id: 'mm-target-200',
+            imported_payee: 'Einzahlung',
+            notes: 'Ruecklagen',
+            cleared: true,
+        },
+    ]);
+});

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -55,11 +55,13 @@ const makeImporter = ({
     importComments = true,
     resolvedTransferCategoryUuids = new Set(['mm-transfer']),
     invalidTransferRefs = [],
+    getTransactions = async () => [],
     getTransactionsByIds = async () => [],
     updateTransaction = async () => {},
 } = {}) => {
     const logger = makeLogger();
     const actualApi = {
+        getTransactions,
         getTransactionsByIds,
         updateTransaction,
     };
@@ -117,7 +119,7 @@ test('buildTransferPlan creates delayed transfer seed from hard target account m
         accountUuid: sourceMonMon.uuid,
         amount: -1440,
         accountNumber: targetMonMon.accountNumber,
-        name: 'Jens Bergmann',
+        name: 'Example Sender',
     });
 
     const plan = importer.buildTransferPlan({
@@ -181,7 +183,7 @@ test('buildTransferPlan can seed transfer when only source account is selected',
         accountUuid: sourceMonMon.uuid,
         amount: -1440,
         accountNumber: targetMonMon.accountNumber,
-        name: 'Jens Bergmann',
+        name: 'Example Sender',
     });
 
     const plan = importer.buildTransferPlan({
@@ -300,7 +302,7 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
         accountUuid: sourceMonMon.uuid,
         amount: -1440,
         accountNumber: targetMonMon.accountNumber,
-        name: 'Jens Bergmann',
+        name: 'Example Sender',
         purpose: 'Ruecklagen',
     });
     const targetTx = makeTransaction({
@@ -610,6 +612,80 @@ test('buildTransferPlan does not suppress delayed counterpart when source side i
     assert.deepEqual([...plan.suppressedImportedIds], []);
 });
 
+test('getExistingTransactionsForStartBalanceCheck refreshes empty accounts for live transfer runs', async () => {
+    const getTransactions = mock.fn(async () => [
+        {
+            id: 'generated-counterpart',
+            imported_id: undefined,
+            transfer_id: 'source-transfer',
+        },
+    ]);
+    const importer = makeImporter({ getTransactions });
+    const getExistingTransactionsForStartBalanceCheck =
+        Object.getPrototypeOf(
+            importer
+        ).getExistingTransactionsForStartBalanceCheck;
+
+    const refreshed = await getExistingTransactionsForStartBalanceCheck.call(
+        importer,
+        {
+            actualAccountId: 'actual-target',
+            existingActualTransactions: [],
+            transfersEnabled: true,
+            isDryRun: false,
+        }
+    );
+
+    assert.equal(getTransactions.mock.callCount(), 1);
+    assert.equal(refreshed.length, 1);
+    assert.equal(refreshed[0]?.id, 'generated-counterpart');
+});
+
+test('getExistingTransactionsForStartBalanceCheck does not refetch non-empty or dry-run accounts', async () => {
+    const getTransactions = mock.fn(async () => [
+        {
+            id: 'should-not-be-used',
+        },
+    ]);
+    const importer = makeImporter({ getTransactions });
+    const getExistingTransactionsForStartBalanceCheck =
+        Object.getPrototypeOf(
+            importer
+        ).getExistingTransactionsForStartBalanceCheck;
+
+    const existing = [{ id: 'existing-1' }];
+
+    assert.deepEqual(
+        await getExistingTransactionsForStartBalanceCheck.call(importer, {
+            actualAccountId: 'actual-target',
+            existingActualTransactions: existing,
+            transfersEnabled: true,
+            isDryRun: false,
+        }),
+        existing
+    );
+    assert.deepEqual(
+        await getExistingTransactionsForStartBalanceCheck.call(importer, {
+            actualAccountId: 'actual-target',
+            existingActualTransactions: [],
+            transfersEnabled: true,
+            isDryRun: true,
+        }),
+        []
+    );
+    assert.deepEqual(
+        await getExistingTransactionsForStartBalanceCheck.call(importer, {
+            actualAccountId: 'actual-target',
+            existingActualTransactions: [],
+            transfersEnabled: false,
+            isDryRun: false,
+        }),
+        []
+    );
+
+    assert.equal(getTransactions.mock.callCount(), 0);
+});
+
 test('convertToActualTransaction uses transfer payee for planned seed', async () => {
     const importer = makeImporter();
     const transaction = makeTransaction({
@@ -617,7 +693,7 @@ test('convertToActualTransaction uses transfer payee for planned seed', async ()
         accountUuid: 'mm-source',
         amount: -1440,
         accountNumber: 'DE-TARGET',
-        name: 'Jens Bergmann',
+        name: 'Example Sender',
         purpose: 'Ruecklagen',
         comment: 'memo',
     });
@@ -631,28 +707,25 @@ test('convertToActualTransaction uses transfer payee for planned seed', async ()
 
     assert.equal(converted.payee, 'transfer-payee');
     assert.equal(converted.imported_id, 'mm-source-100');
-    assert.equal(converted.imported_payee, 'Jens Bergmann');
+    assert.equal(converted.imported_payee, 'Example Sender');
     assert.equal(converted.notes, 'Ruecklagen | Comment: memo');
     assert.equal(converted.cleared, true);
 });
 
 test('applyTransferCounterpartUpdates stamps generated counterpart with second imported id', async () => {
-    const getTransactionsByIds = mock.fn(async () => [
-        {
-            id: 'source-tx',
-            imported_id: 'mm-source-100',
-            transfer_id: 'counterpart-tx',
-        },
-    ]);
     const updateTransaction = mock.fn(async () => {});
     const importer = makeImporter({
-        getTransactionsByIds,
         updateTransaction,
     });
 
     await importer.applyTransferCounterpartUpdates({
-        actualAccount: makeActualAccount({ id: 'actual-source', name: 'A' }),
-        importedTransactionIds: ['source-tx'],
+        importedTransactions: [
+            {
+                id: 'source-tx',
+                imported_id: 'mm-source-100',
+                transfer_id: 'counterpart-tx',
+            },
+        ],
         transferPlan: {
             seedByImportedId: new Map([
                 [
@@ -675,7 +748,6 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
         },
     });
 
-    assert.equal(getTransactionsByIds.mock.callCount(), 1);
     assert.equal(updateTransaction.mock.callCount(), 1);
     assert.deepEqual(updateTransaction.mock.calls[0].arguments, [
         'counterpart-tx',


### PR DESCRIPTION
## Summary
- add opt-in automatic transfer seeding via `[import.transfers]` with category refs resolved by UUID, path, or exact name
- seed transfers when MoneyMoney provides a strong mapped target account signal and support same-run counterpart suppression plus counterpart stamping
- document the new config and add focused tests for delayed seeding, scoped imports, ambiguity guards, and counterpart updates

## Testing
- `npm run build`
- `node --test \"test/unit/config-defaults.test.mjs\" \"test/unit/category-map.test.mjs\" \"test/unit/actual-api.test.mjs\" \"test/unit/importer-category-sync-flow.test.mjs\" \"test/unit/importer-transfers.test.mjs\"`
- `npm run lint:eslint`
- `npm run lint:prettier`
- manual live validation against Actual/MoneyMoney: seeded one side as transfer, later import updated the generated counterpart with no duplicate

## Notes
- no breaking changes; feature is opt-in behind `[import.transfers]`
- ambiguous or weak-signal cases intentionally fall back to normal transaction import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic transfer detection and seeding functionality. Users can now enable transfers via configuration, specifying target categories and transaction match window parameters.

* **Documentation**
  * Updated README with comprehensive automatic transfers configuration guide, including behavioral notes and constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->