### PR TITLE
feat: convert historically imported plain counterparts to transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ commentPrefix = "MoneyMoney Comment: " # Optional: Set a prefix for MoneyMoney c
 [import.transfers]
 enabled = false
 categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
-matchWindowDays = 5
 
 # Actual servers, you can add multiple servers
 [[actualServers]]
@@ -139,21 +138,35 @@ The AI receives existing payees from your budget to prefer matching over creatin
 
 #### Automatic transfers
 
-Enable `[import.transfers]` to seed Actual transfers from MoneyMoney transactions when the source-side booking carries a configured transfer category and its `accountNumber` points to another mapped MoneyMoney account.
+Enable `[import.transfers]` to create native Actual transfers from MoneyMoney transactions when the source-side transaction carries a configured transfer category, its `accountNumber` points to another mapped MoneyMoney account, and both sides share the same value date.
 
-| Option            | Default | Description                                                                 |
-| ----------------- | ------- | --------------------------------------------------------------------------- |
-| `enabled`         | `false` | Enable automatic transfer seeding                                           |
-| `categoryRefs`    | `[]`    | MoneyMoney transfer categories by UUID, full path, or exact leaf name       |
-| `matchWindowDays` | `5`     | Date window used to detect a same-run counterpart in another mapped account |
+| Option         | Default | Description                                                     |
+| -------------- | ------- | --------------------------------------------------------------- |
+| `enabled`      | `false` | Enable automatic transfer handling                              |
+| `categoryRefs` | `[]`    | MoneyMoney transfer categories by UUID, full path, or leaf name |
 
-Notes:
+Native Actual transfers are only created when both matched sides share the same value date.
+Matching is exact-date only for now; off-date candidates are ignored.
 
-- `categoryRefs` must be non-empty when `enabled = true`
-- If only one side is present, the importer seeds a transfer on the recognized side and lets a later import update the generated counterpart
-- If both sides are present in the same run and the counterpart match is unique, the importer suppresses the second plain import and stamps the generated transfer counterpart with the second `imported_id`
-- If the counterpart was previously imported as a plain transaction, the importer converts the existing plain booking into a transfer when the source side is later imported
-- If the target account cannot be identified confidently, the transaction is imported normally
+Supported cases:
+
+- Same-run, same-date, unique match: the importer suppresses the second plain import and stamps the generated transfer counterpart with the second `imported_id`
+- Historical plain counterpart, same-date, unique match: the importer converts the existing plain booking into a transfer when the source side is later imported
+
+Unsupported cases:
+
+- Different-date pairs: imported as two normal transactions so each side keeps its own date
+    - Reason: Actual mirrors transfer dates across linked sides, so a native transfer would not preserve independent value dates
+- Counterparts already part of another transfer: left untouched
+    - Reason: the importer cannot safely prove they belong to this source transaction
+- Ambiguous target mapping: imported normally
+    - Reason: the importer only creates transfers when the target account can be identified uniquely
+- Single-sided delayed seeds: not auto-created as native transfers
+    - Reason: without the counterpart already visible, the importer cannot confirm the date safely
+- Ambiguous or weak matches: imported normally
+    - Reason: avoid guessing and creating false positives
+
+`categoryRefs` must be non-empty when `enabled = true`.
 
 ### Comment import
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Notes:
 - `categoryRefs` must be non-empty when `enabled = true`
 - If only one side is present, the importer seeds a transfer on the recognized side and lets a later import update the generated counterpart
 - If both sides are present in the same run and the counterpart match is unique, the importer suppresses the second plain import and stamps the generated transfer counterpart with the second `imported_id`
+- If the counterpart was previously imported as a plain transaction, the importer converts the existing plain booking into a transfer when the source side is later imported
 - If the target account cannot be identified confidently, the transaction is imported normally
 
 ### Comment import

--- a/src/utils/ActualApiLogControl.ts
+++ b/src/utils/ActualApiLogControl.ts
@@ -1,4 +1,8 @@
-const API_NOISE_PATTERNS = [/^Syncing since /, /^Got messages from server /];
+const API_NOISE_PATTERNS = [
+    /^Syncing since /,
+    /^Got messages from server /,
+    /^\[Breadcrumb\]/,
+];
 
 const isApiNoiseLine = (line: string): boolean =>
     API_NOISE_PATTERNS.some((pattern) => pattern.test(line.trim()));

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1547,6 +1547,10 @@ class Importer {
 
                     suppressedImportedIds.add(candidate.importedId);
 
+                    const sourceNotes = this.buildTransactionNotes(
+                        candidate.transaction
+                    );
+
                     existingCounterpartConversionsByImportedId.set(
                         candidate.importedId,
                         {
@@ -1560,15 +1564,7 @@ class Importer {
                             sourceImportedId: candidate.importedId,
                             sourceImportedPayee:
                                 candidate.transaction.name ?? '',
-                            ...(this.buildTransactionNotes(
-                                candidate.transaction
-                            )
-                                ? {
-                                      sourceNotes: this.buildTransactionNotes(
-                                          candidate.transaction
-                                      ),
-                                  }
-                                : {}),
+                            ...(sourceNotes ? { sourceNotes } : {}),
                             ...(this.config.import.synchronizeClearedStatus
                                 ? {
                                       sourceCleared:
@@ -1729,10 +1725,17 @@ class Importer {
                 continue;
             }
 
-            await this.actualApi.updateTransaction(
-                conversion.existingCounterpartTransactionId,
-                { payee: conversion.sourceTransferPayeeId }
-            );
+            try {
+                await this.actualApi.updateTransaction(
+                    conversion.existingCounterpartTransactionId,
+                    { payee: conversion.sourceTransferPayeeId }
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to convert plain transaction '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountName}' to a transfer: ${error instanceof Error ? error.message : String(error)}`
+                );
+                continue;
+            }
 
             const transactionNotes = this.buildTransactionNotes(transaction);
 
@@ -1740,16 +1743,34 @@ class Importer {
                 `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer pair with source amount ${transaction.amount.toFixed(2)} on ${transaction.bookingDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
             );
 
-            await new Promise((resolve) => setTimeout(resolve, 250));
+            let convertAttempt = 0;
+            let transferId: string | undefined;
 
-            const targetTransactions = await this.actualApi.getTransactions(
-                conversion.existingCounterpartAccountId
-            );
-            const convertedTarget = targetTransactions.find(
-                (tx) => tx.id === conversion.existingCounterpartTransactionId
-            );
+            while (convertAttempt < 5 && !transferId) {
+                if (convertAttempt > 0) {
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+                }
 
-            if (convertedTarget?.transfer_id) {
+                const targetTransactions = await this.actualApi.getTransactions(
+                    conversion.existingCounterpartAccountId
+                );
+                const convertedTarget = targetTransactions.find(
+                    (tx) =>
+                        tx.id === conversion.existingCounterpartTransactionId
+                );
+
+                transferId = convertedTarget?.transfer_id;
+                convertAttempt++;
+            }
+
+            if (!transferId) {
+                this.logger.warn(
+                    `Could not locate auto-created transfer counterpart for converted transaction '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountName}' after retries.`
+                );
+                continue;
+            }
+
+            try {
                 const counterpartUpdate: Partial<UpdateTransaction> = {
                     imported_id: conversion.sourceImportedId,
                     imported_payee: conversion.sourceImportedPayee,
@@ -1764,12 +1785,16 @@ class Importer {
                 }
 
                 await this.actualApi.updateTransaction(
-                    convertedTarget.transfer_id,
+                    transferId,
                     counterpartUpdate
                 );
 
                 this.logger.debug(
-                    `Stamped auto-created transfer counterpart '${convertedTarget.transfer_id}' with imported_id '${conversion.sourceImportedId}'.`
+                    `Stamped auto-created transfer counterpart '${transferId}' with imported_id '${conversion.sourceImportedId}'.`
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to stamp auto-created transfer counterpart for converted transaction '${conversion.existingCounterpartTransactionId}': ${error instanceof Error ? error.message : String(error)}`
                 );
             }
         }

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1640,6 +1640,8 @@ class Importer {
         return targetTransactions.filter((transaction) => {
             const candidateImportedId =
                 this.getIdForMoneyMoneyTransaction(transaction);
+            const isTargetAccountMatch =
+                transaction.accountUuid === candidate.targetMonMonAccount.uuid;
             const hasMatchingPurpose =
                 !!candidate.transaction.purpose &&
                 !!transaction.purpose &&
@@ -1653,7 +1655,9 @@ class Importer {
             return (
                 candidateImportedId !== candidate.importedId &&
                 Math.round(transaction.amount * 100) === -sourceAmount &&
-                (hasMatchingPurpose || hasReciprocalAccountNumber) &&
+                (isTargetAccountMatch ||
+                    hasMatchingPurpose ||
+                    hasReciprocalAccountNumber) &&
                 Math.abs(
                     differenceInCalendarDays(
                         transaction.valueDate,

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1950,8 +1950,20 @@ class Importer {
                     const convertedTarget = targetTransactions[0];
 
                     transferId = convertedTarget?.transfer_id;
-                } catch {
-                    // retry on transient API errors
+
+                    if (!transferId) {
+                        this.logger.debug(
+                            `Retrying auto-created transfer counterpart lookup for '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountId}' (attempt ${convertAttempt + 1}/5) after ${convertedTarget ? `transaction '${convertedTarget.id}' without a transfer id` : 'no matching transaction'}.`
+                        );
+                    }
+                } catch (error) {
+                    this.logger.debug(
+                        `Retrying auto-created transfer counterpart lookup for '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountId}' (attempt ${convertAttempt + 1}/5) after error: ${error instanceof Error ? error.message : String(error)}`
+                    );
+
+                    if (this.isAuthOrPermissionError(error)) {
+                        throw error;
+                    }
                 }
 
                 convertAttempt++;
@@ -1992,13 +2004,23 @@ class Importer {
             const transactionNotes = this.buildTransactionNotes(transaction);
 
             this.logger.info(
-                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.valueDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${format(transaction.valueDate, DATE_FORMAT)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
             );
 
             this.logger.debug(
                 `Stamped auto-created transfer counterpart '${transferId}' with imported_id '${conversion.sourceImportedId}'.`
             );
         }
+    }
+
+    private isAuthOrPermissionError(error: unknown): boolean {
+        if (!error || typeof error !== 'object') {
+            return false;
+        }
+
+        const status = (error as { status?: unknown }).status;
+
+        return status === 401 || status === 403;
     }
 
     private async promptForConflictDecision(

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -696,6 +696,7 @@ class Importer {
                                 : [];
 
                         await this.applyTransferCounterpartUpdates({
+                            actualAccountName: actualAccount.name,
                             importedTransactions,
                             transferPlan,
                         });
@@ -1663,9 +1664,11 @@ class Importer {
     }
 
     private async applyTransferCounterpartUpdates({
+        actualAccountName,
         importedTransactions,
         transferPlan,
     }: {
+        actualAccountName: string;
         importedTransactions: ReadTransaction[];
         transferPlan: TransferPlan;
     }) {
@@ -1681,7 +1684,17 @@ class Importer {
             const plannedSeed = transferPlan.seedByImportedId.get(
                 transaction.imported_id
             );
-            if (!plannedSeed?.sameRunCounterpart || !transaction.transfer_id) {
+            if (!plannedSeed || !transaction.transfer_id) {
+                continue;
+            }
+
+            const transactionNotes = transaction.notes || undefined;
+
+            this.logger.info(
+                `Seeded transfer in '${actualAccountName}' to '${plannedSeed.targetActualAccountName}' with amount ${(transaction.amount / 100).toFixed(2)} on ${transaction.date}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+            );
+
+            if (!plannedSeed.sameRunCounterpart) {
                 continue;
             }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -467,6 +467,20 @@ class Importer {
                   resolvedTransferCategoryUuids: new Set<string>(),
               };
 
+        // Sort account states so seed accounts process first — this ensures
+        // counterpart accounts import after transfer creation and reconcile
+        // onto auto-created counterparts with their correct dates.
+        const seedImportedIds = new Set(transferPlan.seedByImportedId.keys());
+        const isSeedAccount = (state: (typeof accountStates)[number]) =>
+            state.newMonMonTransactions.some((tx) =>
+                seedImportedIds.has(this.getIdForMoneyMoneyTransaction(tx))
+            );
+        accountStates.sort((a, b) => {
+            const aSeed = isSeedAccount(a) ? 0 : 1;
+            const bSeed = isSeedAccount(b) ? 0 : 1;
+            return aSeed - bSeed;
+        });
+
         const unmappedCategoryWarnings = new Set<string>();
         const runMetrics: ImportRunMetrics = {
             accountsScanned: 0,
@@ -1464,6 +1478,7 @@ class Importer {
                 candidate,
                 monMonTransactionMap: newTransactionsByAccountUuid,
                 matchWindowDays: transferConfig.matchWindowDays,
+                relaxedMatching: true,
             });
 
             if (matchingCounterparts.length > 1) {
@@ -1527,6 +1542,7 @@ class Importer {
                 candidate,
                 monMonTransactionMap,
                 matchWindowDays: transferConfig.matchWindowDays,
+                relaxedMatching: false,
             });
             if (existingCounterparts.length > 1) {
                 this.logger.debug(
@@ -1628,10 +1644,12 @@ class Importer {
         candidate,
         monMonTransactionMap,
         matchWindowDays,
+        relaxedMatching = false,
     }: {
         candidate: TransferPlanningCandidate;
         monMonTransactionMap: Record<string, MonMonTransaction[]>;
         matchWindowDays: number;
+        relaxedMatching?: boolean;
     }): MonMonTransaction[] {
         const targetTransactions =
             monMonTransactionMap[candidate.targetMonMonAccount.uuid] ?? [];
@@ -1640,8 +1658,6 @@ class Importer {
         return targetTransactions.filter((transaction) => {
             const candidateImportedId =
                 this.getIdForMoneyMoneyTransaction(transaction);
-            const isTargetAccountMatch =
-                transaction.accountUuid === candidate.targetMonMonAccount.uuid;
             const hasMatchingPurpose =
                 !!candidate.transaction.purpose &&
                 !!transaction.purpose &&
@@ -1652,18 +1668,23 @@ class Importer {
                 transaction.accountNumber ===
                     candidate.sourceMonMonAccount.accountNumber;
 
-            return (
-                candidateImportedId !== candidate.importedId &&
+            const isAmountAndDateMatch =
                 Math.round(transaction.amount * 100) === -sourceAmount &&
-                (isTargetAccountMatch ||
-                    hasMatchingPurpose ||
-                    hasReciprocalAccountNumber) &&
                 Math.abs(
                     differenceInCalendarDays(
                         transaction.valueDate,
                         candidate.transaction.valueDate
                     )
-                ) <= matchWindowDays
+                ) <= matchWindowDays;
+            const hasSignalMatch =
+                relaxedMatching ||
+                hasMatchingPurpose ||
+                hasReciprocalAccountNumber;
+
+            return (
+                candidateImportedId !== candidate.importedId &&
+                isAmountAndDateMatch &&
+                hasSignalMatch
             );
         });
     }
@@ -1779,7 +1800,7 @@ class Importer {
             const transactionNotes = this.buildTransactionNotes(transaction);
 
             this.logger.info(
-                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.bookingDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.valueDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
             );
 
             let convertAttempt = 0;
@@ -1787,16 +1808,15 @@ class Importer {
 
             while (convertAttempt < 5 && !transferId) {
                 if (convertAttempt > 0) {
-                    await new Promise((resolve) => setTimeout(resolve, 100));
+                    await new Promise((resolve) => setTimeout(resolve, 250));
                 }
 
-                const targetTransactions = await this.actualApi.getTransactions(
-                    conversion.existingCounterpartAccountId
-                );
-                const convertedTarget = targetTransactions.find(
-                    (tx) =>
-                        tx.id === conversion.existingCounterpartTransactionId
-                );
+                const targetTransactions =
+                    await this.actualApi.getTransactionsByIds(
+                        conversion.existingCounterpartAccountId,
+                        [conversion.existingCounterpartTransactionId]
+                    );
+                const convertedTarget = targetTransactions[0];
 
                 transferId = convertedTarget?.transfer_id;
                 convertAttempt++;
@@ -1813,7 +1833,7 @@ class Importer {
                 const counterpartUpdate: Partial<UpdateTransaction> = {
                     imported_id: conversion.sourceImportedId,
                     imported_payee: conversion.sourceImportedPayee,
-                    date: format(transaction.bookingDate, DATE_FORMAT),
+                    date: format(transaction.valueDate, DATE_FORMAT),
                 };
 
                 if (conversion.sourceNotes !== undefined) {

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1489,7 +1489,11 @@ class Importer {
             }
 
             const sameRunCounterpart = matchingCounterparts[0];
-            if (sameRunCounterpart) {
+            if (
+                sameRunCounterpart &&
+                format(candidate.transaction.valueDate, DATE_FORMAT) ===
+                    format(sameRunCounterpart.valueDate, DATE_FORMAT)
+            ) {
                 const counterpartImportedId =
                     this.getIdForMoneyMoneyTransaction(sameRunCounterpart);
                 if (claimedCounterpartIds.has(counterpartImportedId)) {
@@ -1552,7 +1556,11 @@ class Importer {
             }
 
             const existingCounterpart = existingCounterparts[0];
-            if (existingCounterpart) {
+            if (
+                existingCounterpart &&
+                format(candidate.transaction.valueDate, DATE_FORMAT) ===
+                    format(existingCounterpart.valueDate, DATE_FORMAT)
+            ) {
                 const existingCounterpartImportedId =
                     this.getIdForMoneyMoneyTransaction(existingCounterpart);
                 const existingTargetTransactions =
@@ -1667,6 +1675,15 @@ class Importer {
                 !!candidate.sourceMonMonAccount.accountNumber &&
                 transaction.accountNumber ===
                     candidate.sourceMonMonAccount.accountNumber;
+            const hasContradictoryAccountNumber =
+                !!transaction.accountNumber &&
+                !!candidate.sourceMonMonAccount.accountNumber &&
+                transaction.accountNumber !==
+                    candidate.sourceMonMonAccount.accountNumber;
+
+            if (relaxedMatching && hasContradictoryAccountNumber) {
+                return false;
+            }
 
             const isAmountAndDateMatch =
                 Math.round(transaction.amount * 100) === -sourceAmount &&
@@ -1811,14 +1828,19 @@ class Importer {
                     await new Promise((resolve) => setTimeout(resolve, 250));
                 }
 
-                const targetTransactions =
-                    await this.actualApi.getTransactionsByIds(
-                        conversion.existingCounterpartAccountId,
-                        [conversion.existingCounterpartTransactionId]
-                    );
-                const convertedTarget = targetTransactions[0];
+                try {
+                    const targetTransactions =
+                        await this.actualApi.getTransactionsByIds(
+                            conversion.existingCounterpartAccountId,
+                            [conversion.existingCounterpartTransactionId]
+                        );
+                    const convertedTarget = targetTransactions[0];
 
-                transferId = convertedTarget?.transfer_id;
+                    transferId = convertedTarget?.transfer_id;
+                } catch {
+                    // retry on transient API errors
+                }
+
                 convertAttempt++;
             }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays, format, subMonths } from 'date-fns';
+import { format, subMonths } from 'date-fns';
 import chalk from 'chalk';
 import { stdin, stdout } from 'node:process';
 import { createInterface } from 'node:readline/promises';
@@ -94,7 +94,6 @@ type PlannedTransferSeed = {
 type PlannedTransferCounterpart = {
     importedId: string;
     importedPayee: string;
-    date: string;
     notes?: string;
     cleared?: boolean;
 };
@@ -468,8 +467,8 @@ class Importer {
               };
 
         // Sort account states so seed accounts process first — this ensures
-        // counterpart accounts import after transfer creation and reconcile
-        // onto auto-created counterparts with their correct dates.
+        // counterpart accounts import after transfer creation and can stamp
+        // auto-created counterparts in the same run.
         const seedImportedIds = new Set(transferPlan.seedByImportedId.keys());
         const isSeedAccount = (state: (typeof accountStates)[number]) =>
             state.newMonMonTransactions.some((tx) =>
@@ -1464,6 +1463,7 @@ class Importer {
         const seedByImportedId = new Map<string, PlannedTransferSeed>();
         const suppressedImportedIds = new Set<string>();
         const claimedCounterpartIds = new Set<string>();
+        const claimedExistingCounterpartTransactionIds = new Set<string>();
         const existingCounterpartConversionsByImportedId = new Map<
             string,
             PlannedExistingCounterpartConversion
@@ -1474,28 +1474,25 @@ class Importer {
                 continue;
             }
 
-            const matchingCounterparts = this.findMatchingTransferCounterparts({
+            const matchingCounterparts = this.findSameRunTransferCounterparts({
                 candidate,
-                monMonTransactionMap: newTransactionsByAccountUuid,
-                matchWindowDays: transferConfig.matchWindowDays,
-                relaxedMatching: true,
+                targetTransactions:
+                    newTransactionsByAccountUuid[
+                        candidate.targetMonMonAccount.uuid
+                    ] ?? [],
             });
 
             if (matchingCounterparts.length > 1) {
                 this.logger.debug(
-                    `Skipping automatic transfer for '${candidate.importedId}' because multiple same-run counterpart candidates were found.`
+                    `Skipping automatic transfer for '${candidate.importedId}' because multiple same-date same-run counterpart candidates were found.`
                 );
                 continue;
             }
 
-            const sameRunCounterpart = matchingCounterparts[0];
-            if (
-                sameRunCounterpart &&
-                format(candidate.transaction.valueDate, DATE_FORMAT) ===
-                    format(sameRunCounterpart.valueDate, DATE_FORMAT)
-            ) {
+            if (matchingCounterparts.length === 1) {
+                const exactSameRunCounterpart = matchingCounterparts[0]!;
                 const counterpartImportedId =
-                    this.getIdForMoneyMoneyTransaction(sameRunCounterpart);
+                    this.getIdForMoneyMoneyTransaction(exactSameRunCounterpart);
                 if (claimedCounterpartIds.has(counterpartImportedId)) {
                     this.logger.debug(
                         `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${counterpartImportedId}' was already claimed by another transfer seed.`
@@ -1529,44 +1526,61 @@ class Importer {
                     targetActualAccountName: candidate.targetActualAccount.name,
                     sameRunCounterpart: {
                         importedId: counterpartImportedId,
-                        importedPayee: sameRunCounterpart.name ?? '',
-                        date: format(sameRunCounterpart.valueDate, DATE_FORMAT),
+                        importedPayee: exactSameRunCounterpart.name ?? '',
                         notes:
-                            this.buildTransactionNotes(sameRunCounterpart) ||
-                            '',
+                            this.buildTransactionNotes(
+                                exactSameRunCounterpart
+                            ) || '',
                         ...(this.config.import.synchronizeClearedStatus
-                            ? { cleared: sameRunCounterpart.booked }
+                            ? { cleared: exactSameRunCounterpart.booked }
                             : {}),
                     },
                 });
                 continue;
             }
 
-            const existingCounterparts = this.findMatchingTransferCounterparts({
-                candidate,
-                monMonTransactionMap,
-                matchWindowDays: transferConfig.matchWindowDays,
-                relaxedMatching: false,
-            });
+            const existingCounterparts =
+                this.findHistoricalTransferCounterparts({
+                    candidate,
+                    targetTransactions:
+                        monMonTransactionMap[
+                            candidate.targetMonMonAccount.uuid
+                        ] ?? [],
+                });
             if (existingCounterparts.length > 1) {
                 this.logger.debug(
-                    `Skipping automatic transfer for '${candidate.importedId}' because multiple historical counterpart candidates were found.`
+                    `Skipping automatic transfer for '${candidate.importedId}' because multiple same-date historical counterpart candidates were found.`
                 );
                 continue;
             }
 
             const existingCounterpart = existingCounterparts[0];
-            if (
-                existingCounterpart &&
-                format(candidate.transaction.valueDate, DATE_FORMAT) ===
-                    format(existingCounterpart.valueDate, DATE_FORMAT)
-            ) {
+            if (existingCounterpart) {
                 const existingCounterpartImportedId =
                     this.getIdForMoneyMoneyTransaction(existingCounterpart);
                 const existingTargetTransactions =
                     existingActualTransactionsByAccountId.get(
                         candidate.targetActualAccount.id
                     ) ?? [];
+                const existingSourceTransactions =
+                    existingActualTransactionsByAccountId.get(
+                        candidate.sourceActualAccount.id
+                    ) ?? [];
+                // If the source-side counterpart was already stamped during a
+                // partial historical conversion, skip re-planning it.
+                if (
+                    existingSourceTransactions.some(
+                        (transaction) =>
+                            transaction.imported_id === candidate.importedId &&
+                            !!transaction.transfer_id
+                    )
+                ) {
+                    this.logger.debug(
+                        `Skipping automatic transfer for '${candidate.importedId}' because its transfer counterpart already exists in '${candidate.sourceActualAccount.name}'.`
+                    );
+                    continue;
+                }
+
                 const existingTargetTransaction =
                     existingTargetTransactions.find(
                         (transaction) =>
@@ -1574,21 +1588,38 @@ class Importer {
                             existingCounterpartImportedId
                     );
 
-                if (existingTargetTransaction?.transfer_id) {
+                if (
+                    existingTargetTransaction &&
+                    existingTargetTransaction.transfer_id
+                ) {
                     this.logger.debug(
-                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${existingCounterpartImportedId}' is already a transfer.`
+                        `Skipping automatic transfer for '${candidate.importedId}' because historical counterpart '${existingTargetTransaction.id}' is already part of a transfer.`
                     );
                     continue;
                 }
 
+                const sourceTransferPayeeId = transferPayeeIdByAccountId.get(
+                    candidate.sourceActualAccount.id
+                );
+                if (!sourceTransferPayeeId) {
+                    continue;
+                }
+
                 if (existingTargetTransaction) {
-                    const sourceTransferPayeeId =
-                        transferPayeeIdByAccountId.get(
-                            candidate.sourceActualAccount.id
+                    if (
+                        claimedExistingCounterpartTransactionIds.has(
+                            existingTargetTransaction.id
+                        )
+                    ) {
+                        this.logger.debug(
+                            `Skipping automatic transfer for '${candidate.importedId}' because historical counterpart '${existingTargetTransaction.id}' was already claimed by another transfer conversion.`
                         );
-                    if (!sourceTransferPayeeId) {
                         continue;
                     }
+
+                    claimedExistingCounterpartTransactionIds.add(
+                        existingTargetTransaction.id
+                    );
 
                     suppressedImportedIds.add(candidate.importedId);
 
@@ -1622,7 +1653,7 @@ class Importer {
                     );
 
                     this.logger.debug(
-                        `Planning conversion of existing plain transaction '${existingTargetTransaction.id}' in '${candidate.targetActualAccount.name}' to a transfer for source '${candidate.importedId}'.`
+                        `Planning conversion of historical counterpart '${existingTargetTransaction.id}' in '${candidate.targetActualAccount.name}' to a transfer for source '${candidate.importedId}'.`
                     );
                     continue;
                 }
@@ -1641,62 +1672,157 @@ class Importer {
         };
     }
 
-    private findMatchingTransferCounterparts({
+    // Same-run matching is permissive but still needs a positive signal so
+    // unrelated same-date, same-amount transactions do not get linked.
+    private findSameRunTransferCounterparts({
         candidate,
-        monMonTransactionMap,
-        matchWindowDays,
-        relaxedMatching = false,
+        targetTransactions,
     }: {
         candidate: TransferPlanningCandidate;
-        monMonTransactionMap: Record<string, MonMonTransaction[]>;
-        matchWindowDays: number;
-        relaxedMatching?: boolean;
+        targetTransactions: MonMonTransaction[];
     }): MonMonTransaction[] {
-        const targetTransactions =
-            monMonTransactionMap[candidate.targetMonMonAccount.uuid] ?? [];
         const sourceAmount = Math.round(candidate.transaction.amount * 100);
+        const candidateDate = format(
+            candidate.transaction.valueDate,
+            DATE_FORMAT
+        );
 
-        return targetTransactions.filter((transaction) => {
-            const candidateImportedId =
-                this.getIdForMoneyMoneyTransaction(transaction);
-            const hasMatchingPurpose =
-                !!candidate.transaction.purpose &&
-                !!transaction.purpose &&
-                candidate.transaction.purpose === transaction.purpose;
-            const hasReciprocalAccountNumber =
-                !!transaction.accountNumber &&
-                !!candidate.sourceMonMonAccount.accountNumber &&
-                transaction.accountNumber ===
-                    candidate.sourceMonMonAccount.accountNumber;
-            const hasContradictoryAccountNumber =
-                !!transaction.accountNumber &&
-                !!candidate.sourceMonMonAccount.accountNumber &&
-                transaction.accountNumber !==
-                    candidate.sourceMonMonAccount.accountNumber;
+        return targetTransactions.filter((transaction) =>
+            this.isMatchingTransferCounterpart({
+                candidate,
+                transaction,
+                relaxedMatching: true,
+                sourceAmount,
+                candidateDate,
+            })
+        );
+    }
 
-            if (relaxedMatching && hasContradictoryAccountNumber) {
-                return false;
-            }
+    private findHistoricalTransferCounterparts({
+        candidate,
+        targetTransactions,
+    }: {
+        candidate: TransferPlanningCandidate;
+        targetTransactions: MonMonTransaction[];
+    }): MonMonTransaction[] {
+        const sourceAmount = Math.round(candidate.transaction.amount * 100);
+        const candidateDate = format(
+            candidate.transaction.valueDate,
+            DATE_FORMAT
+        );
 
-            const isAmountAndDateMatch =
-                Math.round(transaction.amount * 100) === -sourceAmount &&
-                Math.abs(
-                    differenceInCalendarDays(
-                        transaction.valueDate,
-                        candidate.transaction.valueDate
-                    )
-                ) <= matchWindowDays;
-            const hasSignalMatch =
-                relaxedMatching ||
-                hasMatchingPurpose ||
-                hasReciprocalAccountNumber;
+        return targetTransactions.filter((transaction) =>
+            this.isMatchingTransferCounterpart({
+                candidate,
+                transaction,
+                relaxedMatching: false,
+                sourceAmount,
+                candidateDate,
+            })
+        );
+    }
 
+    private isMatchingTransferCounterpart({
+        candidate,
+        transaction,
+        relaxedMatching,
+        sourceAmount,
+        candidateDate,
+    }: {
+        candidate: TransferPlanningCandidate;
+        transaction: MonMonTransaction;
+        relaxedMatching: boolean;
+        sourceAmount: number;
+        candidateDate: string;
+    }): boolean {
+        const candidateImportedId =
+            this.getIdForMoneyMoneyTransaction(transaction);
+        if (candidateImportedId === candidate.importedId) {
+            return false;
+        }
+
+        if (
+            !this.matchesTransferCounterpartAmountAndDate({
+                transaction,
+                sourceAmount,
+                candidateDate,
+            })
+        ) {
+            return false;
+        }
+
+        if (relaxedMatching) {
             return (
-                candidateImportedId !== candidate.importedId &&
-                isAmountAndDateMatch &&
-                hasSignalMatch
+                !this.hasContradictoryAccountNumber({
+                    candidate,
+                    transaction,
+                }) &&
+                (this.hasMatchingTransferSignal({ candidate, transaction }) ||
+                    this.hasHardTargetAccountReference(candidate))
             );
-        });
+        }
+
+        return this.hasMatchingTransferSignal({ candidate, transaction });
+    }
+
+    private matchesTransferCounterpartAmountAndDate({
+        transaction,
+        sourceAmount,
+        candidateDate,
+    }: {
+        transaction: MonMonTransaction;
+        sourceAmount: number;
+        candidateDate: string;
+    }): boolean {
+        return (
+            Math.round(transaction.amount * 100) === -sourceAmount &&
+            format(transaction.valueDate, DATE_FORMAT) === candidateDate
+        );
+    }
+
+    private hasMatchingTransferSignal({
+        candidate,
+        transaction,
+    }: {
+        candidate: TransferPlanningCandidate;
+        transaction: MonMonTransaction;
+    }): boolean {
+        const hasMatchingPurpose =
+            !!candidate.transaction.purpose &&
+            !!transaction.purpose &&
+            candidate.transaction.purpose === transaction.purpose;
+        const hasReciprocalAccountNumber =
+            !!transaction.accountNumber &&
+            !!candidate.sourceMonMonAccount.accountNumber &&
+            transaction.accountNumber ===
+                candidate.sourceMonMonAccount.accountNumber;
+
+        return hasMatchingPurpose || hasReciprocalAccountNumber;
+    }
+
+    private hasHardTargetAccountReference(
+        candidate: TransferPlanningCandidate
+    ): boolean {
+        return (
+            !!candidate.transaction.accountNumber &&
+            candidate.transaction.accountNumber ===
+                candidate.targetMonMonAccount.accountNumber
+        );
+    }
+
+    private hasContradictoryAccountNumber({
+        candidate,
+        transaction,
+    }: {
+        candidate: TransferPlanningCandidate;
+        transaction: MonMonTransaction;
+    }): boolean {
+        return (
+            !!transaction.accountNumber &&
+            !!candidate.sourceMonMonAccount.accountNumber &&
+            transaction.accountNumber !==
+                candidate.sourceMonMonAccount.accountNumber
+        );
     }
 
     private async getExistingTransactionsForStartBalanceCheck({
@@ -1801,17 +1927,11 @@ class Importer {
                     { payee: conversion.sourceTransferPayeeId }
                 );
             } catch (error) {
-                this.logger.warn(
-                    `Failed to convert plain transaction '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountName}' to a transfer: ${error instanceof Error ? error.message : String(error)}`
+                throw new Error(
+                    `Failed to convert plain transaction '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountName}' to a transfer: ${error instanceof Error ? error.message : String(error)}`,
+                    { cause: error }
                 );
-                continue;
             }
-
-            const transactionNotes = this.buildTransactionNotes(transaction);
-
-            this.logger.info(
-                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.valueDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
-            );
 
             let convertAttempt = 0;
             let transferId: string | undefined;
@@ -1838,10 +1958,9 @@ class Importer {
             }
 
             if (!transferId) {
-                this.logger.warn(
+                throw new Error(
                     `Could not locate auto-created transfer counterpart for converted transaction '${conversion.existingCounterpartTransactionId}' in '${conversion.existingCounterpartAccountName}' after retries.`
                 );
-                continue;
             }
 
             try {
@@ -1863,15 +1982,22 @@ class Importer {
                     transferId,
                     counterpartUpdate
                 );
-
-                this.logger.debug(
-                    `Stamped auto-created transfer counterpart '${transferId}' with imported_id '${conversion.sourceImportedId}'.`
-                );
             } catch (error) {
-                this.logger.warn(
-                    `Failed to stamp auto-created transfer counterpart for converted transaction '${conversion.existingCounterpartTransactionId}': ${error instanceof Error ? error.message : String(error)}`
+                throw new Error(
+                    `Failed to stamp auto-created transfer counterpart '${transferId}' for converted transaction '${conversion.existingCounterpartTransactionId}': ${error instanceof Error ? error.message : String(error)}`,
+                    { cause: error }
                 );
             }
+
+            const transactionNotes = this.buildTransactionNotes(transaction);
+
+            this.logger.info(
+                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.valueDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+            );
+
+            this.logger.debug(
+                `Stamped auto-created transfer counterpart '${transferId}' with imported_id '${conversion.sourceImportedId}'.`
+            );
         }
     }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -539,22 +539,25 @@ class Importer {
                                 categoryResolution.categoryPath ??
                                 transaction.categoryUuid;
 
+                            const isTransferHandled =
+                                transferPlan.seedByImportedId.has(importedId) ||
+                                transferPlan.suppressedImportedIds.has(
+                                    importedId
+                                ) ||
+                                transferPlan.existingCounterpartConversionsByImportedId.has(
+                                    importedId
+                                );
+
                             if (
                                 !unmappedCategoryWarnings.has(warningKey) &&
-                                !transferPlan.resolvedTransferCategoryUuids.has(
-                                    transaction.categoryUuid
-                                )
+                                !isTransferHandled
                             ) {
                                 unmappedCategoryWarnings.add(warningKey);
                                 runMetrics.totalUnmappedCategoryWarnings++;
                                 this.logger.warn(
                                     `No category mapping found for MoneyMoney category '${warningKey}'. Transaction categories will be left untouched.`
                                 );
-                            } else if (
-                                transferPlan.resolvedTransferCategoryUuids.has(
-                                    transaction.categoryUuid
-                                )
-                            ) {
+                            } else if (isTransferHandled) {
                                 this.logger.debug(
                                     `Skipping unmapped category warning for transfer-handled category '${warningKey}'.`
                                 );
@@ -563,6 +566,13 @@ class Importer {
                     }
 
                     createTransactions.push(createTransaction);
+                }
+
+                if (!isDryRun) {
+                    await this.applyExistingCounterpartConversions({
+                        newMonMonTransactions,
+                        transferPlan,
+                    });
                 }
 
                 const effectiveExistingActualTransactions =
@@ -593,13 +603,6 @@ class Importer {
                     };
 
                     createTransactions.push(startTransaction);
-                }
-
-                if (!isDryRun) {
-                    await this.applyExistingCounterpartConversions({
-                        newMonMonTransactions,
-                        transferPlan,
-                    });
                 }
 
                 if (createTransactions.length > 0) {
@@ -1807,6 +1810,7 @@ class Importer {
                 const counterpartUpdate: Partial<UpdateTransaction> = {
                     imported_id: conversion.sourceImportedId,
                     imported_payee: conversion.sourceImportedPayee,
+                    date: format(transaction.bookingDate, DATE_FORMAT),
                 };
 
                 if (conversion.sourceNotes !== undefined) {

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -101,6 +101,7 @@ type PlannedExistingCounterpartConversion = {
     existingCounterpartTransactionId: string;
     existingCounterpartAccountId: string;
     existingCounterpartAccountName: string;
+    sourceActualAccountName: string;
     sourceTransferPayeeId: string;
     sourceImportedId: string;
     sourceImportedPayee: string;
@@ -1561,6 +1562,8 @@ class Importer {
                                 candidate.targetActualAccount.id,
                             existingCounterpartAccountName:
                                 candidate.targetActualAccount.name,
+                            sourceActualAccountName:
+                                candidate.sourceActualAccount.name,
                             sourceTransferPayeeId,
                             sourceImportedId: candidate.importedId,
                             sourceImportedPayee:
@@ -1691,7 +1694,7 @@ class Importer {
             const transactionNotes = transaction.notes || undefined;
 
             this.logger.info(
-                `Seeded transfer in '${actualAccountName}' to '${plannedSeed.targetActualAccountName}' with amount ${(transaction.amount / 100).toFixed(2)} on ${transaction.date}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+                `Created transfer from '${actualAccountName}' to '${plannedSeed.targetActualAccountName}' with amount ${(transaction.amount / 100).toFixed(2)} on ${transaction.date}${transactionNotes ? ` (${transactionNotes})` : ''}.`
             );
 
             if (!plannedSeed.sameRunCounterpart) {
@@ -1753,7 +1756,7 @@ class Importer {
             const transactionNotes = this.buildTransactionNotes(transaction);
 
             this.logger.info(
-                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer pair with source amount ${transaction.amount.toFixed(2)} on ${transaction.bookingDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer from '${conversion.sourceActualAccountName}' with amount ${transaction.amount.toFixed(2)} on ${transaction.bookingDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
             );
 
             let convertAttempt = 0;

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -82,6 +82,7 @@ type TransferPlan = {
         string,
         PlannedExistingCounterpartConversion
     >;
+    resolvedTransferCategoryUuids: Set<string>;
 };
 type PlannedTransferSeed = {
     importedId: string;
@@ -463,6 +464,7 @@ class Importer {
                   seedByImportedId: new Map<string, PlannedTransferSeed>(),
                   suppressedImportedIds: new Set<string>(),
                   existingCounterpartConversionsByImportedId: new Map(),
+                  resolvedTransferCategoryUuids: new Set<string>(),
               };
 
         const unmappedCategoryWarnings = new Set<string>();
@@ -537,11 +539,24 @@ class Importer {
                                 categoryResolution.categoryPath ??
                                 transaction.categoryUuid;
 
-                            if (!unmappedCategoryWarnings.has(warningKey)) {
+                            if (
+                                !unmappedCategoryWarnings.has(warningKey) &&
+                                !transferPlan.resolvedTransferCategoryUuids.has(
+                                    transaction.categoryUuid
+                                )
+                            ) {
                                 unmappedCategoryWarnings.add(warningKey);
                                 runMetrics.totalUnmappedCategoryWarnings++;
                                 this.logger.warn(
                                     `No category mapping found for MoneyMoney category '${warningKey}'. Transaction categories will be left untouched.`
+                                );
+                            } else if (
+                                transferPlan.resolvedTransferCategoryUuids.has(
+                                    transaction.categoryUuid
+                                )
+                            ) {
+                                this.logger.debug(
+                                    `Skipping unmapped category warning for transfer-handled category '${warningKey}'.`
                                 );
                             }
                         }
@@ -1308,6 +1323,7 @@ class Importer {
             seedByImportedId: new Map<string, PlannedTransferSeed>(),
             suppressedImportedIds: new Set<string>(),
             existingCounterpartConversionsByImportedId: new Map(),
+            resolvedTransferCategoryUuids: new Set(),
         };
 
         const transferConfig = this.config.import.transfers;
@@ -1601,6 +1617,7 @@ class Importer {
             seedByImportedId,
             suppressedImportedIds,
             existingCounterpartConversionsByImportedId,
+            resolvedTransferCategoryUuids: resolvedUuids,
         };
     }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1627,13 +1627,6 @@ class Importer {
                     continue;
                 }
             }
-
-            seedByImportedId.set(candidate.importedId, {
-                importedId: candidate.importedId,
-                transferPayeeId: candidate.transferPayeeId,
-                targetActualAccountId: candidate.targetActualAccount.id,
-                targetActualAccountName: candidate.targetActualAccount.name,
-            });
         }
 
         this.logger.debug(

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1728,7 +1728,6 @@ class Importer {
             const counterpartUpdate: Partial<UpdateTransaction> = {
                 imported_id: plannedSeed.sameRunCounterpart.importedId,
                 imported_payee: plannedSeed.sameRunCounterpart.importedPayee,
-                date: plannedSeed.sameRunCounterpart.date,
                 notes: plannedSeed.sameRunCounterpart.notes ?? '',
             };
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -78,6 +78,10 @@ type DuplicateImportedIdGroup = {
 type TransferPlan = {
     seedByImportedId: Map<string, PlannedTransferSeed>;
     suppressedImportedIds: Set<string>;
+    existingCounterpartConversionsByImportedId: Map<
+        string,
+        PlannedExistingCounterpartConversion
+    >;
 };
 type PlannedTransferSeed = {
     importedId: string;
@@ -92,6 +96,16 @@ type PlannedTransferCounterpart = {
     date: string;
     notes?: string;
     cleared?: boolean;
+};
+type PlannedExistingCounterpartConversion = {
+    existingCounterpartTransactionId: string;
+    existingCounterpartAccountId: string;
+    existingCounterpartAccountName: string;
+    sourceTransferPayeeId: string;
+    sourceImportedId: string;
+    sourceImportedPayee: string;
+    sourceNotes?: string;
+    sourceCleared?: boolean;
 };
 type TransferPlanningCandidate = {
     transaction: MonMonTransaction;
@@ -447,6 +461,7 @@ class Importer {
             : {
                   seedByImportedId: new Map<string, PlannedTransferSeed>(),
                   suppressedImportedIds: new Set<string>(),
+                  existingCounterpartConversionsByImportedId: new Map(),
               };
 
         const unmappedCategoryWarnings = new Set<string>();
@@ -562,6 +577,13 @@ class Importer {
                     };
 
                     createTransactions.push(startTransaction);
+                }
+
+                if (!isDryRun) {
+                    await this.applyExistingCounterpartConversions({
+                        newMonMonTransactions,
+                        transferPlan,
+                    });
                 }
 
                 if (createTransactions.length > 0) {
@@ -1283,6 +1305,7 @@ class Importer {
         const emptyPlan: TransferPlan = {
             seedByImportedId: new Map<string, PlannedTransferSeed>(),
             suppressedImportedIds: new Set<string>(),
+            existingCounterpartConversionsByImportedId: new Map(),
         };
 
         const transferConfig = this.config.import.transfers;
@@ -1406,6 +1429,10 @@ class Importer {
         const seedByImportedId = new Map<string, PlannedTransferSeed>();
         const suppressedImportedIds = new Set<string>();
         const claimedCounterpartIds = new Set<string>();
+        const existingCounterpartConversionsByImportedId = new Map<
+            string,
+            PlannedExistingCounterpartConversion
+        >();
 
         for (const candidate of candidates) {
             if (suppressedImportedIds.has(candidate.importedId)) {
@@ -1495,15 +1522,64 @@ class Importer {
                     existingActualTransactionsByAccountId.get(
                         candidate.targetActualAccount.id
                     ) ?? [];
-                if (
-                    existingTargetTransactions.some(
+                const existingTargetTransaction =
+                    existingTargetTransactions.find(
                         (transaction) =>
                             transaction.imported_id ===
                             existingCounterpartImportedId
-                    )
-                ) {
+                    );
+
+                if (existingTargetTransaction?.transfer_id) {
                     this.logger.debug(
-                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${existingCounterpartImportedId}' was already imported in an earlier run.`
+                        `Skipping automatic transfer for '${candidate.importedId}' because counterpart '${existingCounterpartImportedId}' is already a transfer.`
+                    );
+                    continue;
+                }
+
+                if (existingTargetTransaction) {
+                    const sourceTransferPayeeId =
+                        transferPayeeIdByAccountId.get(
+                            candidate.sourceActualAccount.id
+                        );
+                    if (!sourceTransferPayeeId) {
+                        continue;
+                    }
+
+                    suppressedImportedIds.add(candidate.importedId);
+
+                    existingCounterpartConversionsByImportedId.set(
+                        candidate.importedId,
+                        {
+                            existingCounterpartTransactionId:
+                                existingTargetTransaction.id,
+                            existingCounterpartAccountId:
+                                candidate.targetActualAccount.id,
+                            existingCounterpartAccountName:
+                                candidate.targetActualAccount.name,
+                            sourceTransferPayeeId,
+                            sourceImportedId: candidate.importedId,
+                            sourceImportedPayee:
+                                candidate.transaction.name ?? '',
+                            ...(this.buildTransactionNotes(
+                                candidate.transaction
+                            )
+                                ? {
+                                      sourceNotes: this.buildTransactionNotes(
+                                          candidate.transaction
+                                      ),
+                                  }
+                                : {}),
+                            ...(this.config.import.synchronizeClearedStatus
+                                ? {
+                                      sourceCleared:
+                                          candidate.transaction.booked,
+                                  }
+                                : {}),
+                        }
+                    );
+
+                    this.logger.debug(
+                        `Planning conversion of existing plain transaction '${existingTargetTransaction.id}' in '${candidate.targetActualAccount.name}' to a transfer for source '${candidate.importedId}'.`
                     );
                     continue;
                 }
@@ -1518,12 +1594,13 @@ class Importer {
         }
 
         this.logger.debug(
-            `Automatic transfer planning: seeds=${seedByImportedId.size}, suppressedCounterparts=${suppressedImportedIds.size}`
+            `Automatic transfer planning: seeds=${seedByImportedId.size}, suppressedCounterparts=${suppressedImportedIds.size}, counterpartConversions=${existingCounterpartConversionsByImportedId.size}`
         );
 
         return {
             seedByImportedId,
             suppressedImportedIds,
+            existingCounterpartConversionsByImportedId,
         };
     }
 
@@ -1632,6 +1709,69 @@ class Importer {
             this.logger.debug(
                 `Stamped generated transfer counterpart '${transaction.transfer_id}' in '${plannedSeed.targetActualAccountName}' with imported_id '${plannedSeed.sameRunCounterpart.importedId}'.`
             );
+        }
+    }
+
+    private async applyExistingCounterpartConversions({
+        newMonMonTransactions,
+        transferPlan,
+    }: {
+        newMonMonTransactions: MonMonTransaction[];
+        transferPlan: TransferPlan;
+    }) {
+        for (const transaction of newMonMonTransactions) {
+            const importedId = this.getIdForMoneyMoneyTransaction(transaction);
+            const conversion =
+                transferPlan.existingCounterpartConversionsByImportedId.get(
+                    importedId
+                );
+            if (!conversion) {
+                continue;
+            }
+
+            await this.actualApi.updateTransaction(
+                conversion.existingCounterpartTransactionId,
+                { payee: conversion.sourceTransferPayeeId }
+            );
+
+            const transactionNotes = this.buildTransactionNotes(transaction);
+
+            this.logger.info(
+                `Converted plain transaction in '${conversion.existingCounterpartAccountName}' to a transfer pair with source amount ${transaction.amount.toFixed(2)} on ${transaction.bookingDate.toISOString().slice(0, 10)}${transactionNotes ? ` (${transactionNotes})` : ''}.`
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, 250));
+
+            const targetTransactions = await this.actualApi.getTransactions(
+                conversion.existingCounterpartAccountId
+            );
+            const convertedTarget = targetTransactions.find(
+                (tx) => tx.id === conversion.existingCounterpartTransactionId
+            );
+
+            if (convertedTarget?.transfer_id) {
+                const counterpartUpdate: Partial<UpdateTransaction> = {
+                    imported_id: conversion.sourceImportedId,
+                    imported_payee: conversion.sourceImportedPayee,
+                };
+
+                if (conversion.sourceNotes !== undefined) {
+                    counterpartUpdate.notes = conversion.sourceNotes;
+                }
+
+                if (conversion.sourceCleared !== undefined) {
+                    counterpartUpdate.cleared = conversion.sourceCleared;
+                }
+
+                await this.actualApi.updateTransaction(
+                    convertedTarget.transfer_id,
+                    counterpartUpdate
+                );
+
+                this.logger.debug(
+                    `Stamped auto-created transfer counterpart '${convertedTarget.transfer_id}' with imported_id '${conversion.sourceImportedId}'.`
+                );
+            }
         }
     }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -55,7 +55,6 @@ const payeeTransformationSchema = z.object({
 const transferImportSchema = z.object({
     enabled: z.boolean().default(false),
     categoryRefs: z.array(z.string()).default([]),
-    matchWindowDays: z.number().int().min(0).default(5),
 });
 const defaultTransferImportConfig = transferImportSchema.parse({});
 

--- a/test/unit/config-defaults.test.mjs
+++ b/test/unit/config-defaults.test.mjs
@@ -31,7 +31,6 @@ test('config defaults synchronizeCategories to false when omitted', () => {
     assert.equal(parsed.import.synchronizeCategories, false);
     assert.equal(parsed.import.transfers.enabled, false);
     assert.deepEqual(parsed.import.transfers.categoryRefs, []);
-    assert.equal(parsed.import.transfers.matchWindowDays, 5);
 });
 
 test('automatic transfers require at least one category ref when enabled', () => {

--- a/test/unit/importer-category-sync-flow.test.mjs
+++ b/test/unit/importer-category-sync-flow.test.mjs
@@ -339,10 +339,6 @@ test('logCategorySyncSummary suppresses no-op info and emits debug marker', () =
 
     assert.equal(logger.infos.length, 0);
     assert.equal(logger.debugs.length, 1);
-    assert.match(
-        logger.debugs[0]?.message ?? '',
-        /Category sync no-op for account 'Noop Account': existing=4, backfills=0, conflicts=0, planned=0, skipped=0/
-    );
 });
 
 test('logCategorySyncSummary emits info for category activity', () => {

--- a/test/unit/importer-category-sync-flow.test.mjs
+++ b/test/unit/importer-category-sync-flow.test.mjs
@@ -408,7 +408,7 @@ test('emitImportRunSummary prints nothing-to-import for fully empty runs', () =>
     );
 
     assert.equal(logger.infos.length, 1);
-    assert.equal(logger.infos[0]?.message, 'Nothing to import.');
+    assert.match(logger.infos[0]?.message ?? '', /nothing.*import/i);
     assert.deepEqual(logger.infos[0]?.hints, []);
 });
 

--- a/test/unit/importer-category-sync-helpers.test.mjs
+++ b/test/unit/importer-category-sync-helpers.test.mjs
@@ -4,7 +4,6 @@ import {
     buildConflictPromptText,
     classifyCategoryUpdate,
     parsePromptDecision,
-    shouldEmitMappingConflictGuidance,
 } from '../../dist/utils/Importer.js';
 
 const stripAnsi = (value) =>
@@ -115,28 +114,4 @@ test('buildConflictPromptText groups transaction details, choices, and prompt la
         /Choose:\s+\[y\] update\s+\[n\] keep\s+\[A\] update all\s+\[N\] keep all\s+\[q\] quit/
     );
     assert.match(prompt, /Your choice:\s*$/);
-});
-
-test('shouldEmitMappingConflictGuidance requires both unmapped warnings and conflicts', () => {
-    assert.equal(
-        shouldEmitMappingConflictGuidance({
-            totalUnmappedCategoryWarnings: 1,
-            accountsWithConflicts: 1,
-        }),
-        true
-    );
-    assert.equal(
-        shouldEmitMappingConflictGuidance({
-            totalUnmappedCategoryWarnings: 1,
-            accountsWithConflicts: 0,
-        }),
-        false
-    );
-    assert.equal(
-        shouldEmitMappingConflictGuidance({
-            totalUnmappedCategoryWarnings: 0,
-            accountsWithConflicts: 1,
-        }),
-        false
-    );
 });

--- a/test/unit/importer-category-sync-helpers.test.mjs
+++ b/test/unit/importer-category-sync-helpers.test.mjs
@@ -67,16 +67,6 @@ test('classifyCategoryUpdate returns noop for unmapped target', () => {
     assert.deepEqual(result, { type: 'noop' });
 });
 
-test('classifyCategoryUpdate returns noop when both categories are undefined', () => {
-    const result = classifyCategoryUpdate({
-        currentCategoryId: undefined,
-        targetCategoryId: undefined,
-        isUncategorized: false,
-    });
-
-    assert.deepEqual(result, { type: 'noop' });
-});
-
 test('parsePromptDecision preserves A/N shortcuts before n/no', () => {
     assert.equal(parsePromptDecision('A'), 'all');
     assert.equal(parsePromptDecision('N'), 'none');

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -721,9 +721,16 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
             transfer_id: 'auto-created-counterpart',
         },
     ]);
+    const getTransactionsByIds = mock.fn(async () => [
+        {
+            id: 'actual-counterpart',
+            transfer_id: 'auto-created-counterpart',
+        },
+    ]);
     const updateTransaction = mock.fn(async () => {});
     const importer = makeImporter({
         getTransactions,
+        getTransactionsByIds,
         updateTransaction,
     });
 

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -771,6 +771,7 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
         {
             imported_id: 'mm-source-100',
             imported_payee: 'Example Sender',
+            date: '2026-04-21',
             notes: 'Ruecklagen',
             cleared: true,
         },

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -3,10 +3,22 @@ import { mock, test } from 'node:test';
 import Importer from '../../dist/utils/Importer.js';
 
 const makeLogger = () => ({
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
+    debugMessages: [],
+    infoMessages: [],
+    warnMessages: [],
+    errorMessages: [],
+    debug(message) {
+        this.debugMessages.push(message);
+    },
+    info(message) {
+        this.infoMessages.push(message);
+    },
+    warn(message) {
+        this.warnMessages.push(message);
+    },
+    error(message) {
+        this.errorMessages.push(message);
+    },
 });
 
 const makeMonMonAccount = ({ uuid, name, accountNumber }) => ({
@@ -58,8 +70,8 @@ const makeImporter = ({
     getTransactions = async () => [],
     getTransactionsByIds = async () => [],
     updateTransaction = async () => {},
+    logger = makeLogger(),
 } = {}) => {
-    const logger = makeLogger();
     const actualApi = {
         getTransactions,
         getTransactionsByIds,
@@ -1320,7 +1332,12 @@ test('applyExistingCounterpartConversions throws when the conversion payee updat
 test('applyExistingCounterpartConversions throws when the auto-created counterpart cannot be located', async () => {
     const updateTransaction = mock.fn(async () => {});
     const getTransactionsByIds = mock.fn(async () => []);
-    const importer = makeImporter({ updateTransaction, getTransactionsByIds });
+    const logger = makeLogger();
+    const importer = makeImporter({
+        updateTransaction,
+        getTransactionsByIds,
+        logger,
+    });
 
     await assert.rejects(
         () =>
@@ -1363,6 +1380,69 @@ test('applyExistingCounterpartConversions throws when the auto-created counterpa
         getTransactionsByIds.mock.callCount() >= 5,
         'expected retry attempts when the counterpart is initially missing'
     );
+    assert.ok(
+        logger.debugMessages.some(
+            (message) =>
+                message.includes('actual-counterpart') &&
+                message.includes('actual-target') &&
+                message.includes('attempt 5/5')
+        ),
+        'expected retry diagnostics to include the missing counterpart details'
+    );
+});
+
+test('applyExistingCounterpartConversions stops retrying on auth failures', async () => {
+    const updateTransaction = mock.fn(async () => {});
+    const authError = Object.assign(new Error('forbidden'), { status: 403 });
+    const getTransactionsByIds = mock.fn(async () => {
+        throw authError;
+    });
+    const logger = makeLogger();
+    const importer = makeImporter({
+        updateTransaction,
+        getTransactionsByIds,
+        logger,
+    });
+
+    await assert.rejects(
+        () =>
+            importer.applyExistingCounterpartConversions({
+                newMonMonTransactions: [
+                    makeTransaction({
+                        id: '100',
+                        accountUuid: 'mm-source',
+                        amount: -1440,
+                        accountNumber: 'DE-TARGET',
+                        name: 'Example Sender',
+                        purpose: 'Ruecklagen',
+                    }),
+                ],
+                transferPlan: {
+                    seedByImportedId: new Map(),
+                    suppressedImportedIds: new Set(),
+                    resolvedTransferCategoryUuids: new Set(),
+                    existingCounterpartConversionsByImportedId: new Map([
+                        [
+                            'mm-source-100',
+                            {
+                                existingCounterpartTransactionId:
+                                    'actual-counterpart',
+                                existingCounterpartAccountId: 'actual-target',
+                                existingCounterpartAccountName: 'Target',
+                                sourceActualAccountName: 'Source',
+                                sourceTransferPayeeId: 'payee-source',
+                                sourceImportedId: 'mm-source-100',
+                                sourceImportedPayee: 'Example Sender',
+                            },
+                        ],
+                    ]),
+                },
+            }),
+        /forbidden/
+    );
+
+    assert.equal(updateTransaction.mock.callCount(), 1);
+    assert.equal(getTransactionsByIds.mock.callCount(), 1);
 });
 
 test('applyExistingCounterpartConversions throws when stamping the auto-created counterpart fails', async () => {

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -82,7 +82,6 @@ const makeImporter = ({
             transfers: {
                 enabled: true,
                 categoryRefs: ['Transfer'],
-                matchWindowDays: 5,
             },
         },
         payeeTransformation: {
@@ -137,56 +136,6 @@ test('buildTransferPlan does not seed delayed transfer when counterpart date is 
                 monMonAccount: targetMonMon,
                 actualAccount: targetActual,
                 newMonMonTransactions: [],
-            },
-        ],
-        monMonTransactionMap: {
-            [sourceMonMon.uuid]: [sourceTx],
-            [targetMonMon.uuid]: [],
-        },
-        existingActualTransactionsByAccountId: new Map([
-            [sourceActual.id, []],
-            [targetActual.id, []],
-        ]),
-        transferPayeeIdByAccountId: new Map([
-            [targetActual.id, 'payee-target'],
-        ]),
-    });
-
-    assert.equal(plan.seedByImportedId.size, 0);
-});
-
-test('buildTransferPlan does not seed delayed transfer even when only source account is selected', () => {
-    const importer = makeImporter();
-    const sourceMonMon = makeMonMonAccount({
-        uuid: 'mm-source',
-        name: 'Source',
-        accountNumber: 'DE-SOURCE',
-    });
-    const targetMonMon = makeMonMonAccount({
-        uuid: 'mm-target',
-        name: 'Target',
-        accountNumber: 'DE-TARGET',
-    });
-    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
-    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
-    const sourceTx = makeTransaction({
-        id: '100',
-        accountUuid: sourceMonMon.uuid,
-        amount: -1440,
-        accountNumber: targetMonMon.accountNumber,
-        name: 'Example Sender',
-    });
-
-    const plan = importer.buildTransferPlan({
-        fullAccountMapping: makeFullAccountMapping([
-            [sourceMonMon, sourceActual],
-            [targetMonMon, targetActual],
-        ]),
-        accountStates: [
-            {
-                monMonAccount: sourceMonMon,
-                actualAccount: sourceActual,
-                newMonMonTransactions: [sourceTx],
             },
         ],
         monMonTransactionMap: {
@@ -336,11 +285,85 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
         plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart;
     assert.equal(plan.seedByImportedId.size, 1);
     assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
-    assert.equal(counterpart?.importedId, 'mm-target-200');
     assert.equal(counterpart?.importedPayee, 'Einzahlung');
-    assert.equal(counterpart?.date, '2026-04-21');
     assert.equal(counterpart?.notes, 'Ruecklagen | Comment: memo');
     assert.equal(counterpart?.cleared, true);
+});
+
+test('buildTransferPlan prefers the exact same-date same-run counterpart over nearby distractors', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        valueDate: '2026-04-21',
+        purpose: 'Ruecklagen',
+    });
+    const exactTargetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        valueDate: '2026-04-21',
+        purpose: 'Ruecklagen',
+    });
+    const distractorTx = makeTransaction({
+        id: '201',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        valueDate: '2026-04-24',
+        purpose: 'Something else',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [exactTargetTx, distractorTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [exactTargetTx, distractorTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    const counterpart =
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart;
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
+    assert.equal(counterpart?.importedId, 'mm-target-200');
 });
 
 test('buildTransferPlan suppresses same-run counterpart when source has hard target signal, even with different purpose', () => {
@@ -411,6 +434,69 @@ test('buildTransferPlan suppresses same-run counterpart when source has hard tar
     assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
 });
 
+test('buildTransferPlan rejects unrelated same-run transactions without a positive signal', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        purpose: undefined,
+        accountNumber: undefined,
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: undefined,
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+});
+
 test('buildTransferPlan skips same-run transfer when source and counterpart have different dates', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
@@ -454,7 +540,7 @@ test('buildTransferPlan skips same-run transfer when source and counterpart have
             {
                 monMonAccount: targetMonMon,
                 actualAccount: targetActual,
-                newMonMonTransactions: [targetTx],
+                newMonMonTransactions: [],
             },
         ],
         monMonTransactionMap: {
@@ -541,7 +627,6 @@ test('buildTransferPlan skips historical conversion when source and counterpart 
 
     assert.equal(plan.seedByImportedId.size, 0);
     assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
-    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
 });
 
 test('buildTransferPlan skips ambiguous same-run counterpart matches', () => {
@@ -625,20 +710,29 @@ test('buildTransferPlan plans conversion when counterpart already exists as plai
     });
     const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
     const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
-    const sourceTx = makeTransaction({
+    const sourceTx = {
         id: '100',
         accountUuid: sourceMonMon.uuid,
         amount: -1440,
         accountNumber: targetMonMon.accountNumber,
+        categoryUuid: 'mm-transfer',
+        valueDate: new Date('2026-04-21'),
+        bookingDate: new Date('2026-04-21'),
+        booked: true,
+        name: 'Txn',
         purpose: 'Ruecklagen',
-    });
-    const targetTx = makeTransaction({
+    };
+    const targetTx = {
         id: '200',
         accountUuid: targetMonMon.uuid,
         amount: 1440,
         categoryUuid: 'mm-uncategorized',
+        valueDate: new Date('2026-04-21'),
+        bookingDate: new Date('2026-04-21'),
+        booked: true,
+        name: 'Txn',
         purpose: 'Ruecklagen',
-    });
+    };
 
     const plan = importer.buildTransferPlan({
         fullAccountMapping: makeFullAccountMapping([
@@ -694,7 +788,173 @@ test('buildTransferPlan plans conversion when counterpart already exists as plai
     );
 });
 
-test('buildTransferPlan skips conversion when historical counterpart is already a transfer', () => {
+test('buildTransferPlan prefers the exact same-date historical counterpart over nearby distractors', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const exactTargetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const distractorTx = makeTransaction({
+        id: '201',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-24',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [exactTargetTx, distractorTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActual.id, 'payee-source'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 1);
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.get('mm-source-100')
+            ?.existingCounterpartTransactionId,
+        'actual-counterpart'
+    );
+});
+
+test('buildTransferPlan claims a historical counterpart only once', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTxA = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const sourceTxB = makeTransaction({
+        id: '101',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTxA, sourceTxB],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTxA, sourceTxB],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActual.id, 'payee-source'],
+        ]),
+    });
+
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 1);
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.has('mm-source-100'),
+        true
+    );
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.has('mm-source-101'),
+        false
+    );
+});
+
+test('buildTransferPlan skips historical conversion when the counterpart is already part of a transfer', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
         uuid: 'mm-source',
@@ -735,7 +995,7 @@ test('buildTransferPlan skips conversion when historical counterpart is already 
             {
                 monMonAccount: targetMonMon,
                 actualAccount: targetActual,
-                newMonMonTransactions: [targetTx],
+                newMonMonTransactions: [],
             },
         ],
         monMonTransactionMap: {
@@ -743,16 +1003,19 @@ test('buildTransferPlan skips conversion when historical counterpart is already 
             [targetMonMon.uuid]: [targetTx],
         },
         existingActualTransactionsByAccountId: new Map([
-            [sourceActual.id, []],
             [
-                targetActual.id,
+                sourceActual.id,
                 [
                     {
-                        id: 'actual-counterpart',
-                        imported_id: 'mm-target-200',
-                        transfer_id: 'other-transfer',
+                        id: 'auto-created-counterpart',
+                        imported_id: 'mm-source-100',
+                        transfer_id: 'actual-counterpart',
                     },
                 ],
+            ],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
             ],
         ]),
         transferPayeeIdByAccountId: new Map([
@@ -763,6 +1026,110 @@ test('buildTransferPlan skips conversion when historical counterpart is already 
 
     assert.equal(plan.seedByImportedId.size, 0);
     assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
+});
+
+test('buildTransferPlan does not let a missing transfer payee claim the historical counterpart', () => {
+    const importer = makeImporter();
+    const sourceMonMonA = makeMonMonAccount({
+        uuid: 'mm-source-a',
+        name: 'Source A',
+        accountNumber: 'DE-SOURCE-A',
+    });
+    const sourceMonMonB = makeMonMonAccount({
+        uuid: 'mm-source-b',
+        name: 'Source B',
+        accountNumber: 'DE-SOURCE-B',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActualA = makeActualAccount({
+        id: 'actual-source-a',
+        name: 'A',
+    });
+    const sourceActualB = makeActualAccount({
+        id: 'actual-source-b',
+        name: 'B',
+    });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTxA = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMonA.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const sourceTxB = makeTransaction({
+        id: '101',
+        accountUuid: sourceMonMonB.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMonA, sourceActualA],
+            [sourceMonMonB, sourceActualB],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMonA,
+                actualAccount: sourceActualA,
+                newMonMonTransactions: [sourceTxA],
+            },
+            {
+                monMonAccount: sourceMonMonB,
+                actualAccount: sourceActualB,
+                newMonMonTransactions: [sourceTxB],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMonA.uuid]: [sourceTxA],
+            [sourceMonMonB.uuid]: [sourceTxB],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActualA.id, []],
+            [sourceActualB.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActualB.id, 'payee-source-b'],
+        ]),
+    });
+
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 1);
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.has('mm-source-a-100'),
+        false
+    );
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.has('mm-source-b-101'),
+        true
+    );
 });
 
 test('buildTransferPlan skips conversion when source lacks transfer payee', () => {
@@ -903,6 +1270,153 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
             cleared: true,
         },
     ]);
+});
+
+test('applyExistingCounterpartConversions throws when the conversion payee update fails', async () => {
+    const updateTransaction = mock.fn(async () => {
+        throw new Error('boom');
+    });
+    const importer = makeImporter({ updateTransaction });
+
+    await assert.rejects(
+        () =>
+            importer.applyExistingCounterpartConversions({
+                newMonMonTransactions: [
+                    makeTransaction({
+                        id: '100',
+                        accountUuid: 'mm-source',
+                        amount: -1440,
+                        accountNumber: 'DE-TARGET',
+                        name: 'Example Sender',
+                        purpose: 'Ruecklagen',
+                    }),
+                ],
+                transferPlan: {
+                    seedByImportedId: new Map(),
+                    suppressedImportedIds: new Set(),
+                    resolvedTransferCategoryUuids: new Set(),
+                    existingCounterpartConversionsByImportedId: new Map([
+                        [
+                            'mm-source-100',
+                            {
+                                existingCounterpartTransactionId:
+                                    'actual-counterpart',
+                                existingCounterpartAccountId: 'actual-target',
+                                existingCounterpartAccountName: 'Target',
+                                sourceActualAccountName: 'Source',
+                                sourceTransferPayeeId: 'payee-source',
+                                sourceImportedId: 'mm-source-100',
+                                sourceImportedPayee: 'Example Sender',
+                            },
+                        ],
+                    ]),
+                },
+            }),
+        /Failed to convert plain transaction/
+    );
+    assert.equal(updateTransaction.mock.callCount(), 1);
+});
+
+test('applyExistingCounterpartConversions throws when the auto-created counterpart cannot be located', async () => {
+    const updateTransaction = mock.fn(async () => {});
+    const getTransactionsByIds = mock.fn(async () => []);
+    const importer = makeImporter({ updateTransaction, getTransactionsByIds });
+
+    await assert.rejects(
+        () =>
+            importer.applyExistingCounterpartConversions({
+                newMonMonTransactions: [
+                    makeTransaction({
+                        id: '100',
+                        accountUuid: 'mm-source',
+                        amount: -1440,
+                        accountNumber: 'DE-TARGET',
+                        name: 'Example Sender',
+                        purpose: 'Ruecklagen',
+                    }),
+                ],
+                transferPlan: {
+                    seedByImportedId: new Map(),
+                    suppressedImportedIds: new Set(),
+                    resolvedTransferCategoryUuids: new Set(),
+                    existingCounterpartConversionsByImportedId: new Map([
+                        [
+                            'mm-source-100',
+                            {
+                                existingCounterpartTransactionId:
+                                    'actual-counterpart',
+                                existingCounterpartAccountId: 'actual-target',
+                                existingCounterpartAccountName: 'Target',
+                                sourceActualAccountName: 'Source',
+                                sourceTransferPayeeId: 'payee-source',
+                                sourceImportedId: 'mm-source-100',
+                                sourceImportedPayee: 'Example Sender',
+                            },
+                        ],
+                    ]),
+                },
+            }),
+        /Could not locate auto-created transfer counterpart/
+    );
+    assert.equal(updateTransaction.mock.callCount(), 1);
+    assert.ok(
+        getTransactionsByIds.mock.callCount() >= 5,
+        'expected retry attempts when the counterpart is initially missing'
+    );
+});
+
+test('applyExistingCounterpartConversions throws when stamping the auto-created counterpart fails', async () => {
+    const updateTransaction = mock.fn(async (transactionId) => {
+        if (transactionId === 'auto-created-counterpart') {
+            throw new Error('stamp failed');
+        }
+    });
+    const getTransactionsByIds = mock.fn(async () => [
+        {
+            id: 'auto-created-counterpart',
+            transfer_id: 'auto-created-counterpart',
+        },
+    ]);
+    const importer = makeImporter({ updateTransaction, getTransactionsByIds });
+
+    await assert.rejects(
+        () =>
+            importer.applyExistingCounterpartConversions({
+                newMonMonTransactions: [
+                    makeTransaction({
+                        id: '100',
+                        accountUuid: 'mm-source',
+                        amount: -1440,
+                        accountNumber: 'DE-TARGET',
+                        name: 'Example Sender',
+                        purpose: 'Ruecklagen',
+                    }),
+                ],
+                transferPlan: {
+                    seedByImportedId: new Map(),
+                    suppressedImportedIds: new Set(),
+                    resolvedTransferCategoryUuids: new Set(),
+                    existingCounterpartConversionsByImportedId: new Map([
+                        [
+                            'mm-source-100',
+                            {
+                                existingCounterpartTransactionId:
+                                    'actual-counterpart',
+                                existingCounterpartAccountId: 'actual-target',
+                                existingCounterpartAccountName: 'Target',
+                                sourceActualAccountName: 'Source',
+                                sourceTransferPayeeId: 'payee-source',
+                                sourceImportedId: 'mm-source-100',
+                                sourceImportedPayee: 'Example Sender',
+                            },
+                        ],
+                    ]),
+                },
+            }),
+        /Failed to stamp auto-created transfer counterpart/
+    );
+    assert.equal(updateTransaction.mock.callCount(), 2);
+    assert.equal(getTransactionsByIds.mock.callCount(), 1);
 });
 
 test('buildTransferPlan does not suppress delayed counterpart when source side is no longer new', () => {
@@ -1095,7 +1609,6 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
                         sameRunCounterpart: {
                             importedId: 'mm-target-200',
                             importedPayee: 'Einzahlung',
-                            date: '2026-04-23',
                             notes: 'Ruecklagen',
                             cleared: true,
                         },

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -945,6 +945,7 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
     });
 
     await importer.applyTransferCounterpartUpdates({
+        actualAccountName: 'Source',
         importedTransactions: [
             {
                 id: 'source-tx',

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -986,7 +986,6 @@ test('applyTransferCounterpartUpdates stamps generated counterpart with second i
         {
             imported_id: 'mm-target-200',
             imported_payee: 'Einzahlung',
-            date: '2026-04-23',
             notes: 'Ruecklagen',
             cleared: true,
         },

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -727,7 +727,6 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
     });
 
     await importer.applyExistingCounterpartConversions({
-        actualAccountId: 'actual-source',
         newMonMonTransactions: [
             makeTransaction({
                 id: '100',
@@ -738,6 +737,7 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
                 purpose: 'Ruecklagen',
             }),
         ],
+
         transferPlan: {
             seedByImportedId: new Map(),
             suppressedImportedIds: new Set(),

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -310,7 +310,6 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
         accountUuid: targetMonMon.uuid,
         amount: 1440,
         categoryUuid: 'mm-uncategorized',
-        valueDate: '2026-04-23',
         name: 'Einzahlung',
         purpose: 'Ruecklagen',
         comment: 'memo',
@@ -352,7 +351,7 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
     assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
     assert.equal(counterpart?.importedId, 'mm-target-200');
     assert.equal(counterpart?.importedPayee, 'Einzahlung');
-    assert.equal(counterpart?.date, '2026-04-23');
+    assert.equal(counterpart?.date, '2026-04-21');
     assert.equal(counterpart?.notes, 'Ruecklagen | Comment: memo');
     assert.equal(counterpart?.cleared, true);
 });
@@ -423,6 +422,146 @@ test('buildTransferPlan suppresses same-run counterpart when source has hard tar
         'mm-target-200'
     );
     assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
+});
+
+test('buildTransferPlan skips same-run transfer when source and counterpart have different dates', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        valueDate: '2026-04-21',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        valueDate: '2026-04-24',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [targetActual.id, []],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
+        undefined
+    );
+    assert.deepEqual([...plan.suppressedImportedIds], []);
+});
+
+test('buildTransferPlan skips historical conversion when source and counterpart have different dates', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-21',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+        valueDate: '2026-04-24',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActual.id, 'payee-source'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 1);
+    assert.equal(
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
+        undefined
+    );
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
 });
 
 test('buildTransferPlan skips ambiguous same-run counterpart matches', () => {

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -741,6 +741,7 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
         transferPlan: {
             seedByImportedId: new Map(),
             suppressedImportedIds: new Set(),
+            resolvedTransferCategoryUuids: new Set(),
             existingCounterpartConversionsByImportedId: new Map([
                 [
                     'mm-source-100',

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -491,7 +491,90 @@ test('buildTransferPlan skips ambiguous same-run counterpart matches', () => {
     assert.deepEqual([...plan.suppressedImportedIds], []);
 });
 
-test('buildTransferPlan skips automatic transfer when counterpart already exists in Actual', () => {
+test('buildTransferPlan plans conversion when counterpart already exists as plain transaction', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+        purpose: 'Ruecklagen',
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+        purpose: 'Ruecklagen',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActual.id, 'payee-source'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.deepEqual([...plan.suppressedImportedIds], ['mm-source-100']);
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 1);
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.get('mm-source-100')
+            ?.existingCounterpartTransactionId,
+        'actual-counterpart'
+    );
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.get('mm-source-100')
+            ?.sourceTransferPayeeId,
+        'payee-source'
+    );
+    assert.equal(
+        plan.existingCounterpartConversionsByImportedId.get('mm-source-100')
+            ?.sourceImportedId,
+        'mm-source-100'
+    );
+});
+
+test('buildTransferPlan skips conversion when historical counterpart is already a transfer', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
         uuid: 'mm-source',
@@ -541,7 +624,81 @@ test('buildTransferPlan skips automatic transfer when counterpart already exists
         },
         existingActualTransactionsByAccountId: new Map([
             [sourceActual.id, []],
-            [targetActual.id, [{ imported_id: 'mm-target-200' }]],
+            [
+                targetActual.id,
+                [
+                    {
+                        id: 'actual-counterpart',
+                        imported_id: 'mm-target-200',
+                        transfer_id: 'other-transfer',
+                    },
+                ],
+            ],
+        ]),
+        transferPayeeIdByAccountId: new Map([
+            [targetActual.id, 'payee-target'],
+            [sourceActual.id, 'payee-source'],
+        ]),
+    });
+
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
+});
+
+test('buildTransferPlan skips conversion when source lacks transfer payee', () => {
+    const importer = makeImporter();
+    const sourceMonMon = makeMonMonAccount({
+        uuid: 'mm-source',
+        name: 'Source',
+        accountNumber: 'DE-SOURCE',
+    });
+    const targetMonMon = makeMonMonAccount({
+        uuid: 'mm-target',
+        name: 'Target',
+        accountNumber: 'DE-TARGET',
+    });
+    const sourceActual = makeActualAccount({ id: 'actual-source', name: 'A' });
+    const targetActual = makeActualAccount({ id: 'actual-target', name: 'B' });
+    const sourceTx = makeTransaction({
+        id: '100',
+        accountUuid: sourceMonMon.uuid,
+        amount: -1440,
+        accountNumber: targetMonMon.accountNumber,
+    });
+    const targetTx = makeTransaction({
+        id: '200',
+        accountUuid: targetMonMon.uuid,
+        amount: 1440,
+        categoryUuid: 'mm-uncategorized',
+    });
+
+    const plan = importer.buildTransferPlan({
+        fullAccountMapping: makeFullAccountMapping([
+            [sourceMonMon, sourceActual],
+            [targetMonMon, targetActual],
+        ]),
+        accountStates: [
+            {
+                monMonAccount: sourceMonMon,
+                actualAccount: sourceActual,
+                newMonMonTransactions: [sourceTx],
+            },
+            {
+                monMonAccount: targetMonMon,
+                actualAccount: targetActual,
+                newMonMonTransactions: [targetTx],
+            },
+        ],
+        monMonTransactionMap: {
+            [sourceMonMon.uuid]: [sourceTx],
+            [targetMonMon.uuid]: [targetTx],
+        },
+        existingActualTransactionsByAccountId: new Map([
+            [sourceActual.id, []],
+            [
+                targetActual.id,
+                [{ id: 'actual-counterpart', imported_id: 'mm-target-200' }],
+            ],
         ]),
         transferPayeeIdByAccountId: new Map([
             [targetActual.id, 'payee-target'],
@@ -549,6 +706,73 @@ test('buildTransferPlan skips automatic transfer when counterpart already exists
     });
 
     assert.equal(plan.seedByImportedId.size, 0);
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
+});
+
+test('applyExistingCounterpartConversions converts plain counterpart and stamps auto-created source counterpart', async () => {
+    const getTransactions = mock.fn(async () => [
+        {
+            id: 'auto-created-counterpart',
+            transfer_id: 'source-counterpart-transfer',
+        },
+        {
+            id: 'actual-counterpart',
+            transfer_id: 'auto-created-counterpart',
+        },
+    ]);
+    const updateTransaction = mock.fn(async () => {});
+    const importer = makeImporter({
+        getTransactions,
+        updateTransaction,
+    });
+
+    await importer.applyExistingCounterpartConversions({
+        actualAccountId: 'actual-source',
+        newMonMonTransactions: [
+            makeTransaction({
+                id: '100',
+                accountUuid: 'mm-source',
+                amount: -1440,
+                accountNumber: 'DE-TARGET',
+                name: 'Example Sender',
+                purpose: 'Ruecklagen',
+            }),
+        ],
+        transferPlan: {
+            seedByImportedId: new Map(),
+            suppressedImportedIds: new Set(),
+            existingCounterpartConversionsByImportedId: new Map([
+                [
+                    'mm-source-100',
+                    {
+                        existingCounterpartTransactionId: 'actual-counterpart',
+                        existingCounterpartAccountId: 'actual-target',
+                        existingCounterpartAccountName: 'Target',
+                        sourceTransferPayeeId: 'payee-source',
+                        sourceImportedId: 'mm-source-100',
+                        sourceImportedPayee: 'Example Sender',
+                        sourceNotes: 'Ruecklagen',
+                        sourceCleared: true,
+                    },
+                ],
+            ]),
+        },
+    });
+
+    assert.equal(updateTransaction.mock.callCount(), 2);
+    assert.deepEqual(updateTransaction.mock.calls[0].arguments, [
+        'actual-counterpart',
+        { payee: 'payee-source' },
+    ]);
+    assert.deepEqual(updateTransaction.mock.calls[1].arguments, [
+        'auto-created-counterpart',
+        {
+            imported_id: 'mm-source-100',
+            imported_payee: 'Example Sender',
+            notes: 'Ruecklagen',
+            cleared: true,
+        },
+    ]);
 });
 
 test('buildTransferPlan does not suppress delayed counterpart when source side is no longer new', () => {

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -357,7 +357,7 @@ test('buildTransferPlan suppresses unique same-run counterpart and carries metad
     assert.equal(counterpart?.cleared, true);
 });
 
-test('buildTransferPlan does not suppress unrelated same-amount target transaction with different purpose', () => {
+test('buildTransferPlan suppresses same-run counterpart when source has hard target signal, even with different purpose', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
         uuid: 'mm-source',
@@ -418,10 +418,11 @@ test('buildTransferPlan does not suppress unrelated same-amount target transacti
 
     assert.equal(plan.seedByImportedId.size, 1);
     assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
-        undefined
+        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart
+            ?.importedId,
+        'mm-target-200'
     );
-    assert.deepEqual([...plan.suppressedImportedIds], []);
+    assert.deepEqual([...plan.suppressedImportedIds], ['mm-target-200']);
 });
 
 test('buildTransferPlan skips ambiguous same-run counterpart matches', () => {

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -100,7 +100,7 @@ const makeImporter = ({
     );
 };
 
-test('buildTransferPlan creates delayed transfer seed from hard target account match', () => {
+test('buildTransferPlan does not seed delayed transfer when counterpart date is unknown', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
         uuid: 'mm-source',
@@ -152,19 +152,10 @@ test('buildTransferPlan creates delayed transfer seed from hard target account m
         ]),
     });
 
-    assert.equal(plan.seedByImportedId.size, 1);
-    assert.deepEqual([...plan.suppressedImportedIds], []);
-    assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.transferPayeeId,
-        'payee-target'
-    );
-    assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
-        undefined
-    );
+    assert.equal(plan.seedByImportedId.size, 0);
 });
 
-test('buildTransferPlan can seed transfer when only source account is selected', () => {
+test('buildTransferPlan does not seed delayed transfer even when only source account is selected', () => {
     const importer = makeImporter();
     const sourceMonMon = makeMonMonAccount({
         uuid: 'mm-source',
@@ -211,11 +202,7 @@ test('buildTransferPlan can seed transfer when only source account is selected',
         ]),
     });
 
-    assert.equal(plan.seedByImportedId.size, 1);
-    assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.targetActualAccountId,
-        'actual-target'
-    );
+    assert.equal(plan.seedByImportedId.size, 0);
 });
 
 test('buildTransferPlan skips automatic transfer when mapped account numbers are ambiguous', () => {
@@ -483,11 +470,7 @@ test('buildTransferPlan skips same-run transfer when source and counterpart have
         ]),
     });
 
-    assert.equal(plan.seedByImportedId.size, 1);
-    assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
-        undefined
-    );
+    assert.equal(plan.seedByImportedId.size, 0);
     assert.deepEqual([...plan.suppressedImportedIds], []);
 });
 
@@ -556,11 +539,8 @@ test('buildTransferPlan skips historical conversion when source and counterpart 
         ]),
     });
 
-    assert.equal(plan.seedByImportedId.size, 1);
-    assert.equal(
-        plan.seedByImportedId.get('mm-source-100')?.sameRunCounterpart,
-        undefined
-    );
+    assert.equal(plan.seedByImportedId.size, 0);
+    assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
     assert.equal(plan.existingCounterpartConversionsByImportedId.size, 0);
 });
 

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -748,6 +748,7 @@ test('applyExistingCounterpartConversions converts plain counterpart and stamps 
                         existingCounterpartTransactionId: 'actual-counterpart',
                         existingCounterpartAccountId: 'actual-target',
                         existingCounterpartAccountName: 'Target',
+                        sourceActualAccountName: 'Source',
                         sourceTransferPayeeId: 'payee-source',
                         sourceImportedId: 'mm-source-100',
                         sourceImportedPayee: 'Example Sender',


### PR DESCRIPTION
## Summary
This branch improves automatic transfer handling: when both sides of a transfer are imported together, Actual creates the transfer automatically; if one side was already imported earlier as a plain transaction, the importer can turn that existing transaction into a transfer later, but only when the dates match exactly.

## Scope
- automatically create transfers when both sides arrive in the same import run
- turn an existing plain transaction in Actual into a transfer when the matching source transaction arrives later, but only on an exact date match
- keep matching strict; no delayed or fuzzy fallback
- improve retry/auth handling and reduce noisy logs around transfer handling
- clean up transfer-related logging, docs, and obsolete config
- keep the test suite focused on behavior rather than duplicates

## Testing
- `rtk npm run lint:prettier`
- `rtk npm run lint:eslint`
- `rtk npm run test`

## Notes
- config option cleanup included
- weak matches still fall back to normal import