### PR TITLE
fix: harden Actual API log suppression

### DIFF
--- a/src/utils/ActualApiLogControl.ts
+++ b/src/utils/ActualApiLogControl.ts
@@ -4,8 +4,24 @@ const API_NOISE_PATTERNS = [
     /^\[Breadcrumb\]/,
 ];
 
+// Keep this list small and explicit; these are the only known Actual log lines
+// we want to suppress while preserving everything else.
 const isApiNoiseLine = (line: string): boolean =>
     API_NOISE_PATTERNS.some((pattern) => pattern.test(line.trim()));
+
+type ConsoleMethod = typeof console.log;
+type StreamWrite = typeof process.stdout.write;
+type StreamWriteArgs = Parameters<StreamWrite>;
+type StreamWriteCallback = (err?: Error | null) => void;
+
+// Only one top-level suppressing call should be active at a time.
+// Nested calls within a single async chain are safe.
+let globalApiNoiseFilterDepth = 0;
+
+const getStreamWriteCallback = (args: StreamWriteArgs) =>
+    args.find(
+        (value): value is StreamWriteCallback => typeof value === 'function'
+    );
 
 export async function withApiLogControl<T>(
     verbose: boolean,
@@ -33,17 +49,31 @@ export async function withGlobalApiNoiseFilter<T>(
         return await callback();
     }
 
+    const shouldPatchGlobals = globalApiNoiseFilterDepth === 0;
+    globalApiNoiseFilterDepth++;
+
+    if (!shouldPatchGlobals) {
+        try {
+            return await callback();
+        } finally {
+            globalApiNoiseFilterDepth--;
+        }
+    }
+
     const originalConsoleLog = console.log;
     const originalConsoleInfo = console.info;
     const originalConsoleWarn = console.warn;
     const originalConsoleError = console.error;
-    const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-    const originalStderrWrite = process.stderr.write.bind(process.stderr);
-    let suppressNextStandaloneNewline = false;
+    const originalStdoutWrite = process.stdout.write.bind(
+        process.stdout
+    ) as StreamWrite;
+    const originalStderrWrite = process.stderr.write.bind(
+        process.stderr
+    ) as StreamWrite;
 
     const filterConsoleMethod =
-        (method: (...args: unknown[]) => void) =>
-        (...args: unknown[]) => {
+        (method: ConsoleMethod): ConsoleMethod =>
+        (...args: Parameters<ConsoleMethod>) => {
             const firstArg = args[0];
             if (typeof firstArg === 'string' && isApiNoiseLine(firstArg)) {
                 return;
@@ -51,10 +81,11 @@ export async function withGlobalApiNoiseFilter<T>(
             method(...args);
         };
 
-    const filterWrite =
-        (write: (...args: StreamWriteArg[]) => boolean) =>
-        (...args: StreamWriteArg[]) => {
-            const chunk = args[0] as string | Uint8Array;
+    const filterWrite = (write: StreamWrite) => {
+        let suppressNextStandaloneNewline = false;
+
+        return ((...args: StreamWriteArgs) => {
+            const chunk = args[0];
             const text =
                 typeof chunk === 'string'
                     ? chunk
@@ -62,46 +93,31 @@ export async function withGlobalApiNoiseFilter<T>(
 
             if (suppressNextStandaloneNewline && /^\r?\n$/.test(text)) {
                 suppressNextStandaloneNewline = false;
-                const completionCallback = args.find(
-                    (value): value is (err?: Error | null) => void =>
-                        typeof value === 'function'
-                );
+                const completionCallback = getStreamWriteCallback(args);
                 completionCallback?.();
                 return true;
             }
 
             if (isApiNoiseLine(text)) {
+                // Actual sometimes emits the payload and the trailing newline as
+                // separate writes. Keep the next standalone newline from leaking.
                 suppressNextStandaloneNewline = true;
-                const completionCallback = args.find(
-                    (value): value is (err?: Error | null) => void =>
-                        typeof value === 'function'
-                );
+                const completionCallback = getStreamWriteCallback(args);
                 completionCallback?.();
                 return true;
             }
 
             suppressNextStandaloneNewline = false;
             return write(...args);
-        };
+        }) as StreamWrite;
+    };
 
-    console.log = filterConsoleMethod(
-        originalConsoleLog as unknown as (...args: unknown[]) => void
-    );
-    console.info = filterConsoleMethod(
-        originalConsoleInfo as unknown as (...args: unknown[]) => void
-    );
-    console.warn = filterConsoleMethod(
-        originalConsoleWarn as unknown as (...args: unknown[]) => void
-    );
-    console.error = filterConsoleMethod(
-        originalConsoleError as unknown as (...args: unknown[]) => void
-    );
-    process.stdout.write = filterWrite(
-        originalStdoutWrite as unknown as (...args: StreamWriteArg[]) => boolean
-    ) as unknown as typeof process.stdout.write;
-    process.stderr.write = filterWrite(
-        originalStderrWrite as unknown as (...args: StreamWriteArg[]) => boolean
-    ) as unknown as typeof process.stderr.write;
+    console.log = filterConsoleMethod(originalConsoleLog);
+    console.info = filterConsoleMethod(originalConsoleInfo);
+    console.warn = filterConsoleMethod(originalConsoleWarn);
+    console.error = filterConsoleMethod(originalConsoleError);
+    process.stdout.write = filterWrite(originalStdoutWrite);
+    process.stderr.write = filterWrite(originalStderrWrite);
 
     try {
         return await callback();
@@ -112,11 +128,6 @@ export async function withGlobalApiNoiseFilter<T>(
         console.error = originalConsoleError;
         process.stdout.write = originalStdoutWrite;
         process.stderr.write = originalStderrWrite;
+        globalApiNoiseFilterDepth--;
     }
 }
-type StreamWriteCallback = (err?: Error | null) => void;
-type StreamWriteArg =
-    | string
-    | Uint8Array
-    | BufferEncoding
-    | StreamWriteCallback;

--- a/test/unit/actual-api-log-control.test.mjs
+++ b/test/unit/actual-api-log-control.test.mjs
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+    withApiLogControl,
+    withGlobalApiNoiseFilter,
+} from '../../dist/utils/ActualApiLogControl.js';
+
+const normalizeChunk = (chunk) =>
+    typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+
+const createCaptureState = () => ({
+    log: [],
+    info: [],
+    warn: [],
+    error: [],
+    stdout: [],
+    stderr: [],
+});
+
+const createCaptureMethods = (calls) => ({
+    log: (...args) => {
+        calls.log.push(args[0]);
+    },
+    info: (...args) => {
+        calls.info.push(args[0]);
+    },
+    warn: (...args) => {
+        calls.warn.push(args[0]);
+    },
+    error: (...args) => {
+        calls.error.push(args[0]);
+    },
+    stdout: (...args) => {
+        calls.stdout.push(normalizeChunk(args[0]));
+        const callback = args.find((value) => typeof value === 'function');
+        callback?.();
+        return true;
+    },
+    stderr: (...args) => {
+        calls.stderr.push(normalizeChunk(args[0]));
+        const callback = args.find((value) => typeof value === 'function');
+        callback?.();
+        return true;
+    },
+});
+
+const patchGlobals = (t, methods) => {
+    const originals = {
+        log: console.log,
+        info: console.info,
+        warn: console.warn,
+        error: console.error,
+        stdout: process.stdout.write,
+        stderr: process.stderr.write,
+    };
+
+    console.log = methods.log;
+    console.info = methods.info;
+    console.warn = methods.warn;
+    console.error = methods.error;
+    process.stdout.write = methods.stdout;
+    process.stderr.write = methods.stderr;
+
+    t.after(() => {
+        console.log = originals.log;
+        console.info = originals.info;
+        console.warn = originals.warn;
+        console.error = originals.error;
+        process.stdout.write = originals.stdout;
+        process.stderr.write = originals.stderr;
+    });
+};
+
+test('withApiLogControl suppresses console.log when verbose is false', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withApiLogControl(false, async () => {
+        console.log('hidden');
+        console.info('shown');
+    });
+
+    assert.deepEqual(calls.log, []);
+    assert.deepEqual(calls.info, ['shown']);
+    assert.strictEqual(console.log, methods.log);
+});
+
+test('withApiLogControl passes through console.log when verbose is true', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withApiLogControl(true, async () => {
+        console.log('visible');
+    });
+
+    assert.deepEqual(calls.log, ['visible']);
+    assert.strictEqual(console.log, methods.log);
+});
+
+test('withApiLogControl restores console.log after errors', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await assert.rejects(
+        () =>
+            withApiLogControl(false, async () => {
+                console.log('hidden');
+                throw new Error('boom');
+            }),
+        /boom/
+    );
+
+    assert.deepEqual(calls.log, []);
+    assert.strictEqual(console.log, methods.log);
+});
+
+test('withGlobalApiNoiseFilter suppresses known Actual noise', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        console.log('Syncing since 2026-01-01');
+        console.warn('Got messages from server 123');
+        console.error('[Breadcrumb] trace');
+        console.info('keep this');
+        process.stdout.write('Syncing since 2026-01-01\n');
+        process.stdout.write('\n');
+        process.stdout.write('keep stdout\n');
+        process.stderr.write('Got messages from server 123\n');
+        process.stderr.write('keep stderr\n');
+    });
+
+    assert.deepEqual(calls.log, []);
+    assert.deepEqual(calls.warn, []);
+    assert.deepEqual(calls.error, []);
+    assert.deepEqual(calls.info, ['keep this']);
+    assert.deepEqual(calls.stdout, ['keep stdout\n']);
+    assert.deepEqual(calls.stderr, ['keep stderr\n']);
+    assert.strictEqual(console.log, methods.log);
+
+    process.stdout.write('after restore stdout\n');
+    process.stderr.write('after restore stderr\n');
+
+    assert.deepEqual(calls.stdout, ['keep stdout\n', 'after restore stdout\n']);
+    assert.deepEqual(calls.stderr, ['keep stderr\n', 'after restore stderr\n']);
+});
+
+test('withGlobalApiNoiseFilter does not bleed newline suppression across streams', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        process.stdout.write('Syncing since 2026-01-01\n');
+        process.stderr.write('\n');
+        process.stdout.write('keep stdout\n');
+        process.stderr.write('keep stderr\n');
+    });
+
+    assert.deepEqual(calls.stdout, ['keep stdout\n']);
+    assert.deepEqual(calls.stderr, ['\n', 'keep stderr\n']);
+});
+
+test('withGlobalApiNoiseFilter passes through when suppression is disabled', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(false, async () => {
+        console.log('plain log');
+        process.stdout.write('plain stdout\n');
+        process.stderr.write('plain stderr\n');
+    });
+
+    assert.deepEqual(calls.log, ['plain log']);
+    assert.deepEqual(calls.stdout, ['plain stdout\n']);
+    assert.deepEqual(calls.stderr, ['plain stderr\n']);
+    assert.strictEqual(console.log, methods.log);
+
+    process.stdout.write('after restore stdout\n');
+    process.stderr.write('after restore stderr\n');
+
+    assert.deepEqual(calls.stdout, [
+        'plain stdout\n',
+        'after restore stdout\n',
+    ]);
+    assert.deepEqual(calls.stderr, [
+        'plain stderr\n',
+        'after restore stderr\n',
+    ]);
+});
+
+test('withGlobalApiNoiseFilter supports nested suppression', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        await withGlobalApiNoiseFilter(true, async () => {
+            console.log('Syncing since 2026-01-01');
+            process.stdout.write('Got messages from server 123\n');
+        });
+
+        console.info('still visible');
+        process.stdout.write('keep outer stdout\n');
+    });
+
+    assert.deepEqual(calls.log, []);
+    assert.deepEqual(calls.stdout, ['keep outer stdout\n']);
+    assert.deepEqual(calls.info, ['still visible']);
+});
+
+test('withGlobalApiNoiseFilter keeps outer suppression across inner passthrough', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        await withGlobalApiNoiseFilter(false, async () => {
+            console.log('Syncing since 2026-01-01');
+            process.stdout.write('Got messages from server 123\n');
+            console.info('inner visible');
+        });
+
+        console.info('outer visible');
+        process.stdout.write('keep outer stdout\n');
+    });
+
+    assert.deepEqual(calls.log, []);
+    assert.deepEqual(calls.info, ['inner visible', 'outer visible']);
+    assert.deepEqual(calls.stdout, ['keep outer stdout\n']);
+});
+
+test('withGlobalApiNoiseFilter recovers after nested inner error', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        await assert.rejects(
+            () =>
+                withGlobalApiNoiseFilter(true, async () => {
+                    console.log('Syncing since 2026-01-01');
+                    throw new Error('boom');
+                }),
+            /boom/
+        );
+
+        console.log('Syncing since 2026-01-01');
+        process.stdout.write('keep outer stdout\n');
+    });
+
+    await withGlobalApiNoiseFilter(true, async () => {
+        console.log('Syncing since 2026-01-01');
+        process.stdout.write('keep post recovery stdout\n');
+    });
+
+    assert.deepEqual(calls.log, []);
+    assert.deepEqual(calls.stdout, [
+        'keep outer stdout\n',
+        'keep post recovery stdout\n',
+    ]);
+});
+
+test('withGlobalApiNoiseFilter restores globals after errors', async (t) => {
+    const calls = createCaptureState();
+    const methods = createCaptureMethods(calls);
+    patchGlobals(t, methods);
+
+    await assert.rejects(
+        () =>
+            withGlobalApiNoiseFilter(true, async () => {
+                console.log('Syncing since 2026-01-01');
+                throw new Error('boom');
+            }),
+        /boom/
+    );
+
+    assert.deepEqual(calls.log, []);
+    assert.strictEqual(console.log, methods.log);
+
+    process.stdout.write('after restore stdout\n');
+    process.stderr.write('after restore stderr\n');
+
+    assert.deepEqual(calls.stdout, ['after restore stdout\n']);
+    assert.deepEqual(calls.stderr, ['after restore stderr\n']);
+});


### PR DESCRIPTION
## Summary
- Harden `ActualApiLogControl` with safer restore behavior and per-stream newline suppression.
- Add focused unit coverage for suppression, nesting, recovery, and cross-stream newline behavior.
- Keep the existing logging strategy intact while documenting the remaining assumptions.

## Testing
- npm run test:unit
- npm run lint:eslint
- npm run lint:prettier

## Notes
- No breaking changes.
- The noise filter still assumes a single top-level suppressing call at a time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of known Actual API "noise" in console output for cleaner logs.

* **Refactor**
  * Enhanced internal API log control to better handle nested operations and prevent redundant global patching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->