### PR TITLE
chore(deps): bundle dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
       directory: '/'
       schedule:
           interval: weekly
+      groups:
+          npm-dependencies:
+              patterns:
+                  - '*'
       commit-message:
           prefix: chore
           prefix-development: chore

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,17 +209,17 @@
             }
         },
         "node_modules/@commitlint/cli": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.0.tgz",
-            "integrity": "sha512-p3y2oC0G2R45zaadMwBxCiSesS8digi5RDplP3Zrfpzm7xIgrgAj0W4fGzONjpHyg8obDVJDU45g5txzeMcblg==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.1.tgz",
+            "integrity": "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/format": "^21.0.0",
-                "@commitlint/lint": "^21.0.0",
-                "@commitlint/load": "^21.0.0",
-                "@commitlint/read": "^21.0.0",
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/format": "^21.0.1",
+                "@commitlint/lint": "^21.0.1",
+                "@commitlint/load": "^21.0.1",
+                "@commitlint/read": "^21.0.1",
+                "@commitlint/types": "^21.0.1",
                 "tinyexec": "^1.0.0",
                 "yargs": "^18.0.0"
             },
@@ -231,13 +231,13 @@
             }
         },
         "node_modules/@commitlint/config-conventional": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.0.tgz",
-            "integrity": "sha512-QJX/rPK4Yu3f5J4OCIBy5aXq2e0EEdwSDFZ3NQvFAXTm3gs12ipyZ+yjhZxm3hHn6DB8wuv3zhFTL1I2tYzUBA==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.1.tgz",
+            "integrity": "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "conventional-changelog-conventionalcommits": "^9.2.0"
             },
             "engines": {
@@ -245,13 +245,13 @@
             }
         },
         "node_modules/@commitlint/config-validator": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.0.tgz",
-            "integrity": "sha512-v0UplTYryNUB463X5WrelzKq5/qyYm9/iUNk38S7ZLnd56Uuk2T9awhYKGlgD2/4L5YuN2gsKkyy4EHpRPPz2Q==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz",
+            "integrity": "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "ajv": "^8.11.0"
             },
             "engines": {
@@ -259,13 +259,13 @@
             }
         },
         "node_modules/@commitlint/ensure": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.0.tgz",
-            "integrity": "sha512-n+OYs0Ws9GKC2WlmAeLNoPz9CUg6n/ZyYMkFF8rJ0aMn2kDTDTG0VqK/2Dco0EB4fhuF3JPIllJmU9/LKTl4aw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz",
+            "integrity": "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "es-toolkit": "^1.46.0"
             },
             "engines": {
@@ -273,9 +273,9 @@
             }
         },
         "node_modules/@commitlint/execute-rule": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.0.tgz",
-            "integrity": "sha512-3OhTq2gQX1tEheMsbDNqxfcNHsAM6g9cub9plf05I9jCxtbNfn8Y+mhClKyUwhX4dbtmC4OLZ9i+HNmoL1aksA==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+            "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -283,13 +283,13 @@
             }
         },
         "node_modules/@commitlint/format": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.0.tgz",
-            "integrity": "sha512-RTfGSrueEgofs1piqwi42U05d85wfxiMH2ncMCZnltx1XqPR3N2S48oACBtTy4xRAhWlf5XlHkK2RaDzEQu3dA==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz",
+            "integrity": "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "picocolors": "^1.1.1"
             },
             "engines": {
@@ -297,13 +297,13 @@
             }
         },
         "node_modules/@commitlint/is-ignored": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.0.tgz",
-            "integrity": "sha512-K3SaaOTVY9VKhge7vl0R3ng7GENRzJQ9MPV43Tu53kAwEgSx/E0HF4US3AcVqdvlvsDUbF2yXvED95dhela83w==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.1.tgz",
+            "integrity": "sha512-iNDP8SFdw8JEkM0CHZ2XFnhTN4Zg5jKUY2d8kBOSFrI2aA+3YJI7fcqVpfgbpJ9xtxFVYpi+DBATU5AvhoTq8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "semver": "^7.6.0"
             },
             "engines": {
@@ -311,32 +311,32 @@
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.0.tgz",
-            "integrity": "sha512-dlUJA0Ka14R1YaR46JVRWE3m/8dOQAgE/D0heUfzYua5Jogtq/zzu2ITAIaB/u25DaKjtEO6kuvASzsFDyrPMw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.1.tgz",
+            "integrity": "sha512-gF+iYtUw1gBG3HUH9z3VxwUjGg2R2G5j+nmvPs8aIeYkiB7TtneBu3wO85I0bUl93bYNsvsCNI9Nte2fmDUMww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/is-ignored": "^21.0.0",
-                "@commitlint/parse": "^21.0.0",
-                "@commitlint/rules": "^21.0.0",
-                "@commitlint/types": "^21.0.0"
+                "@commitlint/is-ignored": "^21.0.1",
+                "@commitlint/parse": "^21.0.1",
+                "@commitlint/rules": "^21.0.1",
+                "@commitlint/types": "^21.0.1"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.0.tgz",
-            "integrity": "sha512-l0nBfO/20PKcJXHZqDIgh7kw/TWVVwn8zZJOkVGBK/ig/h328jBu9jK7OiDl2oZr5mLphmKGjYDR2ffEyb2lIA==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.1.tgz",
+            "integrity": "sha512-Btg1q1mKmiihN4W3x0EsPDrJMOQfMa9NIqlzlJyXAfxvsOGdGXOW5p3R3RcSxDCaY7JabY9flIl+Om1af3PSrw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^21.0.0",
-                "@commitlint/execute-rule": "^21.0.0",
-                "@commitlint/resolve-extends": "^21.0.0",
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/config-validator": "^21.0.1",
+                "@commitlint/execute-rule": "^21.0.1",
+                "@commitlint/resolve-extends": "^21.0.1",
+                "@commitlint/types": "^21.0.1",
                 "cosmiconfig": "^9.0.1",
                 "cosmiconfig-typescript-loader": "^6.1.0",
                 "es-toolkit": "^1.46.0",
@@ -348,9 +348,9 @@
             }
         },
         "node_modules/@commitlint/message": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.0.tgz",
-            "integrity": "sha512-+daU92JaOHhI2En9KcH+2mvZGJ6D4YSxb/32QDwqkOwSj1Vanjio8PbAqX7dneACdg6B7RgQ7i3mpyYZAws4nw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.1.tgz",
+            "integrity": "sha512-R3dVQeJQ0B6yqrZEjkUHD4r7UJYLV9Lvk2xs3PTOmtWk2G3mI6Xgc+YdRxL1PwcDfBiUjv2SkIkW4AUc976w1w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -358,13 +358,13 @@
             }
         },
         "node_modules/@commitlint/parse": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.0.tgz",
-            "integrity": "sha512-1dbvFBcQK79aTbpc2QCrgEDc6/MMkQ0Mdz4gGmYkN4AHMnAK9HesSewTHqGTrW5mALrMlYSgcWyvKjloY2w19A==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.1.tgz",
+            "integrity": "sha512-oh/nCSOqdoeQNA1tO8aAmxkq5EBo8/NzcFQRvv66AWc9HpED28sL2iSicCKU6hPintWuscL6BJEWi77Wq1LPMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/types": "^21.0.1",
                 "conventional-changelog-angular": "^8.2.0",
                 "conventional-commits-parser": "^6.3.0"
             },
@@ -373,14 +373,14 @@
             }
         },
         "node_modules/@commitlint/read": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.0.tgz",
-            "integrity": "sha512-8VKLKLl2vBSKoTMm1LwcySsyxrBeotnqcT5qJi9pPuPfqSapdAD870Ckgh79c41UFywL6kMqtiyY+kxtfcqZGg==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.1.tgz",
+            "integrity": "sha512-pMEu4lbpC8W0ZgKJj2U6WaobXIZWdFlULpIEewYhkPXx+WZcnoO53YrVPc7QErQuNolq2Me8dP58Wu7YAVXVOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/top-level": "^21.0.0",
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/top-level": "^21.0.1",
+                "@commitlint/types": "^21.0.1",
                 "git-raw-commits": "^5.0.0",
                 "tinyexec": "^1.0.0"
             },
@@ -389,14 +389,14 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.0.tgz",
-            "integrity": "sha512-hrJYSZRpmecmSoxYrpuJ/1Q4J9JHt4AVVtr5/Ac6upLO/jJ1DnIm2AjD+38gru3KGOec4aHCVqETuWWLJhydWw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz",
+            "integrity": "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/config-validator": "^21.0.0",
-                "@commitlint/types": "^21.0.0",
+                "@commitlint/config-validator": "^21.0.1",
+                "@commitlint/types": "^21.0.1",
                 "es-toolkit": "^1.46.0",
                 "global-directory": "^5.0.0",
                 "resolve-from": "^5.0.0"
@@ -406,25 +406,25 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.0.tgz",
-            "integrity": "sha512-NgQhX1qENA+rbrMw5KKyvVZpZG4D/0wgK8Z4INtcwKbfKtVDFMbn0oNc/Rs8wdyBPBj7ue8Lo/GllUL2Mqjwkg==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.1.tgz",
+            "integrity": "sha512-VMooYpz4nJg7xlaUso6CCOWEz8D/ChkvsvZUMARcoJ1ZpfKPyFCGrHNha2tbsETNAb6ErgiRuCr2DvghrvPDYQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@commitlint/ensure": "^21.0.0",
-                "@commitlint/message": "^21.0.0",
-                "@commitlint/to-lines": "^21.0.0",
-                "@commitlint/types": "^21.0.0"
+                "@commitlint/ensure": "^21.0.1",
+                "@commitlint/message": "^21.0.1",
+                "@commitlint/to-lines": "^21.0.1",
+                "@commitlint/types": "^21.0.1"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@commitlint/to-lines": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.0.tgz",
-            "integrity": "sha512-qMwvrJK/x3dPcXsIAtQAMKV5Q0wTioyqyHKR06vVN4wmBF4cCrrLq5x81FDeY3Ba+GWgDt0/P3Zw/IHGM8lwgg==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+            "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -432,9 +432,9 @@
             }
         },
         "node_modules/@commitlint/top-level": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.0.tgz",
-            "integrity": "sha512-8jPqyWZueuN4hU6/ArKVsZ6i8xWtjIrbzHEOaLaTGUfjhhbZNBfXef/DGjzxy55hAv3yFNxHLINfI1bCJ0/MzA==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.1.tgz",
+            "integrity": "sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -445,9 +445,9 @@
             }
         },
         "node_modules/@commitlint/types": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.0.tgz",
-            "integrity": "sha512-6nEz+M7I90iix4sviA8NLwskOuyt0M98KUU2aYgiKbn46jMSxUm1l2ACtzRd9ec+y38aKyJhW4Fp6NW0z35kJQ==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+            "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -556,9 +556,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-            "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1340,17 +1340,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-            "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+            "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/type-utils": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/type-utils": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1363,7 +1363,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.2",
+                "@typescript-eslint/parser": "^8.59.3",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -1379,16 +1379,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-            "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+            "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1404,14 +1404,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-            "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+            "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.2",
-                "@typescript-eslint/types": "^8.59.2",
+                "@typescript-eslint/tsconfig-utils": "^8.59.3",
+                "@typescript-eslint/types": "^8.59.3",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1426,14 +1426,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-            "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+            "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2"
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1444,9 +1444,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-            "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+            "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1461,15 +1461,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-            "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+            "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1486,9 +1486,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-            "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+            "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1500,16 +1500,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-            "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+            "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.2",
-                "@typescript-eslint/tsconfig-utils": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/visitor-keys": "8.59.2",
+                "@typescript-eslint/project-service": "8.59.3",
+                "@typescript-eslint/tsconfig-utils": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/visitor-keys": "8.59.3",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1528,16 +1528,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-            "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+            "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.2",
-                "@typescript-eslint/types": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2"
+                "@typescript-eslint/scope-manager": "8.59.3",
+                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1552,13 +1552,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-            "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+            "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.2",
+                "@typescript-eslint/types": "8.59.3",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2928,16 +2928,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-            "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+            "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
                 "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.5.5",
+                "@eslint/config-helpers": "^0.6.0",
                 "@eslint/core": "^1.2.1",
                 "@eslint/plugin-kit": "^0.7.1",
                 "@humanfs/node": "^0.16.6",
@@ -4096,9 +4096,9 @@
             "license": "MIT"
         },
         "node_modules/lint-staged": {
-            "version": "17.0.3",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.3.tgz",
-            "integrity": "sha512-wnvMRhzC3GNpjixxleiG+pAW09dHTUgBCjMS7XouAg5E7wKUc8YdfogpF7zIgvXKDbH+452O6+XpnKm6V67rPw==",
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.4.tgz",
+            "integrity": "sha512-+rU9lSUyVOZ/hDUmRLVGzyS2v73cDdQjX+XQz1AaOdIE4RysLq0HoPW2HrrgeNCLklkhi904VBU1bmgWLHVnkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6684,9 +6684,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "6.37.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
-            "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+            "version": "6.38.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
+            "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
             "license": "Apache-2.0",
             "bin": {
                 "openai": "bin/cli"
@@ -8392,16 +8392,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.2",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-            "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+            "version": "8.59.3",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+            "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.2",
-                "@typescript-eslint/parser": "8.59.2",
-                "@typescript-eslint/typescript-estree": "8.59.2",
-                "@typescript-eslint/utils": "8.59.2"
+                "@typescript-eslint/eslint-plugin": "8.59.3",
+                "@typescript-eslint/parser": "8.59.3",
+                "@typescript-eslint/typescript-estree": "8.59.3",
+                "@typescript-eslint/utils": "8.59.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## Description
Bundle routine npm dependency updates into a single Dependabot group and refresh the lockfile to the latest in-range versions.

## Changes Made
- [x] Group npm Dependabot updates into one weekly PR
- [x] Update package-lock.json for current in-range dependency bumps
- [ ] Note any breaking changes

## Testing
- [x] `npm run lint:eslint`
- [x] `npm run test`

## Release / Config Impact
- [x] Describe any release, config, or user-visible impact
- Dependabot will now batch npm updates into a single grouped PR instead of one PR per dependency.

## Checklist
- [x] Code follows project conventions
- [ ] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
- [x] Ready for review