### PR TITLE
fix: improve payee transformation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ password = ""
 
 ### Payee transformation
 
-Converts cryptic payee names to human-readable formats using OpenAI (e.g. "AMAZN S.A.R.L" to "Amazon"). Requires an API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+Converts cryptic payee names to human-readable formats using OpenAI (e.g. "AMAZN S.A.R.L" to "Amazon"). The importer also reuses existing budget payees with a bounded shortlist and snaps close matches back to canonical names. Requires an API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys).
 
 | Option             | Default      | Description                                                                     |
 | ------------------ | ------------ | ------------------------------------------------------------------------------- |
@@ -124,7 +124,7 @@ Converts cryptic payee names to human-readable formats using OpenAI (e.g. "AMAZN
 | `onTransformError` | `warn`       | Error handling: `warn` (use raw names) or `fail` (abort import)                 |
 | `prompt`           | built-in     | Custom transformation instructions (existing payees are appended automatically) |
 
-The AI receives existing payees from your budget to prefer matching over creating duplicates.
+The AI receives a bounded shortlist of existing payees from your budget to prefer matching over creating duplicates, and close matches are normalized back to existing payee names after the API call.
 
 ### Import settings
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -141,6 +141,37 @@ export const shouldEmitMappingConflictGuidance = ({
     accountsWithConflicts: number;
 }): boolean => totalUnmappedCategoryWarnings > 0 && accountsWithConflicts > 0;
 
+export const collectUniquePayeeNamesForTransformation = ({
+    accountStates,
+    transferPlan,
+}: {
+    accountStates: Array<{
+        newMonMonTransactions: MonMonTransaction[];
+    }>;
+    transferPlan: TransferPlan;
+}) => {
+    const payeeNames = new Set<string>();
+
+    for (const accountState of accountStates) {
+        for (const transaction of accountState.newMonMonTransactions) {
+            const importedId = getIdForMoneyMoneyTransaction(transaction);
+            if (
+                transferPlan.suppressedImportedIds.has(importedId) ||
+                transferPlan.seedByImportedId.has(importedId)
+            ) {
+                continue;
+            }
+
+            const payeeName = transaction.name?.trim();
+            if (payeeName) {
+                payeeNames.add(payeeName);
+            }
+        }
+    }
+
+    return [...payeeNames].sort((a, b) => a.localeCompare(b));
+};
+
 export const getTransferFetchWindow = ({
     importDate,
     toDate,
@@ -511,6 +542,42 @@ class Importer {
             return aSeed - bSeed;
         });
 
+        const shouldTransformPayees = !!this.payeeTransformer && !isDryRun;
+        let transformedPayeesByRawName: Record<string, string> | null = null;
+        const payeeTransformer = this.payeeTransformer;
+
+        if (shouldTransformPayees && payeeTransformer) {
+            const uniquePayeeNames = collectUniquePayeeNamesForTransformation({
+                accountStates,
+                transferPlan,
+            });
+
+            if (uniquePayeeNames.length > 0) {
+                const transformedPayees =
+                    await payeeTransformer.transformPayees(
+                        uniquePayeeNames,
+                        existingPayeeNames
+                    );
+
+                if (transformedPayees === null) {
+                    const onError =
+                        this.config.payeeTransformation.onTransformError;
+
+                    if (onError === 'fail') {
+                        throw new Error(
+                            'Payee transformation failed. Check the error messages above for details.'
+                        );
+                    }
+
+                    this.logger.warn(
+                        'Payee transformation failed. Using default payee names...'
+                    );
+                } else {
+                    transformedPayeesByRawName = transformedPayees;
+                }
+            }
+        }
+
         const unmappedCategoryWarnings = new Set<string>();
         const runMetrics: ImportRunMetrics = {
             accountsScanned: 0,
@@ -654,66 +721,19 @@ class Importer {
                         `Considering ${createTransactions.length} new transactions for Actual account '${actualAccount.name}'...`
                     );
 
-                    if (this.payeeTransformer && !isDryRun) {
-                        const transactionPayees = createTransactions
-                            .filter((t) => !t.payee)
-                            .map((t) => t.imported_payee as string);
-                        const uniquePayees = [
-                            ...new Set(transactionPayees),
-                        ].filter((p) => p && p.trim());
-
-                        this.logger.debug(
-                            `Cleaning up ${uniquePayees.length} unique payee names (from ${createTransactions.length} transactions) using OpenAI...`
-                        );
-
-                        const transformedPayees =
-                            await this.payeeTransformer.transformPayees(
-                                uniquePayees,
-                                existingPayeeNames
-                            );
-
-                        if (transformedPayees !== null) {
-                            createTransactions.forEach((t) => {
-                                if (t.payee) {
-                                    return;
-                                }
-                                t.payee_name =
-                                    transformedPayees[
-                                        t.imported_payee as string
-                                    ] ??
-                                    t.imported_payee ??
-                                    '';
-                            });
-                        } else {
-                            const onError =
-                                this.config.payeeTransformation
-                                    .onTransformError;
-
-                            if (onError === 'fail') {
-                                throw new Error(
-                                    'Payee transformation failed. Check the error messages above for details.'
-                                );
-                            }
-
-                            this.logger.warn(
-                                'Payee transformation failed. Using default payee names...'
-                            );
-
-                            createTransactions.forEach((t) => {
-                                if (t.payee) {
-                                    return;
-                                }
-                                t.payee_name = t.imported_payee ?? '';
-                            });
+                    createTransactions.forEach((t) => {
+                        if (t.payee) {
+                            return;
                         }
-                    } else {
-                        createTransactions.forEach((t) => {
-                            if (t.payee) {
-                                return;
-                            }
-                            t.payee_name = t.imported_payee ?? '';
-                        });
-                    }
+
+                        t.payee_name = shouldTransformPayees
+                            ? (transformedPayeesByRawName?.[
+                                  t.imported_payee as string
+                              ] ??
+                              t.imported_payee ??
+                              '')
+                            : (t.imported_payee ?? '');
+                    });
 
                     if (!isDryRun) {
                         const result = await this.actualApi.importTransactions(
@@ -1624,7 +1644,7 @@ class Importer {
             date: format(transaction.valueDate, DATE_FORMAT),
             amount: Math.round(transaction.amount * 100),
             imported_id: getIdForMoneyMoneyTransaction(transaction),
-            imported_payee: transaction.name ?? '',
+            imported_payee: transaction.name?.trim() ?? '',
         };
 
         if (plannedTransfer) {

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -2,15 +2,149 @@ import OpenAI from 'openai';
 import Logger from './Logger.js';
 import { PayeeTransformationConfig } from './config.js';
 
-class PayeeTransformer {
-    private openai: OpenAI;
-    private validatedModel: string;
+type OpenAICompletionResponse = {
+    choices: Array<{
+        message?: {
+            content?: string | null;
+        };
+    }>;
+};
 
-    private static availableModels: Array<string> | null = null;
+type OpenAIClient = {
+    chat: {
+        completions: {
+            create: (options: {
+                model: string;
+                messages: Array<{
+                    role: 'system' | 'user';
+                    content: string;
+                }>;
+                response_format: {
+                    type: 'json_object';
+                };
+                temperature: number;
+            }) => Promise<OpenAICompletionResponse>;
+        };
+    };
+};
+
+const MAX_EXISTING_PAYEES_IN_PROMPT = 100;
+const EXISTING_PAYEE_MATCH_THRESHOLD = 0.75;
+
+const normalizePayee = (value: string) =>
+    value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+
+const buildBigramCounts = (value: string) => {
+    const normalized = normalizePayee(value);
+    const counts = new Map<string, number>();
+
+    for (let i = 0; i < normalized.length - 1; i++) {
+        const bigram = normalized.slice(i, i + 2);
+        counts.set(bigram, (counts.get(bigram) ?? 0) + 1);
+    }
+
+    return counts;
+};
+
+const diceCoefficient = (left: string, right: string) => {
+    const normalizedLeft = normalizePayee(left);
+    const normalizedRight = normalizePayee(right);
+
+    if (!normalizedLeft && !normalizedRight) {
+        return 1;
+    }
+
+    if (!normalizedLeft || !normalizedRight) {
+        return 0;
+    }
+
+    if (normalizedLeft === normalizedRight) {
+        return 1;
+    }
+
+    if (normalizedLeft.length < 2 || normalizedRight.length < 2) {
+        return 0;
+    }
+
+    const leftCounts = buildBigramCounts(normalizedLeft);
+    const rightCounts = buildBigramCounts(normalizedRight);
+    let intersection = 0;
+
+    for (const [bigram, leftCount] of leftCounts.entries()) {
+        const rightCount = rightCounts.get(bigram) ?? 0;
+        intersection += Math.min(leftCount, rightCount);
+    }
+
+    const total = normalizedLeft.length - 1 + (normalizedRight.length - 1);
+    return total > 0 ? (2 * intersection) / total : 0;
+};
+
+const findBestExistingPayee = (payee: string, existingPayeeNames: string[]) => {
+    let bestMatch: { payeeName: string; score: number } | null = null;
+
+    for (const existingPayeeName of existingPayeeNames) {
+        const score = diceCoefficient(payee, existingPayeeName);
+
+        if (
+            !bestMatch ||
+            score > bestMatch.score ||
+            (score === bestMatch.score &&
+                existingPayeeName.localeCompare(bestMatch.payeeName) < 0)
+        ) {
+            bestMatch = {
+                payeeName: existingPayeeName,
+                score,
+            };
+        }
+    }
+
+    return bestMatch;
+};
+
+const selectRelevantExistingPayees = (
+    existingPayeeNames: string[],
+    unresolvedPayees: string[],
+    maxExistingPayeesInPrompt: number
+) => {
+    if (existingPayeeNames.length === 0 || unresolvedPayees.length === 0) {
+        return [] as string[];
+    }
+
+    return existingPayeeNames
+        .map((existingPayeeName) => {
+            const bestScore = unresolvedPayees.reduce((score, payee) => {
+                return Math.max(
+                    score,
+                    diceCoefficient(payee, existingPayeeName)
+                );
+            }, 0);
+
+            return {
+                existingPayeeName,
+                bestScore,
+            };
+        })
+        .filter(({ bestScore }) => bestScore > 0)
+        .sort(
+            (a, b) =>
+                b.bestScore - a.bestScore ||
+                a.existingPayeeName.localeCompare(b.existingPayeeName)
+        )
+        .slice(0, maxExistingPayeesInPrompt)
+        .map(({ existingPayeeName }) => existingPayeeName);
+};
+
+class PayeeTransformer {
+    private openai: OpenAIClient;
 
     constructor(
         private config: PayeeTransformationConfig,
-        private logger: Logger
+        private logger: Logger,
+        openai?: OpenAIClient
     ) {
         if (!config.openAiApiKey) {
             throw new Error(
@@ -18,40 +152,74 @@ class PayeeTransformer {
             );
         }
 
-        this.openai = new OpenAI({
-            apiKey: config.openAiApiKey,
-        });
+        this.openai = openai ?? new OpenAI({ apiKey: config.openAiApiKey });
     }
 
     public async transformPayees(
         payeeList: string[],
         existingPayeeNames: string[] = []
     ) {
-        const prompt = this.generatePrompt(existingPayeeNames);
+        const uniquePayees = [
+            ...new Set(payeeList.map((payee) => payee.trim())),
+        ]
+            .filter((payee) => payee.length > 0)
+            .sort((a, b) => a.localeCompare(b));
 
-        if (payeeList.length === 0) {
+        if (uniquePayees.length === 0) {
             this.logger.debug(
                 'No payees to transform. Returning empty object.'
             );
             return {};
         }
 
-        try {
-            // Lazy validation - only validate model when we actually need to use it
-            if (!this.validatedModel) {
-                this.validatedModel = await this.getConfiguredModel();
+        const resolvedPayees = new Map<string, string>();
+        const unresolvedPayees = uniquePayees.filter((payee) => {
+            const bestExistingPayee = findBestExistingPayee(
+                payee,
+                existingPayeeNames
+            );
+
+            if (
+                bestExistingPayee &&
+                bestExistingPayee.score >= EXISTING_PAYEE_MATCH_THRESHOLD
+            ) {
+                resolvedPayees.set(payee, bestExistingPayee.payeeName);
+                return false;
             }
 
+            return true;
+        });
+
+        if (unresolvedPayees.length === 0) {
+            this.logger.debug(
+                'All payees matched existing payees locally. Returning existing payee names.'
+            );
+            return Object.fromEntries(resolvedPayees);
+        }
+
+        const relevantExistingPayees = selectRelevantExistingPayees(
+            existingPayeeNames,
+            unresolvedPayees,
+            MAX_EXISTING_PAYEES_IN_PROMPT
+        );
+        const prompt = this.generatePrompt(
+            relevantExistingPayees,
+            existingPayeeNames.length
+        );
+
+        try {
             this.logger.debug(`Starting payee transformation...`, [
-                `Payees: ${payeeList.length}`,
+                `Payees: ${unresolvedPayees.length}`,
+                `Locally matched payees: ${resolvedPayees.size}`,
+                `Existing payees used in prompt: ${relevantExistingPayees.length}${existingPayeeNames.length > relevantExistingPayees.length ? ` of ${existingPayeeNames.length}` : ''}`,
                 `Model: ${this.config.openAiModel}`,
             ]);
 
             const response = await this.openai.chat.completions.create({
-                model: this.validatedModel,
+                model: this.config.openAiModel,
                 messages: [
                     { role: 'system', content: prompt },
-                    { role: 'user', content: payeeList.join('\n') },
+                    { role: 'user', content: unresolvedPayees.join('\n') },
                 ],
                 response_format: {
                     type: 'json_object',
@@ -59,99 +227,84 @@ class PayeeTransformer {
                 temperature: this.config.temperature,
             });
 
-            const output = response.choices[0]?.message?.content as string;
+            const output = response.choices[0]?.message?.content ?? '';
+            let parsed: unknown;
 
             try {
-                return JSON.parse(output) as { [key: string]: string };
+                parsed = JSON.parse(output);
             } catch (parseError) {
                 this.logger.error(
                     `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
                 );
                 this.logger.debug(`Raw response: ${output}`);
-                return null;
+                throw parseError;
             }
-        } catch (error) {
-            if (error instanceof Error) {
-                if (this.isModelUnavailableError(error)) {
-                    throw this.createModelUnavailableError(
-                        this.config.openAiModel,
-                        error.message
-                    );
-                }
 
-                // Check if it's a temperature incompatibility error
-                if (
-                    error.message.includes('temperature') &&
-                    error.message.includes('does not support')
-                ) {
-                    throw new Error(
-                        `Incompatible configuration: Model '${this.config.openAiModel}' does not support temperature=${this.config.temperature}. ` +
-                            `Please update the 'temperature' setting in your configuration file. Error: ${error.message}`,
-                        { cause: error }
-                    );
-                }
+            if (
+                !parsed ||
+                typeof parsed !== 'object' ||
+                Array.isArray(parsed)
+            ) {
+                throw new Error('OpenAI response was not a JSON object.');
+            }
 
-                this.logger.error(
-                    `Error in payee transformation: ${error.message}`
+            const transformedPayees = parsed as Record<string, unknown>;
+
+            for (const rawPayee of unresolvedPayees) {
+                const transformedPayee = transformedPayees[rawPayee];
+                const normalizedPayee =
+                    typeof transformedPayee === 'string' &&
+                    transformedPayee.trim()
+                        ? transformedPayee.trim()
+                        : rawPayee;
+                const bestExistingPayee = findBestExistingPayee(
+                    normalizedPayee,
+                    existingPayeeNames
+                );
+
+                resolvedPayees.set(
+                    rawPayee,
+                    bestExistingPayee &&
+                        bestExistingPayee.score >=
+                            EXISTING_PAYEE_MATCH_THRESHOLD
+                        ? bestExistingPayee.payeeName
+                        : normalizedPayee
                 );
             }
+
+            return Object.fromEntries(resolvedPayees);
+        } catch (error) {
+            this.logger.error(this.describeTransformationError(error));
+
+            if (error instanceof Error) {
+                this.logger.debug(
+                    `Raw payee transformation error: ${error.stack ?? error.message}`
+                );
+            }
+
             return null;
         }
     }
 
-    private async getConfiguredModel() {
-        let availableModels: Array<string>;
-        if (PayeeTransformer.availableModels) {
-            this.logger.debug('Found available models in cache.');
-            availableModels = PayeeTransformer.availableModels;
-        } else {
-            this.logger.debug('Listing available models...');
-            const modelsIterator = await this.openai.models.list();
-            availableModels = (await Array.fromAsync(modelsIterator)).map(
-                (m) => m.id
-            );
-            PayeeTransformer.availableModels = availableModels;
-        }
-
-        this.logger.debug(`Found ${availableModels.length} available models.`);
-
-        if (!availableModels.includes(this.config.openAiModel)) {
-            this.logger.error(
-                `The specified model '${this.config.openAiModel}' is invalid. The following models are available:`,
-                availableModels
-            );
-            throw this.createModelUnavailableError(this.config.openAiModel);
-        }
-
-        return this.config.openAiModel;
-    }
-
-    private generatePrompt(existingPayeeNames: string[] = []) {
+    private generatePrompt(
+        existingPayeeNames: string[] = [],
+        totalExistingPayees = existingPayeeNames.length
+    ) {
         const existingPayeesSection =
             existingPayeeNames.length > 0
                 ? `
 
-            IMPORTANT: The following payee names already exist in the budget. When transforming payees,
-            you MUST prefer using these existing names when they match the transaction. This helps maintain
-            consistency in the budget.
-
-            Existing payees:
+            Existing payees already in the budget (prefer these exact names when they clearly match):
             ${existingPayeeNames.join('\n')}
 
-            For example:
-            - If you see "AMAZON.COM/BILLWA" and "Amazon" already exists, use "Amazon"
-            - If you see "COSTCO WHOLESALE" and "Costco" already exists, use "Costco"
-            - If you see "STARBUCKS #12345" and "Starbucks" already exists, use "Starbucks"
-            - Only create a new payee name if no existing payee is a clear match
+            ${totalExistingPayees > existingPayeeNames.length ? `Showing ${existingPayeeNames.length} relevant existing payees out of ${totalExistingPayees}.` : ''}
             `
                 : '';
 
-        // If custom prompt is provided, append existing payees section to it
         if (this.config.prompt?.trim()) {
             return this.config.prompt + existingPayeesSection;
         }
 
-        // Default prompt optimized for GPT 4o-mini/5.1-nano
         return `You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings (how they appear in MoneyMoney). Produce a JSON object that maps each original string to a single cleaned, human-readable merchant name. Always return valid JSON and never return "Unknown", "unknown", or any placeholder—if you cannot identify a distinct merchant, normalize the input (remove extraneous punctuation/ordering, fix capitalization) and return that normalized form as the cleaned name. Favor concise, canonical brand names (e.g., Amazon, Netflix, IKEA) and remove terminal IDs, country codes, or POS data. Do not include explanations, metadata, or anything outside the JSON object.${existingPayeesSection}
 
 Examples (input separated by newline, output shown as JSON):
@@ -173,6 +326,25 @@ Output:
 {"AMAZON.COM/BILLWA":"Amazon", "AMAZON.COM":"Amazon"}`;
     }
 
+    private describeTransformationError(error: unknown) {
+        if (!(error instanceof Error)) {
+            return `Error in payee transformation: ${String(error)}`;
+        }
+
+        if (this.isModelUnavailableError(error)) {
+            return `OpenAI model '${this.config.openAiModel}' is unavailable. Set 'payeeTransformation.openAiModel' in your config to an available model and try again. Original error: ${error.message}`;
+        }
+
+        if (
+            error.message.includes('temperature') &&
+            error.message.includes('does not support')
+        ) {
+            return `Incompatible configuration: Model '${this.config.openAiModel}' does not support temperature=${this.config.temperature}. Please update the 'temperature' setting in your configuration file. Error: ${error.message}`;
+        }
+
+        return `Error in payee transformation: ${error.message}`;
+    }
+
     private isModelUnavailableError(error: Error) {
         const message = error.message.toLowerCase();
         return (
@@ -181,12 +353,6 @@ Output:
                 message.includes('not found') ||
                 message.includes('invalid model') ||
                 message.includes('unknown model'))
-        );
-    }
-
-    private createModelUnavailableError(model: string, cause?: string) {
-        return new Error(
-            `OpenAI model '${model}' is unavailable. Set 'payeeTransformation.openAiModel' in your config to an available model and try again.${cause ? ` Original error: ${cause}` : ''}`
         );
     }
 }

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -148,7 +148,7 @@ class PayeeTransformer {
     ) {
         if (!config.openAiApiKey) {
             throw new Error(
-                'An OpenAPI API key is required for payee transformation. Please set the key in the configuration file.'
+                'An OpenAI API key is required for payee transformation. Please set the key in the configuration file.'
             );
         }
 

--- a/test/unit/importer-payee-transform-trim.test.mjs
+++ b/test/unit/importer-payee-transform-trim.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectUniquePayeeNamesForTransformation } from '../../dist/utils/Importer.js';
+
+test('collectUniquePayeeNamesForTransformation trims payee names', () => {
+    const result = collectUniquePayeeNamesForTransformation({
+        accountStates: [
+            {
+                newMonMonTransactions: [
+                    {
+                        accountUuid: 'acc-1',
+                        id: '1',
+                        name: '  Netflix  ',
+                        valueDate: new Date('2026-04-21'),
+                    },
+                ],
+            },
+        ],
+        transferPlan: {
+            seedByImportedId: new Map(),
+            suppressedImportedIds: new Set(),
+            existingCounterpartConversionsByImportedId: new Map(),
+            resolvedTransferCategoryUuids: new Set(),
+        },
+    });
+
+    assert.deepEqual(result, ['Netflix']);
+});

--- a/test/unit/importer-payee-transform.test.mjs
+++ b/test/unit/importer-payee-transform.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectUniquePayeeNamesForTransformation } from '../../dist/utils/Importer.js';
+
+const makeTransaction = ({ accountUuid, id, name }) => ({
+    accountUuid,
+    id,
+    name,
+    valueDate: new Date('2026-04-21'),
+});
+
+test('collectUniquePayeeNamesForTransformation dedupes and excludes transfer seeds', () => {
+    const result = collectUniquePayeeNamesForTransformation({
+        accountStates: [
+            {
+                newMonMonTransactions: [
+                    makeTransaction({
+                        accountUuid: 'acc-1',
+                        id: '1',
+                        name: 'Netflix',
+                    }),
+                    makeTransaction({
+                        accountUuid: 'acc-1',
+                        id: '2',
+                        name: 'Coffee Shop',
+                    }),
+                ],
+                existingActualTransactions: [],
+            },
+            {
+                newMonMonTransactions: [
+                    makeTransaction({
+                        accountUuid: 'acc-2',
+                        id: '3',
+                        name: 'Coffee Shop',
+                    }),
+                    makeTransaction({
+                        accountUuid: 'acc-2',
+                        id: '4',
+                        name: 'Books',
+                    }),
+                ],
+                existingActualTransactions: [
+                    {
+                        id: 'existing-1',
+                        imported_id: 'existing-1',
+                    },
+                ],
+            },
+        ],
+        transferPlan: {
+            seedByImportedId: new Map([['acc-1-2', { importedId: 'acc-1-2' }]]),
+            suppressedImportedIds: new Set(['acc-2-4']),
+            existingCounterpartConversionsByImportedId: new Map(),
+            resolvedTransferCategoryUuids: new Set(),
+        },
+    });
+
+    assert.deepEqual(result, ['Coffee Shop', 'Netflix']);
+});

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import PayeeTransformer from '../../dist/utils/PayeeTransformer.js';
+
+const makeLogger = () => ({
+    debugMessages: [],
+    errorMessages: [],
+    debug(message, details) {
+        this.debugMessages.push([message, details]);
+    },
+    error(message) {
+        this.errorMessages.push(message);
+    },
+});
+
+const makeOpenAIStub = ({ response, error, onCreate } = {}) => ({
+    chat: {
+        completions: {
+            create: async (options) => {
+                onCreate?.(options);
+
+                if (error) {
+                    throw error;
+                }
+
+                return (
+                    response ?? {
+                        choices: [
+                            {
+                                message: {
+                                    content: '{}',
+                                },
+                            },
+                        ],
+                    }
+                );
+            },
+        },
+    },
+});
+
+const makeConfig = () => ({
+    enabled: true,
+    openAiApiKey: 'test-key',
+    openAiModel: 'gpt-5-nano',
+    temperature: 1,
+    onTransformError: 'warn',
+});
+
+test('transformPayees returns an empty object for no payees', async () => {
+    const logger = makeLogger();
+    let createCalls = 0;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            onCreate: () => {
+                createCalls++;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees([], []);
+
+    assert.deepEqual(result, {});
+    assert.equal(createCalls, 0);
+});
+
+test('transformPayees skips OpenAI for local existing-payee matches', async () => {
+    const logger = makeLogger();
+    let createCalls = 0;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            onCreate: () => {
+                createCalls++;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['Netflix.com'],
+        ['Netflix']
+    );
+
+    assert.deepEqual(result, {
+        'Netflix.com': 'Netflix',
+    });
+    assert.equal(createCalls, 0);
+});
+
+test('transformPayees bounds the relevant existing-payee shortlist', async () => {
+    const logger = makeLogger();
+    let capturedOptions;
+    const existingPayees = Array.from({ length: 150 }, (_, index) => {
+        return `Alpha Market ${String(index + 1).padStart(3, '0')}`;
+    });
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            response: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                'Alpha Hyperstore': 'Alpha Market 001',
+                            }),
+                        },
+                    },
+                ],
+            },
+            onCreate: (options) => {
+                capturedOptions = options;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['Alpha Hyperstore'],
+        existingPayees
+    );
+
+    assert.equal(capturedOptions.model, 'gpt-5-nano');
+    assert.equal(capturedOptions.temperature, 1);
+    assert.equal(capturedOptions.messages[1].content, 'Alpha Hyperstore');
+    assert.match(
+        capturedOptions.messages[0].content,
+        /Showing 100 relevant existing payees out of 150\./
+    );
+    assert.equal(
+        capturedOptions.messages[0].content
+            .split('\n')
+            .filter((line) => line.trim().startsWith('Alpha Market ')).length,
+        100
+    );
+    assert.deepEqual(result, {
+        'Alpha Hyperstore': 'Alpha Market 001',
+    });
+});
+
+test('transformPayees snaps transformed payees back to existing names', async () => {
+    const logger = makeLogger();
+    let capturedOptions;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            response: {
+                choices: [
+                    {
+                        message: {
+                            content: JSON.stringify({
+                                'AMZN Mktp US*1234567890': 'Amazon.com',
+                            }),
+                        },
+                    },
+                ],
+            },
+            onCreate: (options) => {
+                capturedOptions = options;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['AMZN Mktp US*1234567890'],
+        ['Amazon']
+    );
+
+    assert.equal(
+        capturedOptions.messages[1].content,
+        'AMZN Mktp US*1234567890'
+    );
+    assert.deepEqual(result, {
+        'AMZN Mktp US*1234567890': 'Amazon',
+    });
+});
+
+test('transformPayees returns null for malformed JSON', async () => {
+    const logger = makeLogger();
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            response: {
+                choices: [
+                    {
+                        message: {
+                            content: 'not-json',
+                        },
+                    },
+                ],
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(['Coffee Shop'], []);
+
+    assert.equal(result, null);
+    assert.match(logger.errorMessages[0], /^Failed to parse JSON response:/);
+    assert.match(logger.debugMessages[1][0], /Raw response: not-json/);
+});
+
+test('transformPayees returns null when OpenAI fails', async () => {
+    const logger = makeLogger();
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeOpenAIStub({
+            error: new Error('The model does not exist'),
+        })
+    );
+
+    const result = await transformer.transformPayees(['Coffee Shop'], []);
+
+    assert.equal(result, null);
+    assert.equal(logger.errorMessages.length, 1);
+    assert.match(
+        logger.errorMessages[0],
+        /OpenAI model 'gpt-5-nano' is unavailable/
+    );
+});


### PR DESCRIPTION
## Description
Improve payee transformation so it is run-scoped, graceful on OpenAI failures, and bounded in existing-payee context.

## Changes Made
- Remove OpenAI model preflight validation and fail gracefully on API/model errors
- Transform payees once per import run for consistent names across accounts
- Bound existing-payee context and add local fuzzy snapping back to canonical names
- Trim payee names consistently and restore raw-response logging on parse failures
- Add unit coverage and update README

## Testing
- npm run build
- npm run test
- npm run lint:eslint
- npm run lint:prettier

## Release / Config Impact
- None

## Checklist
- Code follows project conventions
- Documentation updated
- No breaking changes
- Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payee transformation now performs local fuzzy matching against existing payees before using OpenAI, improving efficiency and reducing API calls.
  * Limits displayed payee suggestions to most relevant matches in transformation prompts.

* **Bug Fixes**
  * Improved error handling for transformation failures; now returns gracefully instead of throwing errors.
  * Fixed whitespace handling in payee names to properly trim leading/trailing spaces.

* **Documentation**
  * Updated README to clarify payee transformation process and matching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->