### PR TITLE
fix: harden import validation and exit codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "@commitlint/cli": "^21.0.0",
                 "@commitlint/config-conventional": "^21.0.0",
                 "@eslint/js": "^10.0.1",
+                "@types/node": "^25.0.0",
                 "@types/yargs": "^17.0.35",
                 "eslint": "^10.3.0",
                 "globals": "^17.6.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",
+        "@types/node": "^25.0.0",
         "@eslint/js": "^10.0.1",
         "@types/yargs": "^17.0.35",
         "eslint": "^10.3.0",

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -12,6 +12,27 @@ import { withGlobalApiNoiseFilter } from '../utils/ActualApiLogControl.js';
 import { getConfig } from '../utils/config.js';
 import { DATE_FORMAT } from '../utils/shared.js';
 
+export const buildBudgetNameBySyncIdMap = async (
+    actualApi: Pick<ActualApi, 'getUserFiles'>,
+    serverUrl: string
+) => {
+    try {
+        const userFiles = await actualApi.getUserFiles();
+
+        return new Map(userFiles.map((file) => [file.fileId, file.name]));
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+
+        throw new Error(
+            `Failed to list Actual user files for server '${serverUrl}': ${reason}`,
+            { cause: error }
+        );
+    }
+};
+
+export const getImportExitCode = (encounteredImportErrors: boolean) =>
+    encounteredImportErrors ? 1 : 0;
+
 const handleCommand = async (argv: ArgumentsCamelCase) => {
     const config = await getConfig(argv);
 
@@ -103,6 +124,8 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
     logger.debug(`MoneyMoney database is accessible.`);
 
     await withGlobalApiNoiseFilter(logLevel < LogLevel.ACTUAL, async () => {
+        let encounteredImportErrors = false;
+
         for (const serverConfig of selectedServerConfigs) {
             const selectedBudgetConfigs = serverConfig.budgets.filter(
                 (budgetConfig) => includesRef(budgetRefs, budgetConfig.syncId)
@@ -126,14 +149,24 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
             logger.debug(`Initializing Actual API...`);
             await actualApi.init();
 
-            const userFiles = await actualApi
-                .getUserFiles()
-                .catch(() => [] as Array<{ fileId: string; name: string }>);
-            const budgetNameBySyncId = new Map(
-                userFiles.map((file) => [file.fileId, file.name])
-            );
-
             try {
+                let budgetNameBySyncId = new Map<string, string>();
+
+                try {
+                    budgetNameBySyncId = await buildBudgetNameBySyncIdMap(
+                        actualApi,
+                        serverConfig.serverUrl
+                    );
+                } catch (error) {
+                    const reason =
+                        error instanceof Error ? error.message : String(error);
+
+                    logger.warn(
+                        `Could not list Actual user files for server '${serverConfig.serverUrl}'. Continuing without budget names.`,
+                        reason
+                    );
+                }
+
                 for (const budgetConfig of selectedBudgetConfigs) {
                     const budgetName = budgetNameBySyncId.get(
                         budgetConfig.syncId
@@ -202,14 +235,15 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
                     }
 
                     await importer.importTransactions(importOptions);
+                    encounteredImportErrors ||= importer.hasImportErrors();
                 }
             } finally {
                 await actualApi.shutdown();
             }
         }
-    });
 
-    process.exit(0);
+        process.exit(getImportExitCode(encounteredImportErrors));
+    });
 };
 
 export default {

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -1,10 +1,10 @@
 import toml from 'toml';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
-import { configSchema, getConfigFile } from '../utils/config.js';
+import { getConfigFile, parseConfigData } from '../utils/config.js';
 import fs from 'fs/promises';
 import path from 'path';
 import Logger, { LogLevel } from '../utils/Logger.js';
-import { z } from 'zod';
+import { ZodError } from 'zod';
 import { EXAMPLE_CONFIG } from '../utils/shared.js';
 
 const handleValidate = async (argv: ArgumentsCamelCase) => {
@@ -44,9 +44,9 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
             const configData = toml.parse(configContent);
 
             logger.debug(`Parsing configuration schema...`);
-            configSchema.parse(configData);
+            parseConfigData(configData);
         } catch (e) {
-            if (e instanceof z.core.$ZodError) {
+            if (e instanceof ZodError) {
                 logger.error('Configuration file is invalid:');
                 for (const error of e.issues) {
                     logger.error(
@@ -61,7 +61,7 @@ const handleValidate = async (argv: ArgumentsCamelCase) => {
                     `Failed to parse configuration file: ${e.message} (line ${line}, column ${column})`
                 );
             } else {
-                logger.error(`An unexpected error occured: ${e}`);
+                logger.error(`An unexpected error occurred: ${e}`);
             }
 
             process.exit(1);

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -230,6 +230,20 @@ export const filterTransactionsForRequestedImportRange = ({
         })
     );
 
+export const getLatestTransactionValueDate = (
+    transactions: MonMonTransaction[]
+): Date | null => {
+    if (transactions.length === 0) {
+        return null;
+    }
+
+    return transactions.reduce(
+        (latest, transaction) =>
+            transaction.valueDate > latest ? transaction.valueDate : latest,
+        transactions[0]!.valueDate
+    );
+};
+
 const buildExistingCategoryUpdate = ({
     pair,
     targetCategoryId,
@@ -253,6 +267,7 @@ const buildExistingCategoryUpdate = ({
 
 class Importer {
     private readonly transferPlanner: TransferPlanner;
+    private hadImportErrors = false;
 
     constructor(
         private config: Config,
@@ -594,6 +609,8 @@ class Importer {
             totalSkippedConflicts: 0,
             totalUnmappedCategoryWarnings: 0,
             totalAutoRuleOverrides: 0,
+            accountsWithImportErrors: 0,
+            totalImportErrors: 0,
         };
 
         const promptState: PromptState = { mode: 'prompt' };
@@ -695,12 +712,12 @@ class Importer {
                     });
 
                 if (effectiveExistingActualTransactions.length === 0) {
+                    const latestTransactionDate =
+                        getLatestTransactionValueDate(accountTransactions);
+
                     const startTransaction: CreateTransaction = {
                         date: format(
-                            accountTransactions.length > 0
-                                ? (accountTransactions.at(-1)?.valueDate ??
-                                      new Date())
-                                : new Date(),
+                            latestTransactionDate ?? new Date(),
                             DATE_FORMAT
                         ),
                         amount: this.getStartingBalanceForAccount(
@@ -751,24 +768,40 @@ class Importer {
                             runMetrics.accountsWithImportActivity++;
                         }
 
-                        if (result.errors && result.errors.length > 0) {
+                        const importErrors = result.errors ?? [];
+                        const hadImportErrors = importErrors.length > 0;
+
+                        if (hadImportErrors) {
+                            this.hadImportErrors = true;
+                            runMetrics.accountsWithImportErrors++;
+                            runMetrics.totalImportErrors += importErrors.length;
                             this.logger.error(
                                 'Some errors occurred during import:'
                             );
-                            for (let i = 0; i < result.errors.length; i++) {
+                            for (let i = 0; i < importErrors.length; i++) {
                                 this.logger.error(
-                                    `Error ${i + 1}: ${result.errors[i]?.message ?? 'Unknown error'}`
+                                    `Error ${i + 1}: ${importErrors[i]?.message ?? 'Unknown error'}`
                                 );
                             }
                         }
 
-                        this.logger.info(
-                            `Transaction import to account '${actualAccount.name}' successful`,
-                            [
-                                `Added ${result.added.length} new transaction.`,
-                                `Updated ${result.updated.length} existing transaction.`,
-                            ]
-                        );
+                        if (hadImportErrors) {
+                            this.logger.warn(
+                                `Transaction import to account '${actualAccount.name}' completed with errors`,
+                                [
+                                    `Added ${result.added.length} new transaction.`,
+                                    `Updated ${result.updated.length} existing transaction.`,
+                                ]
+                            );
+                        } else {
+                            this.logger.info(
+                                `Transaction import to account '${actualAccount.name}' successful`,
+                                [
+                                    `Added ${result.added.length} new transaction.`,
+                                    `Updated ${result.updated.length} existing transaction.`,
+                                ]
+                            );
+                        }
 
                         const importedTransactions =
                             result.added.length > 0 || result.updated.length > 0
@@ -878,6 +911,10 @@ class Importer {
         }
     }
 
+    public hasImportErrors() {
+        return this.hadImportErrors;
+    }
+
     private logCategorySyncSummary({
         actualAccountName,
         existingPairsCount,
@@ -975,7 +1012,9 @@ class Importer {
             metrics.totalTransactionsAdded > 0 ||
             metrics.totalTransactionsUpdated > 0;
         const hasCategoryActivity = metrics.totalCategoryUpdatesPlanned > 0;
-        const hasNotableWarnings = metrics.totalUnmappedCategoryWarnings > 0;
+        const hasImportErrors = metrics.totalImportErrors > 0;
+        const hasNotableWarnings =
+            metrics.totalUnmappedCategoryWarnings > 0 || hasImportErrors;
 
         if (!hasImportActivity && !hasCategoryActivity && !hasNotableWarnings) {
             this.logger.info('Nothing to import.');
@@ -1042,7 +1081,14 @@ class Importer {
             );
         }
 
-        this.logger.info('Import run summary', hints);
+        if (hasImportErrors) {
+            hints.push(
+                `Import errors: ${metrics.totalImportErrors} row-level error(s) across ${metrics.accountsWithImportErrors} account(s)`
+            );
+            this.logger.warn('Import run completed with errors', hints);
+        } else {
+            this.logger.info('Import run summary', hints);
+        }
     }
 
     private buildAccountTransactionBuckets({

--- a/src/utils/Importer.types.ts
+++ b/src/utils/Importer.types.ts
@@ -63,6 +63,8 @@ export type ImportRunMetrics = {
     totalSkippedConflicts: number;
     totalUnmappedCategoryWarnings: number;
     totalAutoRuleOverrides: number;
+    accountsWithImportErrors: number;
+    totalImportErrors: number;
 };
 
 export type DuplicateImportedIdGroup = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,27 @@ import { ArgumentsCamelCase } from 'yargs';
 import { z } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
 
+const isValidCalendarDate = (dateString: string) => {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    if (!dateRegex.test(dateString)) {
+        return false;
+    }
+
+    const [yearString, monthString, dayString] = dateString.split('-');
+    const year = Number(yearString);
+    const month = Number(monthString);
+    const day = Number(dayString);
+
+    const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+    return (
+        parsedDate.getUTCFullYear() === year &&
+        parsedDate.getUTCMonth() === month - 1 &&
+        parsedDate.getUTCDate() === day
+    );
+};
+
 const budgetSchema = z
     .object({
         syncId: z.string(),
@@ -26,12 +47,12 @@ const budgetSchema = z
         }
 
         if (val.earliestImportDate) {
-            const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-            if (!dateRegex.test(val.earliestImportDate)) {
+            if (!isValidCalendarDate(val.earliestImportDate)) {
                 ctx.addIssue({
                     code: 'custom',
+                    path: ['earliestImportDate'],
                     message:
-                        'Invalid earliest import date format (required format is YYYY-MM-DD)',
+                        'Invalid earliest import date (required format is YYYY-MM-DD and must be a real calendar date)',
                 });
             }
         }
@@ -117,6 +138,46 @@ export type ActualServerConfig = z.infer<typeof actualServerSchema>;
 export type ActualBudgetConfig = z.infer<typeof budgetSchema>;
 export type Config = z.infer<typeof configSchema>;
 
+const isLocalhostServerUrl = (serverUrl: string) => {
+    try {
+        const url = new URL(serverUrl);
+        const hostname = url.hostname.replace(/^\[|\]$/g, '');
+
+        return (
+            hostname === 'localhost' ||
+            hostname === '127.0.0.1' ||
+            hostname === '::1'
+        );
+    } catch {
+        return false;
+    }
+};
+
+export const warnOnCleartextActualServers = (
+    actualServers: ActualServerConfig[]
+) => {
+    for (const server of actualServers) {
+        try {
+            const url = new URL(server.serverUrl);
+            if (url.protocol === 'http:' && !isLocalhostServerUrl(url.href)) {
+                console.error(
+                    `WARNING: Actual server '${server.serverUrl}' uses cleartext HTTP. Server passwords will be sent in plain text. Use HTTPS instead.`
+                );
+            }
+        } catch {
+            continue;
+        }
+    }
+};
+
+export const parseConfigData = (configData: unknown): Config => {
+    const config = configSchema.parse(configData);
+
+    warnOnCleartextActualServers(config.actualServers);
+
+    return config;
+};
+
 export const getConfigFile = (argv: ArgumentsCamelCase) => {
     if (argv.config) {
         const argvConfigFile = path.resolve(argv.config as string);
@@ -144,7 +205,7 @@ export const getConfig = async (argv: ArgumentsCamelCase) => {
 
     try {
         const configData = toml.parse(configContent);
-        return configSchema.parse(configData);
+        return parseConfigData(configData);
     } catch (e) {
         if (e instanceof Error && e.name === 'SyntaxError') {
             const line = 'line' in e ? e.line : -1;
@@ -154,6 +215,21 @@ export const getConfig = async (argv: ArgumentsCamelCase) => {
                 `Failed to parse configuration file: ${e.message} (line ${line}, column ${column})`,
                 { cause: e }
             );
+        }
+
+        if (e instanceof z.ZodError) {
+            const issues = e.issues
+                .map((issue) => {
+                    const pathLabel =
+                        issue.path.length > 0 ? issue.path.join('.') : '(root)';
+
+                    return `- ${pathLabel}: ${issue.message}`;
+                })
+                .join('\n');
+
+            throw new Error(`Invalid configuration file:\n${issues}`, {
+                cause: e,
+            });
         }
 
         throw new Error(

--- a/test/cli/validate.test.mjs
+++ b/test/cli/validate.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -20,6 +20,38 @@ const runCli = (args = []) => {
         output: `${result.stdout}${result.stderr}`,
     };
 };
+
+const makeValidConfig = (serverUrl) => `
+[payeeTransformation]
+enabled = false
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "${serverUrl}"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
 
 test('validate creates nested config directories when missing', async (t) => {
     const tempRoot = await mkdtemp(
@@ -44,4 +76,35 @@ test('validate creates nested config directories when missing', async (t) => {
 
     assert.equal(secondRun.status, 0);
     assert.match(secondRun.output, /Configuration file is valid\./);
+});
+
+test('validate warns on cleartext HTTP Actual URLs but allows localhost', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-validate-http-')
+    );
+    const remoteConfigPath = path.join(tempRoot, 'remote.toml');
+    const localConfigPath = path.join(tempRoot, 'local.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(
+        remoteConfigPath,
+        makeValidConfig('http://example.com:5006'),
+        'utf8'
+    );
+    await writeFile(
+        localConfigPath,
+        makeValidConfig('http://localhost:5006'),
+        'utf8'
+    );
+
+    const remoteRun = runCli(['validate', '--config', remoteConfigPath]);
+    assert.equal(remoteRun.status, 0);
+    assert.match(remoteRun.output, /cleartext HTTP/);
+
+    const localRun = runCli(['validate', '--config', localConfigPath]);
+    assert.equal(localRun.status, 0);
+    assert.doesNotMatch(localRun.output, /cleartext HTTP/);
 });

--- a/test/unit/config-defaults.test.mjs
+++ b/test/unit/config-defaults.test.mjs
@@ -72,3 +72,38 @@ test('automatic transfers require at least one category ref when enabled', () =>
             )
     );
 });
+
+test('earliestImportDate rejects impossible calendar dates', () => {
+    assert.throws(
+        () =>
+            configSchema.parse({
+                payeeTransformation: {
+                    enabled: false,
+                },
+                import: {
+                    importUncheckedTransactions: true,
+                },
+                actualServers: [
+                    {
+                        serverUrl: 'http://localhost:5006',
+                        serverPassword: 'pw',
+                        budgets: [
+                            {
+                                syncId: 'budget-id',
+                                earliestImportDate: '2026-02-31',
+                                e2eEncryption: {
+                                    enabled: false,
+                                },
+                                accountMapping: {},
+                            },
+                        ],
+                    },
+                ],
+            }),
+        (error) =>
+            error instanceof ZodError &&
+            error.issues.some((issue) =>
+                issue.message.includes('real calendar date')
+            )
+    );
+});

--- a/test/unit/config-loading.test.mjs
+++ b/test/unit/config-loading.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { getConfig } from '../../dist/utils/config.js';
+
+const makeConfig = () => `
+[payeeTransformation]
+enabled = false
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+earliestImportDate = "2026-02-31"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig surfaces detailed validation errors', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfig(), 'utf8');
+
+    await assert.rejects(
+        () => getConfig({ config: configPath }),
+        (error) =>
+            error instanceof Error &&
+            error.message.includes('Invalid configuration file:') &&
+            error.message.includes(
+                'actualServers.0.budgets.0.earliestImportDate'
+            ) &&
+            error.message.includes('real calendar date')
+    );
+});

--- a/test/unit/import-command.test.mjs
+++ b/test/unit/import-command.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { mock, test } from 'node:test';
+import {
+    buildBudgetNameBySyncIdMap,
+    getImportExitCode,
+} from '../../dist/commands/import.command.js';
+
+test('buildBudgetNameBySyncIdMap fails fast on user file lookup errors', async () => {
+    const getUserFiles = mock.fn(async () => {
+        throw new Error('login failed');
+    });
+
+    await assert.rejects(
+        () =>
+            buildBudgetNameBySyncIdMap(
+                { getUserFiles },
+                'http://example.com:5006'
+            ),
+        /Failed to list Actual user files for server 'http:\/\/example.com:5006': login failed/
+    );
+
+    assert.equal(getUserFiles.mock.callCount(), 1);
+});
+
+test('getImportExitCode returns failure when import errors occurred', () => {
+    assert.equal(getImportExitCode(false), 0);
+    assert.equal(getImportExitCode(true), 1);
+});

--- a/test/unit/importer-transfers.test.mjs
+++ b/test/unit/importer-transfers.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { mock, test } from 'node:test';
 import Importer, {
     filterTransactionsForRequestedImportRange,
+    getLatestTransactionValueDate,
     getTransferFetchWindow,
     isWithinRequestedImportRange,
 } from '../../dist/utils/Importer.js';
@@ -2380,6 +2381,52 @@ test('getExistingTransactionsForStartBalanceCheck does not refetch non-empty or 
     );
 
     assert.equal(getTransactions.mock.callCount(), 0);
+});
+
+test('getLatestTransactionValueDate picks the latest value date regardless of order', () => {
+    const latest = getLatestTransactionValueDate([
+        makeTransaction({ id: '1', valueDate: '2026-04-21' }),
+        makeTransaction({ id: '2', valueDate: '2026-04-24' }),
+        makeTransaction({ id: '3', valueDate: '2026-04-22' }),
+    ]);
+
+    assert.equal(latest?.toISOString().slice(0, 10), '2026-04-24');
+});
+
+test('emitImportRunSummary warns when row-level import errors are present', () => {
+    const logger = makeLogger();
+    const importer = makeImporter({ logger });
+    const emitImportRunSummary =
+        Object.getPrototypeOf(importer).emitImportRunSummary;
+
+    emitImportRunSummary.call(
+        importer,
+        {
+            accountsScanned: 1,
+            accountsWithImportActivity: 1,
+            accountsWithCategoryActivity: 0,
+            accountsWithConflicts: 0,
+            totalTransactionsAdded: 1,
+            totalTransactionsUpdated: 0,
+            totalCategoryUpdatesPlanned: 0,
+            totalCategoryUpdatesApplied: 0,
+            totalCategoryUpdatesDryRun: 0,
+            totalBackfills: 0,
+            totalConflicts: 0,
+            totalSkippedConflicts: 0,
+            totalUnmappedCategoryWarnings: 0,
+            totalAutoRuleOverrides: 0,
+            accountsWithImportErrors: 1,
+            totalImportErrors: 2,
+        },
+        false
+    );
+
+    assert.equal(
+        logger.warnMessages.at(-1),
+        'Import run completed with errors'
+    );
+    assert.equal(logger.infoMessages.length, 0);
 });
 
 test('convertToActualTransaction uses transfer payee for planned seed', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
         "module": "nodenext" /* Specify what module code is generated. */,
         "baseUrl": ".",
         "ignoreDeprecations": "6.0",
+        "types": ["node"],
         "paths": {
             "@actual-app/api": ["src/types/actual-app__api.d.ts"]
         },


### PR DESCRIPTION
## Summary
- hard-warn on cleartext HTTP Actual URLs
- hard-fail invalid earliestImportDate values
- fail fast on Actual user-file lookup errors while keeping server processing resilient
- return non-zero exit code when any partial import errors occur
- make starting-balance date selection deterministic
- surface config validation details in import/validate flows

## Testing
- npm run build
- npm run test:unit
- npm run test:cli
- npm run lint:eslint
- npm run lint:prettier

## Notes
- partial import row errors now affect the CLI exit code
- this includes a small devDependency update for @types/node to restore local type resolution