### PR TITLE
chore(deps): update outdated npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,14 +1306,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.6.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-            "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+            "version": "25.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "undici-types": "~7.19.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -2557,9 +2556,9 @@
             "license": "MIT"
         },
         "node_modules/date-fns": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
-            "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+            "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8775,12 +8774,11 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.19.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/unicode-emoji-modifier-base": {
             "version": "1.0.0",


### PR DESCRIPTION
## Description
Update the remaining outdated npm dependencies within their existing semver ranges.

## Changes Made
- Updated `@types/node` and `date-fns` in `package-lock.json`
- No `package.json` range changes were needed

## Testing
- `npm run build`
- `npm run test`
- `npm outdated`

## Release / Config Impact
- None

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)
- [x] Ready for review
