### PR TITLE
refactor: TypeScript hardening — strictPropertyInitialization and typed argv

### DIFF
--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -2,7 +2,7 @@
 
 Based on codebase assessment 2026-05-24.
 
-**Status:** PR 1 complete ✅ · PR 2 complete ✅ · PRs 3–5 pending
+**Status:** PR 1 complete ✅ · PR 2 complete ✅ · PR 3 complete ✅ · PRs 4–5 pending
 
 ---
 
@@ -60,35 +60,27 @@ Based on codebase assessment 2026-05-24.
 
 ---
 
-## PR 3: TypeScript hardening
+## PR 3: TypeScript hardening ✅
 
-**Issues:** #5 (`strictPropertyInitialization`), #6 (unparameterized `ArgumentsCamelCase`)
+**Issues:** #5 (`strictPropertyInitialization`), #6 (unparameterized `ArgumentsCamelCase`)  
+**Delivered in:** [#243](https://github.com/1cu/actual-moneymoney-importer/pull/243)
 
-### What
+### What was done
 
-`tsconfig.json` has `strictPropertyInitialization: false` because `AccountMap.ts` declares `moneyMoneyAccounts`, `actualAccounts`, and `mapping` without initializers, relying on `loadFromConfig()` to populate them. This weakens TypeScript checking globally.
+1. Initialized AccountMap fields with empty defaults (`[]`, `new Map()`) and updated the load-guard from truthiness to `mapping.size > 0`
+2. Re-enabled `strictPropertyInitialization: true` in `tsconfig.json` — no other uninitialized fields in the project
+3. Added `CommonArgs` shared type in `cliArgs.ts` (config?, logLevel?, loglevel?)
+4. Defined command-specific argv types:
+    - `ImportArgs` extending `CommonArgs` — eliminated 7 casts (logLevel as number, dryRun as boolean, from/to as string, account/server/budget as string[], categorySyncOnExisting as union)
+    - `CategoriesMapArgs` extending `CommonArgs` — eliminated 5 casts
+    - `validate.command.ts` uses `ArgumentsCamelCase<CommonArgs>` — eliminated 1 cast
+    - `config.ts` functions (`getConfigFile`, `getConfig`) parameterized on `CommonArgs` — eliminated 1 cast
 
-`ArgumentsCamelCase` is used unparameterized across all command handlers, forcing casts like `argv.from as string`, `argv.dryRun as boolean`.
-
-### Why
-
-- Calling `getMap()` before `loadFromConfig()` is a runtime hazard with no type-level guard
-- Parameterized argv types eliminate the need for casts and provide better IDE support
-
-### Fix
-
-1. Initialize AccountMap fields (`[]`, `new Map()`) or type them as `| undefined` with guards
-2. Re-enable `strictPropertyInitialization`
-3. Define command-specific argv types:
-    ```ts
-    type ImportArgs = { from?: string; to?: string; dryRun?: boolean; ... };
-    const handler = (argv: ArgumentsCamelCase<ImportArgs>) => { ... };
-    ```
-
-### Expected outcome
+### Outcome
 
 - TypeScript catches uninitialized property access at compile time
-- No `as string` / `as boolean` casts in command handlers
+- 14 `as string` / `as boolean` / `as number` casts removed from command handlers
+- Full IDE type-checking on all CLI arguments
 
 ---
 
@@ -154,7 +146,7 @@ const payeeMap = completion.choices[0]?.message?.parsed; // typed!
 
 ## Dependency ordering
 
-1 ✅ → 2 ✅ → 3 → 4 → 5 is natural (core types → behavior → type hardening → feature modernisation → cleanup), but **none strictly depend on others** — they touch different concerns and can ship in any order.
+1 ✅ → 2 ✅ → 3 ✅ → 4 → 5 is natural (core types → behavior → type hardening → feature modernisation → cleanup), but **none strictly depend on others** — they touch different concerns and can ship in any order.
 
 ## Verification
 

--- a/src/commands/categories.command.ts
+++ b/src/commands/categories.command.ts
@@ -3,7 +3,7 @@ import toml from 'toml';
 import { checkDatabaseUnlocked } from 'moneymoney';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import ActualApi from '../utils/ActualApi.js';
-import { includesRef, toRefList } from '../utils/cliArgs.js';
+import { includesRef, toRefList, CommonArgs } from '../utils/cliArgs.js';
 import CategoryMap, { CanonicalMappingEntry } from '../utils/CategoryMap.js';
 import Logger, { LogLevel } from '../utils/Logger.js';
 import { renderTextTable, TableColumnConfig } from '../utils/textTable.js';
@@ -55,20 +55,26 @@ export const handleUnsafeWriteConfigFailure = (
     return 1 as const;
 };
 
-const handleMapCommand = async (argv: ArgumentsCamelCase) => {
+type CategoriesMapArgs = CommonArgs & {
+    server?: string | string[];
+    budget?: string | string[];
+    format?: string;
+    'write-config'?: boolean;
+};
+
+const handleMapCommand = async (
+    argv: ArgumentsCamelCase<CategoriesMapArgs>
+) => {
     const config = await getConfig(argv);
     const configPath = getConfigFile(argv);
 
-    const logLevel = (argv.logLevel ??
-        argv.loglevel ??
-        LogLevel.INFO) as number;
+    const logLevel = argv.logLevel ?? argv.loglevel ?? LogLevel.INFO;
     const logger = new Logger(logLevel);
 
-    const serverRefs = toRefList(argv.server as string | string[] | undefined);
-    const budgetRefs = toRefList(argv.budget as string | string[] | undefined);
-    const outputFormat = ((argv.format as string | undefined) ??
-        'table') as MapFormat;
-    const writeConfig = (argv.writeConfig as boolean | undefined) ?? false;
+    const serverRefs = toRefList(argv.server);
+    const budgetRefs = toRefList(argv.budget);
+    const outputFormat = (argv.format ?? 'table') as MapFormat;
+    const writeConfig = argv.writeConfig ?? false;
 
     const matchingTargets = selectTargets(
         config.actualServers,

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -3,7 +3,7 @@ import { checkDatabaseUnlocked } from 'moneymoney';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { AccountMap } from '../utils/AccountMap.js';
 import ActualApi from '../utils/ActualApi.js';
-import { includesRef, toRefList } from '../utils/cliArgs.js';
+import { includesRef, toRefList, CommonArgs } from '../utils/cliArgs.js';
 import CategoryMap from '../utils/CategoryMap.js';
 import Importer from '../utils/Importer.js';
 import Logger, { LogLevel } from '../utils/Logger.js';
@@ -33,12 +33,20 @@ export const buildBudgetNameBySyncIdMap = async (
 export const getImportExitCode = (encounteredImportErrors: boolean) =>
     encounteredImportErrors ? 1 : 0;
 
-const handleCommand = async (argv: ArgumentsCamelCase) => {
+type ImportArgs = CommonArgs & {
+    'dry-run'?: boolean;
+    account?: string | string[];
+    server?: string | string[];
+    budget?: string | string[];
+    'category-sync-on-existing'?: 'ask' | 'new' | 'always';
+    from?: string;
+    to?: string;
+};
+
+const handleCommand = async (argv: ArgumentsCamelCase<ImportArgs>) => {
     const config = await getConfig(argv);
 
-    const logLevel = (argv.logLevel ??
-        argv.loglevel ??
-        LogLevel.INFO) as number;
+    const logLevel = argv.logLevel ?? argv.loglevel ?? LogLevel.INFO;
     const logger = new Logger(logLevel);
 
     const payeeTransformer = config.payeeTransformation.enabled
@@ -51,28 +59,20 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
         );
     }
 
-    const isDryRun = (argv.dryRun as boolean) || false;
+    const isDryRun = argv.dryRun || false;
     const fromDate = argv.from
-        ? parse(argv.from as string, DATE_FORMAT, new Date())
+        ? parse(argv.from, DATE_FORMAT, new Date())
         : undefined;
     const toDate = argv.to
-        ? parse(argv.to as string, DATE_FORMAT, new Date())
+        ? parse(argv.to, DATE_FORMAT, new Date())
         : undefined;
 
-    const accountRefs = toRefList(
-        argv.account as string | string[] | undefined
-    );
-    const serverRefs = toRefList(argv.server as string | string[] | undefined);
-    const budgetRefs = toRefList(argv.budget as string | string[] | undefined);
-
-    const categorySyncOnExistingArg = argv.categorySyncOnExisting as
-        | 'ask'
-        | 'new'
-        | 'always'
-        | undefined;
+    const accountRefs = toRefList(argv.account);
+    const serverRefs = toRefList(argv.server);
+    const budgetRefs = toRefList(argv.budget);
 
     const categorySyncOnExisting =
-        categorySyncOnExistingArg ?? config.import.categorySyncOnExisting;
+        argv.categorySyncOnExisting ?? config.import.categorySyncOnExisting;
 
     if (
         config.import.synchronizeCategories &&

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -1,18 +1,17 @@
 import toml from 'toml';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
 import { getConfigFile, parseConfigData } from '../utils/config.js';
+import { CommonArgs } from '../utils/cliArgs.js';
 import fs from 'fs/promises';
 import path from 'path';
 import Logger, { LogLevel } from '../utils/Logger.js';
 import { ZodError } from 'zod';
 import { EXAMPLE_CONFIG } from '../utils/shared.js';
 
-const handleValidate = async (argv: ArgumentsCamelCase) => {
+const handleValidate = async (argv: ArgumentsCamelCase<CommonArgs>) => {
     const configPath = await getConfigFile(argv);
 
-    const logLevel = (argv.logLevel ??
-        argv.loglevel ??
-        LogLevel.INFO) as number;
+    const logLevel = argv.logLevel ?? argv.loglevel ?? LogLevel.INFO;
     const logger = new Logger(logLevel);
 
     logger.info(`Current configuration file: ${configPath}`);

--- a/src/utils/AccountMap.ts
+++ b/src/utils/AccountMap.ts
@@ -11,10 +11,10 @@ export class AccountMap {
         private actualApi: ActualApi
     ) {}
 
-    private moneyMoneyAccounts: Array<MonMonAccount>;
-    private actualAccounts: Array<APIAccountEntity>;
+    private moneyMoneyAccounts: Array<MonMonAccount> = [];
+    private actualAccounts: Array<APIAccountEntity> = [];
 
-    private mapping: Map<MonMonAccount, APIAccountEntity>;
+    private mapping: Map<MonMonAccount, APIAccountEntity> = new Map();
 
     public getMap(moneyMoneyAccountRefs?: Array<string>) {
         if (!moneyMoneyAccountRefs) return this.mapping;
@@ -96,7 +96,7 @@ export class AccountMap {
     }
 
     async loadFromConfig() {
-        if (this.mapping) {
+        if (this.mapping.size > 0) {
             this.logger.debug(
                 'Account mapping already loaded. Skipping re-load...'
             );

--- a/src/utils/cliArgs.ts
+++ b/src/utils/cliArgs.ts
@@ -24,3 +24,10 @@ export const includesRef = (
 
     return refs.some((ref) => ref.toLowerCase() === value.toLowerCase());
 };
+
+/** Options shared across all commands (registered at top-level). */
+export type CommonArgs = {
+    config?: string;
+    logLevel?: number;
+    loglevel?: number;
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import toml from 'toml';
 import { ArgumentsCamelCase } from 'yargs';
+import { CommonArgs } from './cliArgs.js';
 import { z } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
 
@@ -178,16 +179,16 @@ export const parseConfigData = (configData: unknown): Config => {
     return config;
 };
 
-export const getConfigFile = (argv: ArgumentsCamelCase) => {
+export const getConfigFile = (argv: ArgumentsCamelCase<CommonArgs>) => {
     if (argv.config) {
-        const argvConfigFile = path.resolve(argv.config as string);
+        const argvConfigFile = path.resolve(argv.config);
         return argvConfigFile;
     }
 
     return DEFAULT_CONFIG_FILE;
 };
 
-export const getConfig = async (argv: ArgumentsCamelCase) => {
+export const getConfig = async (argv: ArgumentsCamelCase<CommonArgs>) => {
     const configFile = getConfigFile(argv);
 
     const configFileExists = await fs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -94,7 +94,7 @@
         // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
         // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
         // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-        "strictPropertyInitialization": false /* Check for class properties that are declared but not set in the constructor. */,
+        "strictPropertyInitialization": true /* Check for class properties that are declared but not set in the constructor. */,
         // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
         "useUnknownInCatchVariables": true /* Default catch clause variables as 'unknown' instead of 'any'. */,
         // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */


### PR DESCRIPTION
## Summary
Completes PR 3 from the improvement plan.

### 1. Re-enable strictPropertyInitialization
- AccountMap fields now initialized with sensible defaults: `[]` and `new Map()`
- `loadFromConfig` guard updated from truthiness to `mapping.size > 0`
- `tsconfig.json` re-enabled — no other uninitialized fields in the project

### 2. Parameterize ArgumentsCamelCase
- Added `CommonArgs` shared type in `cliArgs.ts` (config, logLevel, loglevel)
- `config.ts` functions now use `ArgumentsCamelCase<CommonArgs>`
- `import.command.ts`: `ImportArgs` type eliminates 7 casts (logLevel as number, dryRun as boolean, from/to as string, account/server/budget as string | string[], categorySyncOnExisting as union)
- `categories.command.ts`: `CategoriesMapArgs` type eliminates 6 casts
- `validate.command.ts`: uses `ArgumentsCamelCase<CommonArgs>`, eliminates 1 cast

## Verification
- `npm run lint:eslint` — clean
- `npm run lint:prettier` — clean
- `npm run build` — zero errors
- `npm run test` — 141/141 pass