### PR TITLE
refactor: OpenAI v6 structured outputs — chat.completions.parse() + zodResponseFormat

### DIFF
--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -2,7 +2,7 @@
 
 Based on codebase assessment 2026-05-24.
 
-**Status:** PR 1 complete ✅ · PR 2 complete ✅ · PR 3 complete ✅ · PRs 4–5 pending
+**Status:** PR 1 complete ✅ · PR 2 complete ✅ · PR 3 complete ✅ · PR 4 complete ✅ · PR 5 pending
 
 ---
 
@@ -84,47 +84,24 @@ Based on codebase assessment 2026-05-24.
 
 ---
 
-## PR 4: OpenAI v6 modernisation
+## PR 4: OpenAI v6 modernisation ✅
 
-**Issue:** #7
+**Issue:** #7  
+**Delivered in:** [#244](https://github.com/1cu/actual-moneymoney-importer/pull/244)
 
-### What
+### What was done
 
-`PayeeTransformer.ts` uses `response_format: { type: 'json_object' }` (older JSON mode) with manual `JSON.parse()` and a custom `OpenAIClient` type alias.
+1. Removed custom `OpenAICompletionResponse` and `OpenAIClient` types — now uses `OpenAI` directly from the SDK
+2. Added `z.record(z.string(), z.string())` PayeeMap Zod schema for response validation
+3. Replaced `this.openai.chat.completions.create({ response_format: { type: 'json_object' } })` with `this.openai.chat.completions.parse({ response_format: zodResponseFormat(PayeeMap, 'payee_map') })`
+4. Eliminated manual `JSON.parse()` try/catch, null-checks, and `parsed as Record<string, unknown>` cast
+5. Simplified per-payee fallback to `transformedPayees[key]?.trim() || rawPayee`
 
-### Why
+### Outcome
 
-OpenAI v6 provides `client.chat.completions.parse()` with `zodResponseFormat()` for structured outputs. This eliminates:
-
-- The custom `OpenAIClient` type (use SDK types directly)
-- The manual `JSON.parse()` try/catch block
-- The `parsed as Record<string, unknown>` cast
-- The need to check `finish_reason` manually
-
-Current handling doesn't schema-validate the response and silently falls back to raw payee names for missing/non-string keys.
-
-### Fix
-
-```ts
-import { zodResponseFormat } from 'openai/helpers/zod';
-import { z } from 'zod';
-
-const PayeeMap = z.record(z.string());
-
-const completion = await this.openai.chat.completions.parse({
-    model: this.config.openAiModel,
-    messages: [...],
-    response_format: zodResponseFormat(PayeeMap, 'payee_map'),
-    temperature: this.config.temperature,
-});
-const payeeMap = completion.choices[0]?.message?.parsed; // typed!
-```
-
-### Expected outcome
-
-- End-to-end type safety from OpenAI response to application code
-- No manual JSON.parse or casting
-- Proper schema validation
+- End-to-end type safety: `choices[0].message.parsed` is typed `Record<string, string>`
+- No manual JSON.parse, no `as` casts, no weak validation
+- Proper Zod schema validation enforced by the SDK
 
 ---
 

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -1,32 +1,10 @@
 import OpenAI from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
 import Logger from './Logger.js';
 import { PayeeTransformationConfig } from './config.js';
 
-type OpenAICompletionResponse = {
-    choices: Array<{
-        message?: {
-            content?: string | null;
-        };
-    }>;
-};
-
-type OpenAIClient = {
-    chat: {
-        completions: {
-            create: (options: {
-                model: string;
-                messages: Array<{
-                    role: 'system' | 'user';
-                    content: string;
-                }>;
-                response_format: {
-                    type: 'json_object';
-                };
-                temperature: number;
-            }) => Promise<OpenAICompletionResponse>;
-        };
-    };
-};
+const PayeeMap = z.record(z.string(), z.string());
 
 const MAX_EXISTING_PAYEES_IN_PROMPT = 100;
 const EXISTING_PAYEE_MATCH_THRESHOLD = 0.75;
@@ -139,12 +117,12 @@ const selectRelevantExistingPayees = (
 };
 
 class PayeeTransformer {
-    private openai: OpenAIClient;
+    private openai: OpenAI;
 
     constructor(
         private config: PayeeTransformationConfig,
         private logger: Logger,
-        openai?: OpenAIClient
+        openai?: OpenAI
     ) {
         if (!config.openAiApiKey) {
             throw new Error(
@@ -215,48 +193,22 @@ class PayeeTransformer {
                 `Model: ${this.config.openAiModel}`,
             ]);
 
-            const response = await this.openai.chat.completions.create({
+            const completion = await this.openai.chat.completions.parse({
                 model: this.config.openAiModel,
                 messages: [
                     { role: 'system', content: prompt },
                     { role: 'user', content: unresolvedPayees.join('\n') },
                 ],
-                response_format: {
-                    type: 'json_object',
-                },
+                response_format: zodResponseFormat(PayeeMap, 'payee_map'),
                 temperature: this.config.temperature,
             });
 
-            const output = response.choices[0]?.message?.content ?? '';
-            let parsed: unknown;
-
-            try {
-                parsed = JSON.parse(output);
-            } catch (parseError) {
-                this.logger.error(
-                    `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
-                );
-                this.logger.debug(`Raw response: ${output}`);
-                throw parseError;
-            }
-
-            if (
-                !parsed ||
-                typeof parsed !== 'object' ||
-                Array.isArray(parsed)
-            ) {
-                throw new Error('OpenAI response was not a JSON object.');
-            }
-
-            const transformedPayees = parsed as Record<string, unknown>;
+            const transformedPayees =
+                completion.choices[0]?.message?.parsed ?? {};
 
             for (const rawPayee of unresolvedPayees) {
-                const transformedPayee = transformedPayees[rawPayee];
-                const normalizedPayee =
-                    typeof transformedPayee === 'string' &&
-                    transformedPayee.trim()
-                        ? transformedPayee.trim()
-                        : rawPayee;
+                const transformedPayee = transformedPayees[rawPayee]?.trim();
+                const normalizedPayee = transformedPayee || rawPayee;
                 const bestExistingPayee = findBestExistingPayee(
                     normalizedPayee,
                     existingPayeeNames

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -13,27 +13,25 @@ const makeLogger = () => ({
     },
 });
 
-const makeOpenAIStub = ({ response, error, onCreate } = {}) => ({
+const makeOpenAIStub = ({ parsed, error, onCreate } = {}) => ({
     chat: {
         completions: {
-            create: async (options) => {
+            parse: async (options) => {
                 onCreate?.(options);
 
                 if (error) {
                     throw error;
                 }
 
-                return (
-                    response ?? {
-                        choices: [
-                            {
-                                message: {
-                                    content: '{}',
-                                },
+                return {
+                    choices: [
+                        {
+                            message: {
+                                parsed: parsed ?? {},
                             },
-                        ],
-                    }
-                );
+                        },
+                    ],
+                };
             },
         },
     },
@@ -100,16 +98,8 @@ test('transformPayees bounds the relevant existing-payee shortlist', async () =>
         makeConfig(),
         logger,
         makeOpenAIStub({
-            response: {
-                choices: [
-                    {
-                        message: {
-                            content: JSON.stringify({
-                                'Alpha Hyperstore': 'Alpha Market 001',
-                            }),
-                        },
-                    },
-                ],
+            parsed: {
+                'Alpha Hyperstore': 'Alpha Market 001',
             },
             onCreate: (options) => {
                 capturedOptions = options;
@@ -147,16 +137,8 @@ test('transformPayees snaps transformed payees back to existing names', async ()
         makeConfig(),
         logger,
         makeOpenAIStub({
-            response: {
-                choices: [
-                    {
-                        message: {
-                            content: JSON.stringify({
-                                'AMZN Mktp US*1234567890': 'Amazon.com',
-                            }),
-                        },
-                    },
-                ],
+            parsed: {
+                'AMZN Mktp US*1234567890': 'Amazon.com',
             },
             onCreate: (options) => {
                 capturedOptions = options;
@@ -178,29 +160,24 @@ test('transformPayees snaps transformed payees back to existing names', async ()
     });
 });
 
-test('transformPayees returns null for malformed JSON', async () => {
+test('transformPayees returns null on API errors', async () => {
     const logger = makeLogger();
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
         makeOpenAIStub({
-            response: {
-                choices: [
-                    {
-                        message: {
-                            content: 'not-json',
-                        },
-                    },
-                ],
-            },
+            error: new Error('Connection refused'),
         })
     );
 
     const result = await transformer.transformPayees(['Coffee Shop'], []);
 
     assert.equal(result, null);
-    assert.match(logger.errorMessages[0], /^Failed to parse JSON response:/);
-    assert.match(logger.debugMessages[1][0], /Raw response: not-json/);
+    assert.equal(logger.errorMessages.length, 1);
+    assert.match(
+        logger.errorMessages[0],
+        /^Error in payee transformation: Connection refused$/
+    );
 });
 
 test('transformPayees returns null when OpenAI fails', async () => {


### PR DESCRIPTION
## Summary
Modernises the OpenAI integration from legacy `json_object` mode to v6 structured outputs. Closes PR 4 from the improvement plan.

### Changes

**PayeeTransformer.ts:**
- Removed custom `OpenAICompletionResponse` and `OpenAIClient` types — now uses `OpenAI` directly
- Added `z.record(z.string(), z.string())` PayeeMap schema with Zod
- Replaced `this.openai.chat.completions.create({ response_format: { type: 'json_object' } })` with `this.openai.chat.completions.parse({ response_format: zodResponseFormat(PayeeMap, 'payee_map') })`
- Eliminated manual `JSON.parse()`, null-checks, and `as Record<string, unknown>` cast — SDK validates response against the Zod schema
- Simplified per-payee fallback: `transformedPayees[key]?.trim() || rawPayee`

**payee-transformer.test.mjs:**
- Updated `makeOpenAIStub` from `create` → `parse`
- Changed response shape from `choices[].message.content` (JSON strings) to `choices[].message.parsed` (typed objects)
- Repurposed legacy malformed-JSON test into generic API error path test

### Outcome
- End-to-end type safety from OpenAI response to application code
- No manual JSON.parse, casting, or weak validation
- 141/141 tests pass