### PR TITLE
fix: suppress API noise also on process.stdout.write

### DIFF
--- a/src/utils/ActualApiLogControl.ts
+++ b/src/utils/ActualApiLogControl.ts
@@ -1,6 +1,7 @@
 const API_NOISE_PATTERNS = [
     /^Syncing since /,
     /^Got messages from server /,
+    /^Loaded spreadsheet from cache /,
     /^\[Breadcrumb\]/,
 ];
 
@@ -13,9 +14,12 @@ type ConsoleLog = typeof console.log;
 let noiseFilterDepth = 0;
 
 /**
- * Applies API-noise filtering to `console.log` on the outermost call.
- * Only the specific patterns (sync progress, breadcrumbs) are suppressed;
- * all other `console.log` output passes through normally.
+ * Applies API-noise filtering to `console.log` and `process.stdout.write`
+ * on the outermost call. Only the specific patterns (sync progress,
+ * breadcrumbs) are suppressed; all other output passes through normally.
+ *
+ * @actual-app/api writes some progress messages directly to
+ * process.stdout.write, so we must filter both channels.
  *
  * Nested calls are safe — only the outermost call patches and restores.
  */
@@ -42,10 +46,27 @@ export async function withApiNoiseFilter<T>(
         originalLog(...args);
     }) as ConsoleLog;
 
+    const originalStdoutWrite = process.stdout.write.bind(
+        process.stdout
+    ) as typeof process.stdout.write;
+
+    process.stdout.write = ((data: string | Uint8Array, ...rest: unknown[]) => {
+        if (typeof data === 'string' && isApiNoiseLine(data)) {
+            return true;
+        }
+        return (
+            originalStdoutWrite as (
+                d: string | Uint8Array,
+                ...r: unknown[]
+            ) => boolean
+        )(data, ...rest);
+    }) as typeof process.stdout.write as typeof process.stdout.write;
+
     try {
         return await callback();
     } finally {
         console.log = originalLog;
+        process.stdout.write = originalStdoutWrite;
         noiseFilterDepth--;
     }
 }

--- a/src/utils/ActualApiLogControl.ts
+++ b/src/utils/ActualApiLogControl.ts
@@ -37,36 +37,36 @@ export async function withApiNoiseFilter<T>(
         }
     }
 
-    const originalLog = console.log;
+    const originalConsoleLog = console.log;
+    const originalStdoutWrite = process.stdout.write;
+
     console.log = ((...args: Parameters<ConsoleLog>) => {
         const firstArg = args[0];
         if (typeof firstArg === 'string' && isApiNoiseLine(firstArg)) {
             return;
         }
-        originalLog(...args);
+        originalConsoleLog(...args);
     }) as ConsoleLog;
-
-    const originalStdoutWrite = process.stdout.write.bind(
-        process.stdout
-    ) as typeof process.stdout.write;
 
     process.stdout.write = ((data: string | Uint8Array, ...rest: unknown[]) => {
         if (typeof data === 'string' && isApiNoiseLine(data)) {
             return true;
         }
         return (
-            originalStdoutWrite as (
-                d: string | Uint8Array,
-                ...r: unknown[]
+            originalStdoutWrite as unknown as (
+                data: string | Uint8Array,
+                ...rest: unknown[]
             ) => boolean
-        )(data, ...rest);
-    }) as typeof process.stdout.write as typeof process.stdout.write;
+        ).call(process.stdout, data, ...rest) as boolean;
+    }) as typeof process.stdout.write;
 
     try {
         return await callback();
     } finally {
-        console.log = originalLog;
-        process.stdout.write = originalStdoutWrite;
         noiseFilterDepth--;
+        if (noiseFilterDepth === 0) {
+            console.log = originalConsoleLog;
+            process.stdout.write = originalStdoutWrite;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a regression from #242 where `@actual-app/api` progress messages leaked through the noise filter because they're written directly to `process.stdout.write` rather than `console.log`.

## Changes
- `withApiNoiseFilter` now patches both `console.log` AND `process.stdout.write`
- Added `Loaded spreadsheet from cache` to the noise patterns list
- Both channels are restored in the finally block with nested-safe depth tracking

## Verification
- `npm run build` — zero errors
- `npm run test` — 141/141 pass
- Manual: `actual-mmi import` no longer shows API sync progress noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API operation logging by suppressing additional cache-related messages and reducing console noise for cleaner output visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1cu/actual-moneymoney-importer/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->