### PR TITLE
chore: bump deps to latest + migrate zod .superRefine() to .check()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dependencies": {
                 "@actual-app/api": "^26.5.0",
                 "chalk": "^5.6.2",
-                "date-fns": "^4.1.0",
+                "date-fns": "^4.3.0",
                 "moneymoney": "^1.3.0",
-                "openai": "^6.37.0",
+                "openai": "^6.39.0",
                 "string-width": "^8.2.1",
                 "toml": "^4.1.1",
                 "yargs": "^18.0.0",
@@ -28,15 +28,14 @@
                 "@eslint/js": "^10.0.1",
                 "@types/node": "^25.0.0",
                 "@types/yargs": "^17.0.35",
-                "eslint": "^10.3.0",
+                "eslint": "^10.4.0",
                 "globals": "^17.6.0",
                 "husky": "^9.1.7",
-                "lint-staged": "^17.0.2",
+                "lint-staged": "^17.0.5",
                 "prettier": "^3.8.3",
                 "semantic-release": "^25.0.3",
-                "ts-node": "^10.9.2",
                 "typescript": "^6.0.3",
-                "typescript-eslint": "^8.59.2"
+                "typescript-eslint": "^8.59.4"
             },
             "engines": {
                 "node": "25.x"
@@ -486,19 +485,6 @@
                 }
             }
         },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -698,34 +684,6 @@
             "resolved": "https://registry.npmjs.org/@jlongster/sql.js/-/sql.js-1.6.7.tgz",
             "integrity": "sha512-4hf0kZr5WPoirdR5hUSfQ9O0JpH/qlW1CaR2wZ6zGrDz1xjSdTPuR8AW/oXzIHnJvZSEvlcIE+dfXJZwh/Lxfw==",
             "license": "MIT"
-        },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
-            }
         },
         "node_modules/@octokit/auth-token": {
             "version": "6.0.0",
@@ -1256,34 +1214,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-            "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/esrecurse": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1609,19 +1539,6 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/acorn-walk": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/adm-zip": {
             "version": "0.5.17",
             "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
@@ -1719,13 +1636,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2493,13 +2403,6 @@
                 "typescript": ">=5"
             }
         },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2653,16 +2556,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/diff": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
             }
         },
         "node_modules/dir-glob": {
@@ -4409,13 +4302,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/marked": {
             "version": "15.0.12",
@@ -8282,50 +8168,6 @@
                 "typescript": ">=4.8.4"
             }
         },
-        "node_modules/ts-node": {
-            "version": "10.9.2",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@cspotcode/source-map-support": "^0.8.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "v8-compile-cache-lib": "^3.0.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-esm": "dist/bin-esm.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/tunnel": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -8876,13 +8718,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -9079,16 +8914,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "dependencies": {
         "@actual-app/api": "^26.5.0",
         "chalk": "^5.6.2",
-        "date-fns": "^4.1.0",
+        "date-fns": "^4.3.0",
         "moneymoney": "^1.3.0",
-        "openai": "^6.37.0",
+        "openai": "^6.39.0",
         "string-width": "^8.2.1",
         "toml": "^4.1.1",
         "yargs": "^18.0.0",
@@ -65,14 +65,14 @@
         "@types/node": "^25.0.0",
         "@eslint/js": "^10.0.1",
         "@types/yargs": "^17.0.35",
-        "eslint": "^10.3.0",
+        "eslint": "^10.4.0",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
-        "lint-staged": "^17.0.2",
+        "lint-staged": "^17.0.5",
         "prettier": "^3.8.3",
         "semantic-release": "^25.0.3",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.2"
+        "typescript-eslint": "^8.59.4"
     },
     "lint-staged": {
         "src/**/*.ts": [

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,22 +38,27 @@ const budgetSchema = z
         accountMapping: z.record(z.string(), z.string()),
         categoryMapping: z.record(z.string(), z.string()).optional(),
     })
-    .superRefine((val, ctx) => {
-        if (val.e2eEncryption.enabled && !val.e2eEncryption.password) {
-            ctx.addIssue({
+    .check((payload) => {
+        if (
+            payload.value.e2eEncryption.enabled &&
+            !payload.value.e2eEncryption.password
+        ) {
+            payload.issues.push({
                 code: 'custom',
                 message:
                     'Password must not be empty if end-to-end encryption is enabled',
+                input: payload.value,
             });
         }
 
-        if (val.earliestImportDate) {
-            if (!isValidCalendarDate(val.earliestImportDate)) {
-                ctx.addIssue({
+        if (payload.value.earliestImportDate) {
+            if (!isValidCalendarDate(payload.value.earliestImportDate)) {
+                payload.issues.push({
                     code: 'custom',
                     path: ['earliestImportDate'],
                     message:
                         'Invalid earliest import date (required format is YYYY-MM-DD and must be a real calendar date)',
+                    input: payload.value,
                 });
             }
         }
@@ -68,7 +73,7 @@ const actualServerSchema = z.object({
 const payeeTransformationSchema = z.object({
     enabled: z.boolean(),
     openAiApiKey: z.string().optional(),
-    openAiModel: z.string().optional().default('gpt-5-nano'),
+    openAiModel: z.string().optional().default('gpt-5.4-nano'),
     temperature: z.number().min(0).max(2).optional().default(1),
     onTransformError: z.enum(['warn', 'fail']).optional().default('warn'),
     prompt: z.string().optional(),
@@ -106,28 +111,30 @@ export const configSchema = z
         }),
         actualServers: z.array(actualServerSchema).min(1),
     })
-    .superRefine((val, ctx) => {
+    .check((payload) => {
         // Check openAI key if payeeTransformation is enabled
         if (
-            val.payeeTransformation.enabled &&
-            !val.payeeTransformation.openAiApiKey
+            payload.value.payeeTransformation.enabled &&
+            !payload.value.payeeTransformation.openAiApiKey
         ) {
-            ctx.addIssue({
+            payload.issues.push({
                 code: 'custom',
                 message:
                     'OpenAI key must not be empty if payeeTransformation is enabled',
+                input: payload.value,
             });
         }
 
         if (
-            val.import.transfers.enabled &&
-            val.import.transfers.categoryRefs.length === 0
+            payload.value.import.transfers.enabled &&
+            payload.value.import.transfers.categoryRefs.length === 0
         ) {
-            ctx.addIssue({
+            payload.issues.push({
                 code: 'custom',
                 message:
                     'At least one transfer category ref must be configured if automatic transfers are enabled',
                 path: ['import', 'transfers', 'categoryRefs'],
+                input: payload.value,
             });
         }
     });


### PR DESCRIPTION
## Changes

- Bump 5 dependency versions in `package.json` to match latest installed:
  - `date-fns`: `^4.1.0` → `^4.3.0`
  - `openai`: `^6.37.0` → `^6.39.0`
  - `eslint`: `^10.3.0` → `^10.4.0`
  - `lint-staged`: `^17.0.2` → `^17.0.5`
  - `typescript-eslint`: `^8.59.2` → `^8.59.4`
- Migrate zod v4 deprecated `.superRefine()` → `.check()` in `config.ts` (2 call sites)
  - Callback signature changed from `(val, ctx)` to `(payload)`; issues are now pushed via `payload.issues.push()` instead of `ctx.addIssue()`
- Bump OpenAI default model from `gpt-5-nano` → `gpt-5.4-nano`

## Verification
- Build passes (`npm run build`)
- All 141 tests pass (`npm run test`)