### PR TITLE
chore: silence CodeRabbit noise — disable auto-reviews and status messages

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit stays silent by default — reviews only on explicit
+# `@coderabbitai review` command. No auto-reviews, no status noise,
+# no finishing-touch checkboxes, no poems.
+auto_review:
+  enabled: false
+review_status: false
+reviews:
+  poem: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false


### PR DESCRIPTION
## Problem

CodeRabbit posts noisy "Review limit reached" warnings on every PR, plus finishing-touch checkbox prompts and poems — even on a single-file docs PR (#251).

## Changes

Adds `.coderabbit.yaml`:

- `auto_review.enabled: false` — No automatic reviews. CodeRabbit only responds to explicit `@coderabbitai review` commands.
- `review_status: false` — Suppresses status/skip messages ("Review limit reached" etc.).
- `reviews.poem: false` — No fortune-cookie poems.
- `reviews.finishing_touches.{docstrings,unit_tests}.enabled: false` — No checkbox prompts on reviews.