### PR TITLE
fix: suppress reconciliation debug noise from @actual-app/core

### DIFF
--- a/src/utils/ActualApiLogControl.ts
+++ b/src/utils/ActualApiLogControl.ts
@@ -3,6 +3,8 @@ const API_NOISE_PATTERNS = [
     /^Got messages from server /,
     /^Loaded spreadsheet from cache /,
     /^\[Breadcrumb\]/,
+    /^Performing transaction reconciliation/,
+    /^Debug data for the operations:/,
 ];
 
 const isApiNoiseLine = (line: string): boolean =>


### PR DESCRIPTION
## What

Adds two patterns to `API_NOISE_PATTERNS` in `ActualApiLogControl.ts` to suppress debug-level output from `@actual-app/core`'s transaction reconciliation flow.

## Why

`@actual-app/core`'s `reconcileTransactions` function prints three messages via `logger.log()` (not `console.log` directly), which are only gated by `verboseMode` (defaults to `true`). The existing noise filter matched sync progress and breadcrumb messages but not these reconciliation debug messages.

When running `actual-mmi import` without `--logLevel 4`, users would see:

- `Performing transaction reconciliation`
- `Performing transaction reconciliation matching`
- `Debug data for the operations: { ... }` (with full transaction arrays)

## Changes

- `/^Performing transaction reconciliation/` — catches both the main reconciliation log and the matching log
- `/^Debug data for the operations:/` — catches the debug dump header

These patterns only apply when `logLevel < ACTUAL` (the default); users who explicitly set `--logLevel 4` see all output as before.

## Verification

- `npm run lint:prettier` — passes
- `npm run build` — passes
- `npm run test:unit` — 195/195 pass
- `npm run test:cli` — 13/13 pass