### PR TITLE
chore(release): align semantic-release versioning policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       schedule:
           interval: daily
       commit-message:
-          prefix: chore
+          prefix: fix
           prefix-development: chore
           include: scope
     - package-ecosystem: github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 on:
+    push:
+        branches:
+            - main
     workflow_dispatch:
 jobs:
     release:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,9 +6,7 @@
             {
                 "releaseRules": [
                     {
-                        "type": "chore",
-                        "scope": "deps",
-                        "subject": "bump @actual-app/api from *",
+                        "type": "refactor",
                         "release": "patch"
                     }
                 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,18 @@ Commits must follow Conventional Commits (validated by commitlint), e.g.:
 - `fix: handle missing account mapping`
 - `chore(deps): update dependencies`
 
+Release versions are determined from commit messages by `semantic-release`:
+
+- `feat:` creates a minor release.
+- `fix:`, `perf:`, and `refactor:` create patch releases.
+- `!` or a `BREAKING CHANGE:` footer creates a major release.
+- Runtime dependency updates should use `fix(deps): ...` for patch releases.
+- Runtime dependency updates that intentionally require a minor release should use `feat(deps): ...`.
+- Runtime dependency updates that intentionally require a major release should use `fix(deps)!: ...` or include a `BREAKING CHANGE:` footer.
+- Dev dependency updates should use `chore(deps-dev): ...` and do not create releases by default.
+
+Dependabot is configured to use `fix(deps): ...` for runtime dependency PRs and `chore(deps-dev): ...` for dev dependency PRs. If an Actual API/Core dependency update needs to mirror an upstream major or minor version, edit the PR title or squash commit before merging so it uses the correct Conventional Commit type.
+
 PRs should include:
 
 - Clear description of intent and scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ npm run test
 
 ## Release & Publishing
 
-- Stable releases are published from `main` via a manual `semantic-release` workflow trigger.
+- Stable releases are published automatically from `main` by the `semantic-release` workflow. The workflow can also be triggered manually when a rerun is needed.
 - Releases publish to both GitHub Releases and npm.
 - Do not manually bump `package.json` version or publish locally for routine releases.
 - Keep `package.json`, `README.md`, and release workflow/config files in sync when changing the package name, CLI name, install instructions, or release flow.
@@ -143,7 +143,7 @@ git push origin fix/your-change
 gh pr create --base main --head fix/your-change --title "fix: your change" --body "..."
 ```
 
-After review and CI passes, merge the PR. Releases are triggered manually from `main` afterward.
+After review and CI passes, merge the PR. Release publishing runs automatically from `main` afterward.
 
 ## Commit & Pull Request Guidelines
 

--- a/test/unit/release-config.test.mjs
+++ b/test/unit/release-config.test.mjs
@@ -6,7 +6,7 @@ const releaseConfig = JSON.parse(
     readFileSync(new URL('../../.releaserc.json', import.meta.url), 'utf8')
 );
 
-test('semantic-release promotes Dependabot API bumps', () => {
+test('semantic-release keeps release rules focused on conventional SemVer gaps', () => {
     const commitAnalyzer = releaseConfig.plugins.find((plugin) => {
         return (
             Array.isArray(plugin) &&
@@ -18,13 +18,10 @@ test('semantic-release promotes Dependabot API bumps', () => {
 
     const [, options] = commitAnalyzer;
     assert.ok(Array.isArray(options.releaseRules));
-    assert.ok(
-        options.releaseRules.some(
-            ({ type, scope, subject, release }) =>
-                type === 'chore' &&
-                scope === 'deps' &&
-                subject === 'bump @actual-app/api from *' &&
-                release === 'patch'
-        )
-    );
+    assert.deepEqual(options.releaseRules, [
+        {
+            type: 'refactor',
+            release: 'patch',
+        },
+    ]);
 });


### PR DESCRIPTION
## Summary

- align semantic-release rules with Conventional Commit SemVer behavior
- make Dependabot runtime dependency updates produce patch releases by default while dev dependency updates stay non-releasing
- document how to intentionally request dependency minor/major releases through commit messages
- run the release workflow automatically on pushes to `main`, while keeping manual dispatch available

## Release impact

This changes release automation behavior but should not itself publish a package release because the commits use non-releasing `chore`/`ci` types.

After this lands, releases are published automatically from `main` when semantic-release detects a release-worthy commit.

## Testing

- `rtk npm run test:unit`
- `rtk npm run lint:prettier`
- `rtk npm run test`
- `rtk npm run lint:eslint`