### PR TITLE
feat: add Apple Intelligence backend for payee transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run `actual-mmi --help` at any time for a full list of commands and options. For
 - 🗺️ **`categories map` CLI** – audit, plan, and write your category mapping from the terminal
 - ⚠️ **Auto-rule override detection** – get warned when Actual's rules silently change a synced category
 - 🔬 **Scoped imports** – filter by server, budget, or account with repeatable `-s`/`-b`/`-a` flags
-- 🤖 **AI payee transformation** – configurable prompt, OpenAI models, temperature, and error-handling policy
+- 🤖 **AI payee transformation** – configurable prompt, OpenAI or on-device Apple Intelligence, temperature, and error-handling policy
 - 💬 **Comment import** – carry MoneyMoney transaction comments into Actual notes (with configurable prefix)
 
 ## Installation
@@ -121,12 +121,22 @@ password = ""
 
 ### Payee transformation
 
-Converts cryptic payee names to human-readable formats using OpenAI (e.g. "AMAZN S.A.R.L" to "Amazon"). The importer also reuses existing budget payees with a bounded shortlist and snaps close matches back to canonical names. Requires an API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+**This feature is macOS-only** and converts cryptic payee names to human-readable formats (e.g. "AMAZN S.A.R.L" to "Amazon"). The importer also reuses existing budget payees with a bounded shortlist and snaps close matches back to canonical names.
+
+Two backends are available:
+
+| Backend              | Processing | API Key Required | Requirements                                                      |
+| -------------------- | ---------- | ---------------- | ----------------------------------------------------------------- |
+| `openai` (default)   | Cloud      | Yes              | OpenAI account ([api keys](https://platform.openai.com/api-keys)) |
+| `apple-intelligence` | On-device  | No               | macOS 26+ (Tahoe), Apple Silicon, Apple Intelligence enabled      |
+
+With `apple-intelligence`, all payee data is processed locally on your Mac. Nothing is sent to any cloud service. You need the `tsfm-sdk` npm package installed (`npm install tsfm-sdk`). No API key or network access is required beyond the initial package install.
 
 | Option             | Default        | Description                                                                                                 |
 | ------------------ | -------------- | ----------------------------------------------------------------------------------------------------------- |
 | `enabled`          | `false`        | Enable/disable AI payee transformation                                                                      |
-| `openAiApiKey`     | —              | Your OpenAI API key (required if enabled)                                                                   |
+| `backend`          | `openai`       | Backend to use: `openai` or `apple-intelligence`                                                            |
+| `openAiApiKey`     | —              | Your OpenAI API key (required only with `backend = "openai"`)                                               |
 | `openAiModel`      | `gpt-5.4-nano` | OpenAI model to use. You may need to change this to a model available on your account (e.g. `gpt-4o-mini`). |
 | `temperature`      | `1`            | Temperature for API calls (0–2 inclusive)                                                                   |
 | `onTransformError` | `warn`         | Error handling: `warn` (use raw names) or `fail` (abort import)                                             |
@@ -286,7 +296,7 @@ With `--write-config`, the tool rewrites your `[actualServers.budgets.categoryMa
 
 ### Validate command
 
-`actual-mmi validate` checks your config file's TOML syntax and schema (required fields, types, value ranges). It does **not** verify that your Actual server is reachable, sync IDs exist, accounts map correctly, or your OpenAI key is valid. To test the full import flow without making changes, use `actual-mmi import --dry-run`.
+`actual-mmi validate` checks your config file's TOML syntax and schema (required fields, types, value ranges). It does **not** verify that your Actual server is reachable, sync IDs exist, accounts map correctly, or your OpenAI key / Apple Intelligence is available. To test the full import flow without making changes, use `actual-mmi import --dry-run`.
 
 ## Advanced Configuration
 
@@ -318,7 +328,7 @@ Note that the date is a string, not a TOML date.
 
 ## Security
 
-The configuration file (default: `~/.actually/config.toml`) stores your Actual server password(s) and OpenAI API key in plaintext. To protect these secrets:
+The configuration file (default: `~/.actually/config.toml`) stores your Actual server password(s) and, if using the OpenAI backend, your OpenAI API key in plaintext. The Apple Intelligence backend keeps all data on-device and requires no secrets. To protect your secrets:
 
 - Keep the config file private: `chmod 600 ~/.actually/config.toml`
 - Prefer `https://` for remote Actual servers. The importer will warn if you use cleartext HTTP to a non-localhost server, since passwords would be sent in plaintext.
@@ -326,18 +336,19 @@ The configuration file (default: `~/.actually/config.toml`) stores your Actual s
 
 ## Troubleshooting
 
-| Problem                                                                                        | Likely cause / solution                                                                                                                       |
-| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MoneyMoney database is locked`                                                                | Unlock MoneyMoney and try again. MoneyMoney must be running and unlocked during import.                                                       |
-| `Failed to connect to Actual server`                                                           | Ensure the Actual server is running and reachable at the configured `serverUrl`. Try `curl <serverUrl>` in a terminal.                        |
-| `No matching Actual servers found for --server filter`                                         | The `--server` / `-s` filter matches against the **exact URL** from your config (e.g. `http://localhost:5006`), not a nickname or label.      |
-| `No matching budgets found`                                                                    | The `--budget` / `-b` filter matches against the **sync ID** from your config, not the budget name.                                           |
-| `No matching MoneyMoney accounts found`                                                        | Make sure MoneyMoney is unlocked and the account is mapped in `[actualServers.budgets.accountMapping]`.                                       |
-| `Invalid configuration file`                                                                   | Run `actual-mmi validate` to see specific errors. Check that `syncId` is the budget sync ID (not the name) and `serverUrl` is a valid URL.    |
-| `E2E encryption password is required`                                                          | If your Actual budget uses end-to-end encryption, set `enabled = true` and provide the `password` in `[actualServers.budgets.e2eEncryption]`. |
-| OpenAPI model error (e.g. `model 'gpt-5.4-nano' is unavailable`)                               | Set `payeeTransformation.openAiModel` to a model available on your OpenAI account (e.g. `gpt-4o-mini`).                                       |
-| `Category sync policy 'ask' requires an interactive terminal`                                  | Use `-C=new` or `-C=always` when running in a non-interactive environment (CI, cron, launchd).                                                |
-| Auto-rule override warning: "Actual's rules changed the category of transaction X from Y to Z" | This is informational. Add a corresponding rule in Actual, or adjust the rule ordering so it doesn't conflict with the synced category.       |
+| Problem                                                                                        | Likely cause / solution                                                                                                                          |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MoneyMoney database is locked`                                                                | Unlock MoneyMoney and try again. MoneyMoney must be running and unlocked during import.                                                          |
+| `Failed to connect to Actual server`                                                           | Ensure the Actual server is running and reachable at the configured `serverUrl`. Try `curl <serverUrl>` in a terminal.                           |
+| `No matching Actual servers found for --server filter`                                         | The `--server` / `-s` filter matches against the **exact URL** from your config (e.g. `http://localhost:5006`), not a nickname or label.         |
+| `No matching budgets found`                                                                    | The `--budget` / `-b` filter matches against the **sync ID** from your config, not the budget name.                                              |
+| `No matching MoneyMoney accounts found`                                                        | Make sure MoneyMoney is unlocked and the account is mapped in `[actualServers.budgets.accountMapping]`.                                          |
+| `Invalid configuration file`                                                                   | Run `actual-mmi validate` to see specific errors. Check that `syncId` is the budget sync ID (not the name) and `serverUrl` is a valid URL.       |
+| `E2E encryption password is required`                                                          | If your Actual budget uses end-to-end encryption, set `enabled = true` and provide the `password` in `[actualServers.budgets.e2eEncryption]`.    |
+| OpenAI model error (e.g. `model 'gpt-5.4-nano' is unavailable`)                                | Set `payeeTransformation.openAiModel` to a model available on your OpenAI account (e.g. `gpt-4o-mini`).                                          |
+| `Apple Intelligence backend is unavailable`                                                    | Requires macOS 26+ (Tahoe), Apple Silicon (M1 or later), and Apple Intelligence enabled in System Settings. Also ensure `tsfm-sdk` is installed. |
+| `Category sync policy 'ask' requires an interactive terminal`                                  | Use `-C=new` or `-C=always` when running in a non-interactive environment (CI, cron, launchd).                                                   |
+| Auto-rule override warning: "Actual's rules changed the category of transaction X from Y to Z" | This is informational. Add a corresponding rule in Actual, or adjust the rule ordering so it doesn't conflict with the synced category.          |
 
 ## Bugs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "openai": "^6.39.0",
                 "string-width": "^8.2.1",
                 "toml": "^4.1.1",
+                "tsfm-sdk": "*",
                 "yargs": "^18.0.0",
                 "zod": "^4.4.3"
             },
@@ -40,6 +41,9 @@
             },
             "engines": {
                 "node": ">=22"
+            },
+            "optionalDependencies": {
+                "tsfm-sdk": "^0.3.1"
             }
         },
         "node_modules/@actions/core": {
@@ -3939,6 +3943,17 @@
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/koffi": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+            "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
             }
         },
         "node_modules/levn": {
@@ -8137,6 +8152,25 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4"
+            }
+        },
+        "node_modules/tsfm-sdk": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/tsfm-sdk/-/tsfm-sdk-0.3.1.tgz",
+            "integrity": "sha512-AKu3YeGxAOStpwCj8TSs8hlX2AdXgf3pzF/c3kYgQY1LtN2pUf0ojZsfBPhFE0HarMrM7SkQ33JywLFjrAgxvw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "koffi": "^2.15.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "devDependencies": {
         "@commitlint/cli": "^21.0.0",
         "@commitlint/config-conventional": "^21.0.0",
-        "@types/node": "^25.0.0",
         "@eslint/js": "^10.0.1",
+        "@types/node": "^25.0.0",
         "@types/yargs": "^17.0.35",
         "eslint": "^10.4.0",
         "globals": "^17.6.0",
@@ -110,5 +110,8 @@
             "eslint --fix",
             "prettier --write"
         ]
+    },
+    "optionalDependencies": {
+        "tsfm-sdk": "^0.3.1"
     }
 }

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -1,17 +1,9 @@
-import OpenAI from 'openai';
-import { zodResponseFormat } from 'openai/helpers/zod';
-import { z } from 'zod';
 import Logger from './Logger.js';
 import { PayeeTransformationConfig } from './config.js';
-
-const PayeeMapSchema = z.object({
-    mappings: z.array(
-        z.object({
-            rawPayee: z.string(),
-            cleanedPayee: z.string(),
-        })
-    ),
-});
+import {
+    TransformationBackend,
+    createTransformationBackend,
+} from './TransformationBackend.js';
 
 const MAX_EXISTING_PAYEES_IN_PROMPT = 100;
 const EXISTING_PAYEE_MATCH_THRESHOLD = 0.75;
@@ -124,20 +116,18 @@ const selectRelevantExistingPayees = (
 };
 
 class PayeeTransformer {
-    private openai: OpenAI;
+    private backend: TransformationBackend;
 
     constructor(
         private config: PayeeTransformationConfig,
         private logger: Logger,
-        openai?: OpenAI
+        backend?: TransformationBackend
     ) {
-        if (!config.openAiApiKey) {
-            throw new Error(
-                'An OpenAI API key is required for payee transformation. Please set the key in the configuration file.'
-            );
-        }
-
-        this.openai = openai ?? new OpenAI({ apiKey: config.openAiApiKey });
+        this.backend = backend ?? createTransformationBackend(config);
+        this.logger.debug(`Payee transformation enabled`, [
+            `Backend: ${this.backend.getLabel()}`,
+            `Temperature: ${this.config.temperature}`,
+        ]);
     }
 
     public async transformPayees(
@@ -197,34 +187,18 @@ class PayeeTransformer {
                 `Payees: ${unresolvedPayees.length}`,
                 `Locally matched payees: ${resolvedPayees.size}`,
                 `Existing payees used in prompt: ${relevantExistingPayees.length}${existingPayeeNames.length > relevantExistingPayees.length ? ` of ${existingPayeeNames.length}` : ''}`,
-                `Model: ${this.config.openAiModel}`,
+                `Backend: ${this.backend.getLabel()}`,
             ]);
 
-            const completion = await this.openai.chat.completions.parse({
-                model: this.config.openAiModel,
-                messages: [
-                    { role: 'system', content: prompt },
-                    { role: 'user', content: unresolvedPayees.join('\n') },
-                ],
-                response_format: zodResponseFormat(PayeeMapSchema, 'payee_map'),
-                temperature: this.config.temperature,
-            });
-
-            const parsed = completion.choices[0]?.message?.parsed;
-            if (!parsed) {
-                throw new Error(
-                    'OpenAI returned no payee transformation result'
-                );
-            }
-
-            const transformedPayees = Object.fromEntries(
-                parsed.mappings.map(
-                    (entry: { rawPayee: string; cleanedPayee: string }) => [
-                        entry.rawPayee,
-                        entry.cleanedPayee,
-                    ]
-                )
+            const transformedPayees = await this.backend.transformPayees(
+                prompt,
+                unresolvedPayees,
+                this.config.temperature
             );
+
+            let snappedToExisting = 0;
+            let aiKeptAsNew = 0;
+            let keptRaw = 0;
 
             for (const rawPayee of unresolvedPayees) {
                 const transformedPayee = transformedPayees[rawPayee]?.trim();
@@ -234,15 +208,33 @@ class PayeeTransformer {
                     existingPayeeNames
                 );
 
-                resolvedPayees.set(
-                    rawPayee,
+                if (
                     bestExistingPayee &&
-                        bestExistingPayee.score >=
-                            EXISTING_PAYEE_MATCH_THRESHOLD
-                        ? bestExistingPayee.payeeName
-                        : normalizedPayee
-                );
+                    bestExistingPayee.score >= EXISTING_PAYEE_MATCH_THRESHOLD
+                ) {
+                    resolvedPayees.set(rawPayee, bestExistingPayee.payeeName);
+                    if (transformedPayee) {
+                        snappedToExisting++;
+                    } else {
+                        keptRaw++;
+                    }
+                } else {
+                    resolvedPayees.set(rawPayee, normalizedPayee);
+                    if (transformedPayee) {
+                        aiKeptAsNew++;
+                    } else {
+                        keptRaw++;
+                    }
+                }
             }
+
+            this.logger.debug(`Payee transformation results`, [
+                `Local Dice matches (no AI): ${resolvedPayees.size - unresolvedPayees.length}`,
+                `Sent to backend: ${unresolvedPayees.length}`,
+                `Snapped to existing: ${snappedToExisting}`,
+                `AI new names: ${aiKeptAsNew}`,
+                `Kept raw: ${keptRaw}`,
+            ]);
 
             return Object.fromEntries(resolvedPayees);
         } catch (error) {
@@ -303,29 +295,15 @@ Output:
             return `Error in payee transformation: ${String(error)}`;
         }
 
-        if (this.isModelUnavailableError(error)) {
-            return `OpenAI model '${this.config.openAiModel}' is unavailable. Set 'payeeTransformation.openAiModel' in your config to an available model and try again. Original error: ${error.message}`;
+        if (this.backend.isModelUnavailableError(error)) {
+            return `Model '${this.backend.getLabel()}' is unavailable. Ensure the model is accessible and try again. Original error: ${error.message}`;
         }
 
-        if (
-            error.message.includes('temperature') &&
-            error.message.includes('does not support')
-        ) {
-            return `Incompatible configuration: Model '${this.config.openAiModel}' does not support temperature=${this.config.temperature}. Please update the 'temperature' setting in your configuration file. Error: ${error.message}`;
+        if (this.backend.isTemperatureError(error)) {
+            return `Incompatible configuration: Model '${this.backend.getLabel()}' does not support temperature=${this.config.temperature}. Please update the 'temperature' setting in your configuration file. Error: ${error.message}`;
         }
 
         return `Error in payee transformation: ${error.message}`;
-    }
-
-    private isModelUnavailableError(error: Error) {
-        const message = error.message.toLowerCase();
-        return (
-            message.includes('model') &&
-            (message.includes('does not exist') ||
-                message.includes('not found') ||
-                message.includes('invalid model') ||
-                message.includes('unknown model'))
-        );
     }
 }
 

--- a/src/utils/TransformationBackend.ts
+++ b/src/utils/TransformationBackend.ts
@@ -1,0 +1,287 @@
+/**
+ * Payee transformation backends.
+ *
+ * This importer is **macOS-only**. It depends on the `moneymoney` npm package
+ * which requires macOS with MoneyMoney.app installed and unlocked.
+ *
+ * ## Backends
+ *
+ * - **openai** (default): Cloud-based; requires an OpenAI API key.
+ * - **apple-intelligence**: On-device processing via Apple's Foundation Models.
+ *   Requires macOS 26+ (Tahoe), Apple Silicon (M1 or later), Apple Intelligence
+ *   enabled in System Settings, and the `tsfm-sdk` npm package installed.
+ *
+ * Apple Intelligence processes all data locally. No API key or network call is
+ * needed beyond the initial `tsfm-sdk` install.
+ */
+
+import OpenAI from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { z } from 'zod';
+import { PayeeTransformationConfig } from './config.js';
+
+export const PayeeMapSchema = z.object({
+    mappings: z.array(
+        z.object({
+            rawPayee: z.string(),
+            cleanedPayee: z.string(),
+        })
+    ),
+});
+
+const PAYEE_MAP_JSON_SCHEMA = {
+    type: 'object' as const,
+    properties: {
+        mappings: {
+            type: 'array' as const,
+            items: {
+                type: 'object' as const,
+                properties: {
+                    rawPayee: { type: 'string' as const },
+                    cleanedPayee: { type: 'string' as const },
+                },
+                required: ['rawPayee', 'cleanedPayee'],
+            },
+        },
+    },
+    required: ['mappings'],
+};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const mappingsToRecord = (
+    mappings: Array<{ rawPayee: string; cleanedPayee: string }>
+): Record<string, string> =>
+    Object.fromEntries(mappings.map((m) => [m.rawPayee, m.cleanedPayee]));
+
+// ---------------------------------------------------------------------------
+// Backend interface
+// ---------------------------------------------------------------------------
+
+export interface TransformationBackend {
+    /**
+     * Transform payee names. Takes raw payee strings and returns cleaned names.
+     * @throws On API/network errors
+     */
+    transformPayees(
+        prompt: string,
+        payees: string[],
+        temperature: number
+    ): Promise<Record<string, string>>;
+
+    /** Human-readable label for logging (e.g., model name) */
+    getLabel(): string;
+
+    /** Check if error indicates the model is unavailable / doesn't exist */
+    isModelUnavailableError(error: Error): boolean;
+
+    /** Check if error indicates a temperature incompatibility */
+    isTemperatureError(error: Error): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI backend
+// ---------------------------------------------------------------------------
+
+export class OpenAIBackend implements TransformationBackend {
+    private client: OpenAI;
+    private model: string;
+
+    constructor(config: PayeeTransformationConfig, client?: OpenAI) {
+        if (!config.openAiApiKey) {
+            throw new Error(
+                'An OpenAI API key is required for payee transformation with the OpenAI backend. Please set the key in the configuration file.'
+            );
+        }
+        this.client = client ?? new OpenAI({ apiKey: config.openAiApiKey });
+        this.model = config.openAiModel;
+    }
+
+    async transformPayees(
+        prompt: string,
+        payees: string[],
+        temperature: number
+    ): Promise<Record<string, string>> {
+        const completion = await this.client.chat.completions.parse({
+            model: this.model,
+            messages: [
+                { role: 'system', content: prompt },
+                { role: 'user', content: payees.join('\n') },
+            ],
+            response_format: zodResponseFormat(PayeeMapSchema, 'payee_map'),
+            temperature,
+        });
+
+        const parsed = completion.choices[0]?.message?.parsed;
+        if (!parsed) {
+            throw new Error('OpenAI returned no payee transformation result');
+        }
+
+        return mappingsToRecord(parsed.mappings);
+    }
+
+    getLabel(): string {
+        return this.model;
+    }
+
+    isModelUnavailableError(error: Error): boolean {
+        const message = error.message.toLowerCase();
+        return (
+            message.includes('model') &&
+            (message.includes('does not exist') ||
+                message.includes('not found') ||
+                message.includes('invalid model') ||
+                message.includes('unknown model'))
+        );
+    }
+
+    isTemperatureError(error: Error): boolean {
+        return (
+            error.message.includes('temperature') &&
+            error.message.includes('does not support')
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Apple Intelligence backend
+// ---------------------------------------------------------------------------
+
+export class AppleIntelligenceBackend implements TransformationBackend {
+    constructor(_config: PayeeTransformationConfig) {
+        // No API key needed – on-device processing
+    }
+
+    async transformPayees(
+        prompt: string,
+        payees: string[],
+        temperature: number
+    ): Promise<Record<string, string>> {
+        // Dynamic import so tsfm-sdk is only loaded when this backend is used.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let Client: any;
+
+        try {
+            const mod: { default: unknown } = await import('tsfm-sdk/chat');
+            Client = mod.default;
+        } catch (importError) {
+            const cause =
+                importError instanceof Error
+                    ? importError.message
+                    : String(importError);
+            throw new Error(
+                'Apple Intelligence backend requires the `tsfm-sdk` npm package.\n' +
+                    'Run: npm install tsfm-sdk\n' +
+                    `Import error: ${cause}`,
+                { cause: importError }
+            );
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let client: any;
+
+        try {
+            client = new Client();
+        } catch (clientError) {
+            const cause =
+                clientError instanceof Error
+                    ? clientError.message
+                    : String(clientError);
+            throw new Error(
+                'Apple Intelligence backend is unavailable.\n' +
+                    'Requires macOS 26+ (Tahoe) with Apple Silicon and Apple Intelligence enabled in System Settings.\n' +
+                    `Initialization error: ${cause}`,
+                { cause: clientError }
+            );
+        }
+
+        try {
+            const completion = (await client.chat.completions.create({
+                messages: [
+                    { role: 'system', content: prompt },
+                    { role: 'user', content: payees.join('\n') },
+                ],
+                response_format: {
+                    type: 'json_schema' as const,
+                    json_schema: {
+                        name: 'payee_map',
+                        schema: PAYEE_MAP_JSON_SCHEMA,
+                    },
+                },
+                temperature,
+            })) as {
+                choices: Array<{
+                    message?: { content?: string | null };
+                }>;
+            };
+
+            const content = completion.choices[0]?.message?.content;
+            if (!content) {
+                throw new Error(
+                    'Apple Intelligence returned no payee transformation result'
+                );
+            }
+
+            let json: unknown;
+            try {
+                json = JSON.parse(content);
+            } catch {
+                throw new Error(
+                    'Apple Intelligence returned invalid JSON. Raw response: ' +
+                        content.slice(0, 200)
+                );
+            }
+
+            const validationResult = PayeeMapSchema.safeParse(json);
+            if (!validationResult.success) {
+                throw new Error(
+                    'Apple Intelligence returned unexpected response format: ' +
+                        validationResult.error.message
+                );
+            }
+
+            return mappingsToRecord(validationResult.data.mappings);
+        } finally {
+            client?.close();
+        }
+    }
+
+    getLabel(): string {
+        return 'Apple Intelligence (on-device)';
+    }
+
+    isModelUnavailableError(error: Error): boolean {
+        if (error.constructor?.name === 'ModelNotReadyError') {
+            return true;
+        }
+        const message = error.message.toLowerCase();
+        return (
+            (message.includes('apple intelligence') &&
+                (message.includes('not available') ||
+                    message.includes('not ready') ||
+                    message.includes('not enabled'))) ||
+            message.includes('unavailable')
+        );
+    }
+
+    isTemperatureError(_error: Error): boolean {
+        // Apple's on-device model doesn't reject temperature values
+        return false;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export const createTransformationBackend = (
+    config: PayeeTransformationConfig
+): TransformationBackend => {
+    if (config.backend === 'apple-intelligence') {
+        return new AppleIntelligenceBackend(config);
+    }
+
+    return new OpenAIBackend(config);
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -74,6 +74,10 @@ const actualServerSchema = z.object({
 
 const payeeTransformationSchema = z.object({
     enabled: z.boolean(),
+    backend: z
+        .enum(['openai', 'apple-intelligence'])
+        .optional()
+        .default('openai'),
     openAiApiKey: z.string().optional(),
     openAiModel: z.string().optional().default('gpt-5.4-nano'),
     temperature: z.number().min(0).max(2).optional().default(1),
@@ -114,18 +118,22 @@ export const configSchema = z
         actualServers: z.array(actualServerSchema).min(1),
     })
     .check((payload) => {
-        // Check openAI key if payeeTransformation is enabled
+        // Check OpenAI key if payeeTransformation is enabled and using OpenAI backend
         if (
             payload.value.payeeTransformation.enabled &&
-            !payload.value.payeeTransformation.openAiApiKey
+            payload.value.payeeTransformation.backend === 'openai'
         ) {
-            payload.issues.push({
-                code: 'custom',
-                message:
-                    'OpenAI key must not be empty if payeeTransformation is enabled',
-                input: payload.value,
-                continue: true,
-            });
+            const apiKey = payload.value.payeeTransformation.openAiApiKey;
+            if (!apiKey || apiKey.trim().length === 0) {
+                payload.issues.push({
+                    code: 'custom',
+                    path: ['payeeTransformation', 'openAiApiKey'],
+                    message:
+                        'OpenAI key must not be empty if payeeTransformation is enabled with the openai backend',
+                    input: payload.value,
+                    continue: true,
+                });
+            }
         }
 
         if (

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -39,9 +39,14 @@ export const EXAMPLE_CONFIG = `
 # Payee transformation
 [payeeTransformation]
 enabled = false
-openAiApiKey = "<openAiKey>"
+# backend = "openai"  # Optional: "openai" (default) or "apple-intelligence"
+#                     # "apple-intelligence" provides on-device processing
+#                     # via Apple's Foundation Models. Requires macOS 26+ (Tahoe),
+#                     # Apple Silicon, and Apple Intelligence enabled in System Settings.
+#                     # No API key needed; all data stays local.
+openAiApiKey = "<openAiKey>"  # Required only with backend = "openai"
 # openAiModel = "gpt-4o-mini"  # Optional: OpenAI model (default: gpt-5.4-nano)
-# temperature = 1  # Optional: Temperature for OpenAI API (0–2 inclusive, default: 1)
+# temperature = 1  # Optional: Temperature (0–2 inclusive, default: 1)
 # onTransformError = "warn"  # Optional: "warn" (default) or "fail"
 # prompt = "<custom prompt>"  # Optional: Override the default payee transformation instructions
 

--- a/test/unit/config-loading.test.mjs
+++ b/test/unit/config-loading.test.mjs
@@ -170,3 +170,218 @@ test('getConfig rejects when payeeTransformation enabled with empty openAiApiKey
             error.message.includes('OpenAI key must not be empty')
     );
 });
+
+const makeConfigAppleIntelligenceNoKey = () => `
+[payeeTransformation]
+enabled = true
+backend = "apple-intelligence"
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+earliestImportDate = "2026-02-15"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig accepts apple-intelligence backend without openAiApiKey', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigAppleIntelligenceNoKey(), 'utf8');
+
+    const config = await getConfig({ config: configPath });
+
+    assert.equal(config.payeeTransformation.enabled, true);
+    assert.equal(config.payeeTransformation.backend, 'apple-intelligence');
+});
+
+const makeConfigAppleIntelligenceEmptyKey = () => `
+[payeeTransformation]
+enabled = true
+backend = "apple-intelligence"
+openAiApiKey = ""
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+earliestImportDate = "2026-02-15"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig accepts apple-intelligence backend with empty openAiApiKey', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigAppleIntelligenceEmptyKey(), 'utf8');
+
+    const config = await getConfig({ config: configPath });
+
+    assert.equal(config.payeeTransformation.enabled, true);
+    assert.equal(config.payeeTransformation.backend, 'apple-intelligence');
+});
+
+const makeConfigInvalidBackend = () => `
+[payeeTransformation]
+enabled = true
+backend = "invalid-backend"
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+earliestImportDate = "2026-02-15"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig rejects invalid backend value', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigInvalidBackend(), 'utf8');
+
+    await assert.rejects(
+        () => getConfig({ config: configPath }),
+        (error) =>
+            error instanceof Error &&
+            error.message.includes('Invalid configuration file:') &&
+            error.message.includes('backend')
+    );
+});
+
+const makeConfigWhitespaceOpenaiKey = () => `
+[payeeTransformation]
+enabled = true
+backend = "openai"
+openAiApiKey = "   "
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+earliestImportDate = "2026-02-15"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig rejects whitespace-only openAiApiKey with OpenAI backend', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigWhitespaceOpenaiKey(), 'utf8');
+
+    await assert.rejects(
+        () => getConfig({ config: configPath }),
+        (error) =>
+            error instanceof Error &&
+            error.message.includes('OpenAI key must not be empty')
+    );
+});

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import PayeeTransformer from '../../dist/utils/PayeeTransformer.js';
+import {
+    OpenAIBackend,
+    PayeeMapSchema,
+} from '../../dist/utils/TransformationBackend.js';
+import { zodResponseFormat } from 'openai/helpers/zod';
 
 const makeLogger = () => ({
     debugMessages: [],
@@ -13,35 +18,35 @@ const makeLogger = () => ({
     },
 });
 
-const makeOpenAIStub = ({ parsed, error, onCreate } = {}) => ({
-    chat: {
-        completions: {
-            parse: async (options) => {
-                onCreate?.(options);
+const makeBackendStub = ({ mappings, error, onCreate } = {}) => ({
+    transformPayees: async (_prompt, _payees, _temperature) => {
+        onCreate?.(_prompt, _payees, _temperature);
 
-                if (error) {
-                    throw error;
-                }
+        if (error) {
+            throw error;
+        }
 
-                return {
-                    choices: [
-                        {
-                            message: {
-                                parsed:
-                                    parsed !== undefined
-                                        ? parsed
-                                        : { mappings: [] },
-                            },
-                        },
-                    ],
-                };
-            },
-        },
+        const resolved =
+            mappings !== undefined
+                ? Object.fromEntries(
+                      mappings.map((m) => [m.rawPayee, m.cleanedPayee])
+                  )
+                : {};
+        return resolved;
     },
+    getLabel: () => 'test-model',
+    isModelUnavailableError: (error) =>
+        error.message.toLowerCase().includes('model') &&
+        (error.message.toLowerCase().includes('does not exist') ||
+            error.message.toLowerCase().includes('not found')),
+    isTemperatureError: (error) =>
+        error.message.includes('temperature') &&
+        error.message.includes('does not support'),
 });
 
 const makeConfig = () => ({
     enabled: true,
+    backend: 'openai',
     openAiApiKey: 'test-key',
     openAiModel: 'gpt-5-nano',
     temperature: 1,
@@ -54,7 +59,7 @@ test('transformPayees returns an empty object for no payees', async () => {
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
+        makeBackendStub({
             onCreate: () => {
                 createCalls++;
             },
@@ -67,13 +72,13 @@ test('transformPayees returns an empty object for no payees', async () => {
     assert.equal(createCalls, 0);
 });
 
-test('transformPayees skips OpenAI for local existing-payee matches', async () => {
+test('transformPayees skips AI for local existing-payee matches', async () => {
     const logger = makeLogger();
     let createCalls = 0;
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
+        makeBackendStub({
             onCreate: () => {
                 createCalls++;
             },
@@ -93,24 +98,26 @@ test('transformPayees skips OpenAI for local existing-payee matches', async () =
 
 test('transformPayees bounds the relevant existing-payee shortlist', async () => {
     const logger = makeLogger();
-    let capturedOptions;
+    let capturedPrompt;
+    let capturedPayees;
+    let capturedTemperature;
     const existingPayees = Array.from({ length: 150 }, (_, index) => {
         return `Alpha Market ${String(index + 1).padStart(3, '0')}`;
     });
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
-            parsed: {
-                mappings: [
-                    {
-                        rawPayee: 'Alpha Hyperstore',
-                        cleanedPayee: 'Alpha Market 001',
-                    },
-                ],
-            },
-            onCreate: (options) => {
-                capturedOptions = options;
+        makeBackendStub({
+            mappings: [
+                {
+                    rawPayee: 'Alpha Hyperstore',
+                    cleanedPayee: 'Alpha Market 001',
+                },
+            ],
+            onCreate: (prompt, payees, temperature) => {
+                capturedPrompt = prompt;
+                capturedPayees = payees;
+                capturedTemperature = temperature;
             },
         })
     );
@@ -120,15 +127,14 @@ test('transformPayees bounds the relevant existing-payee shortlist', async () =>
         existingPayees
     );
 
-    assert.equal(capturedOptions.model, 'gpt-5-nano');
-    assert.equal(capturedOptions.temperature, 1);
-    assert.equal(capturedOptions.messages[1].content, 'Alpha Hyperstore');
+    assert.equal(capturedTemperature, 1);
+    assert.deepEqual(capturedPayees, ['Alpha Hyperstore']);
     assert.match(
-        capturedOptions.messages[0].content,
+        capturedPrompt,
         /Showing 100 relevant existing payees out of 150\./
     );
     assert.equal(
-        capturedOptions.messages[0].content
+        capturedPrompt
             .split('\n')
             .filter((line) => line.trim().startsWith('Alpha Market ')).length,
         100
@@ -140,21 +146,19 @@ test('transformPayees bounds the relevant existing-payee shortlist', async () =>
 
 test('transformPayees snaps transformed payees back to existing names', async () => {
     const logger = makeLogger();
-    let capturedOptions;
+    let capturedPayees;
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
-            parsed: {
-                mappings: [
-                    {
-                        rawPayee: 'AMZN Mktp US*1234567890',
-                        cleanedPayee: 'Amazon.com',
-                    },
-                ],
-            },
-            onCreate: (options) => {
-                capturedOptions = options;
+        makeBackendStub({
+            mappings: [
+                {
+                    rawPayee: 'AMZN Mktp US*1234567890',
+                    cleanedPayee: 'Amazon.com',
+                },
+            ],
+            onCreate: (_prompt, payees) => {
+                capturedPayees = payees;
             },
         })
     );
@@ -164,10 +168,7 @@ test('transformPayees snaps transformed payees back to existing names', async ()
         ['Amazon']
     );
 
-    assert.equal(
-        capturedOptions.messages[1].content,
-        'AMZN Mktp US*1234567890'
-    );
+    assert.deepEqual(capturedPayees, ['AMZN Mktp US*1234567890']);
     assert.deepEqual(result, {
         'AMZN Mktp US*1234567890': 'Amazon',
     });
@@ -178,7 +179,7 @@ test('transformPayees returns null on API errors', async () => {
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
+        makeBackendStub({
             error: new Error('Connection refused'),
         })
     );
@@ -193,12 +194,12 @@ test('transformPayees returns null on API errors', async () => {
     );
 });
 
-test('transformPayees returns null when OpenAI fails', async () => {
+test('transformPayees returns null when model is unavailable', async () => {
     const logger = makeLogger();
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
+        makeBackendStub({
             error: new Error('The model does not exist'),
         })
     );
@@ -207,28 +208,125 @@ test('transformPayees returns null when OpenAI fails', async () => {
 
     assert.equal(result, null);
     assert.equal(logger.errorMessages.length, 1);
-    assert.match(
-        logger.errorMessages[0],
-        /OpenAI model 'gpt-5-nano' is unavailable/
-    );
+    assert.match(logger.errorMessages[0], /Model 'test-model' is unavailable/);
 });
 
-test('transformPayees returns null when OpenAI returns null parsed content', async () => {
+test('transformPayees returns raw payee names when backend returns no mappings', async () => {
     const logger = makeLogger();
     const transformer = new PayeeTransformer(
         makeConfig(),
         logger,
-        makeOpenAIStub({
-            parsed: null,
+        makeBackendStub({
+            mappings: undefined,
         })
     );
 
     const result = await transformer.transformPayees(['Coffee Shop'], []);
 
-    assert.equal(result, null);
-    assert.equal(logger.errorMessages.length, 1);
-    assert.match(
-        logger.errorMessages[0],
-        /OpenAI returned no payee transformation result/
+    assert.deepEqual(result, { 'Coffee Shop': 'Coffee Shop' });
+    assert.equal(logger.errorMessages.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// OpenAIBackend unit tests
+// ---------------------------------------------------------------------------
+
+test('OpenAIBackend constructs API call correctly', async () => {
+    const capturedOptions = [];
+    const stubClient = {
+        chat: {
+            completions: {
+                parse: async (options) => {
+                    capturedOptions.push(options);
+                    return {
+                        choices: [{ message: { parsed: { mappings: [] } } }],
+                    };
+                },
+            },
+        },
+    };
+
+    const config = makeConfig();
+    const backend = new OpenAIBackend(config, stubClient);
+
+    const prompt = 'Clean up these payee names';
+    const payees = ['Netflix.com', 'AMZN Mktp'];
+    const temperature = 0.7;
+
+    await backend.transformPayees(prompt, payees, temperature);
+
+    assert.equal(capturedOptions.length, 1);
+    const opts = capturedOptions[0];
+    assert.equal(opts.model, 'gpt-5-nano');
+    assert.deepEqual(opts.messages, [
+        { role: 'system', content: prompt },
+        { role: 'user', content: 'Netflix.com\nAMZN Mktp' },
+    ]);
+    assert.deepEqual(
+        opts.response_format,
+        zodResponseFormat(PayeeMapSchema, 'payee_map')
+    );
+    assert.equal(opts.temperature, 0.7);
+});
+
+test('OpenAIBackend returns mapped record from parsed response', async () => {
+    const stubClient = {
+        chat: {
+            completions: {
+                parse: async () => ({
+                    choices: [
+                        {
+                            message: {
+                                parsed: {
+                                    mappings: [
+                                        {
+                                            rawPayee: 'Netflix.com',
+                                            cleanedPayee: 'Netflix',
+                                        },
+                                        {
+                                            rawPayee: 'AMZN Mktp',
+                                            cleanedPayee: 'Amazon',
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                }),
+            },
+        },
+    };
+
+    const config = makeConfig();
+    const backend = new OpenAIBackend(config, stubClient);
+    const result = await backend.transformPayees(
+        'prompt',
+        ['Netflix.com', 'AMZN Mktp'],
+        0.5
+    );
+
+    assert.deepEqual(result, {
+        'Netflix.com': 'Netflix',
+        'AMZN Mktp': 'Amazon',
+    });
+});
+
+test('OpenAIBackend throws when parsed content is null', async () => {
+    const stubClient = {
+        chat: {
+            completions: {
+                parse: async () => ({
+                    choices: [{ message: { parsed: null } }],
+                }),
+            },
+        },
+    };
+
+    const config = makeConfig();
+    const backend = new OpenAIBackend(config, stubClient);
+
+    await assert.rejects(
+        () => backend.transformPayees('prompt', ['Netflix.com'], 0.5),
+        { message: 'OpenAI returned no payee transformation result' }
     );
 });


### PR DESCRIPTION
## Summary

Adds Apple Intelligence as an alternative AI backend for payee transformation, running entirely on-device (macOS 26+, Apple Silicon required).

## Changes

- **New `src/utils/TransformationBackend.ts`**: Abstract `TransformationBackend` interface with two implementations:
  - `OpenAIBackend` (existing behavior, default) — extracted from `PayeeTransformer`, uses OpenAI `chat.completions.parse()` + `zodResponseFormat`
  - `AppleIntelligenceBackend` — uses `tsfm-sdk` to access Apple's on-device ~3B LLM via `response_format: { type: 'json_schema' }`
- **`src/utils/PayeeTransformer.ts`**: Refactored to depend on `TransformationBackend` instead of `OpenAI` directly
- **`src/utils/config.ts`**: New `backend` field (`'openai' | 'apple-intelligence'`, defaults to `'openai'`). API key validation now gated on `backend === 'openai'`
- **`src/utils/shared.ts`**: Example config updated with `backend` field and Apple Intelligence requirements
- **`package.json`**: `tsfm-sdk` added as optional dependency
- **Tests**: 3 new `OpenAIBackend` unit tests, 4 new config validation tests (Apple backend keyless, invalid backend, whitespace-only key)

## Config

```toml
[payeeTransformation]
enabled = true
backend = apple-intelligence  # on-device, macOS 26+, no API key needed
temperature = 0
```

## Verification

- 215/215 tests pass, ESLint + Prettier clean, `tsc` builds clean
- No breaking changes — `backend` defaults to `'openai'`