### PR TITLE
ci: migrate workflows from ubuntu-latest to macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         name: test (node ${{ matrix.node-version }})
         permissions:
             contents: read
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         strategy:
             matrix:
                 node-version: ['22.x', '24.x', '26.x']
@@ -29,7 +29,7 @@ jobs:
     commitlint:
         permissions:
             contents: read
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     analyze:
         name: Analyze
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         permissions:
             actions: read
             contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
             issues: write
             pull-requests: write
             id-token: write
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Switches CI/CD workflows from Ubuntu to macOS runners. Required for the upcoming Apple Intelligence backend which depends on `tsfm-sdk` (darwin/arm64-only).

## Changes

- `.github/workflows/ci.yml`: `ubuntu-latest` → `macos-latest` (test matrix + commitlint)
- `.github/workflows/release.yml`: `ubuntu-latest` → `macos-latest`
- `.github/workflows/codeql.yml`: `ubuntu-latest` → `macos-latest`

## Compatibility

- All GitHub Actions (`actions/checkout@v6`, `actions/setup-node@v6`, `github/codeql-action@v4`) support macOS runners
- `tsfm-sdk` natively targets `darwin/arm64` — no cross-compilation or emulation needed