### PR TITLE
feat: support ${ENV_VAR} interpolation in config file values

### DIFF
--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -6,7 +6,9 @@ enabled = false
 #                     # via Apple's Foundation Models. Requires macOS 26+ (Tahoe),
 #                     # Apple Silicon, and Apple Intelligence enabled in System Settings.
 #                     # No API key needed; all data stays local.
-openAiApiKey = "<openAiKey>"  # Required only with backend = "openai"
+# openAiApiKey = "${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
+#                                    # Use an env var (${MMI_OPENAI_KEY})
+#                                    # or a literal key string
 # openAiModel = "gpt-4o-mini"  # Optional: OpenAI model (default: gpt-5.4-nano)
 # temperature = 0  # Optional: Temperature (0–2 inclusive, default: 0)
 # onTransformError = "warn"  # Optional: "warn" (default) or "fail"

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -1,6 +1,9 @@
-import toml from 'toml';
 import { ArgumentsCamelCase, CommandModule } from 'yargs';
-import { getConfigFile, parseConfigData } from '../utils/config.js';
+import {
+    EnvVarResolutionError,
+    getConfigFile,
+    parseConfigContent,
+} from '../utils/config.js';
 import { CommonArgs } from '../utils/cliArgs.js';
 import fs from 'fs/promises';
 import path from 'path';
@@ -40,12 +43,11 @@ const handleValidate = async (argv: ArgumentsCamelCase<CommonArgs>) => {
             const configContent = await fs.readFile(configPath, 'utf-8');
 
             logger.debug(`Parsing configuration file...`);
-            const configData = toml.parse(configContent);
-
-            logger.debug(`Parsing configuration schema...`);
-            parseConfigData(configData);
+            parseConfigContent(configContent);
         } catch (e) {
-            if (e instanceof ZodError) {
+            if (e instanceof EnvVarResolutionError) {
+                logger.error(e.message);
+            } else if (e instanceof ZodError) {
                 logger.error('Configuration file is invalid:');
                 for (const error of e.issues) {
                     logger.error(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,6 +6,41 @@ import { CommonArgs } from './cliArgs.js';
 import { z, ZodError } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
 
+const ENV_VAR_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+/**
+ * Recursively walk a parsed config object and replace `${ENV_VAR}` patterns
+ * in any string value with the corresponding environment variable.
+ *
+ * Throws if a referenced environment variable is not set.
+ */
+export const resolveEnvVars = (obj: unknown): unknown => {
+    if (typeof obj === 'string') {
+        return obj.replace(ENV_VAR_PATTERN, (_match, varName) => {
+            const value = process.env[varName as string];
+            if (value === undefined) {
+                throw new Error(
+                    `Environment variable '${varName}' referenced in config but not set`
+                );
+            }
+            return value;
+        });
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(resolveEnvVars);
+    }
+    if (obj !== null && typeof obj === 'object') {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(
+            obj as Record<string, unknown>
+        )) {
+            result[key] = resolveEnvVars(value);
+        }
+        return result;
+    }
+    return obj;
+};
+
 const isValidCalendarDate = (dateString: string) => {
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -256,7 +291,7 @@ export const getConfig = async (argv: ArgumentsCamelCase<CommonArgs>) => {
     const configContent = await fs.readFile(configFile, 'utf-8');
 
     try {
-        const configData = toml.parse(configContent);
+        const configData = resolveEnvVars(toml.parse(configContent));
         return parseConfigData(configData);
     } catch (e) {
         if (e instanceof Error && e.name === 'SyntaxError') {
@@ -267,6 +302,12 @@ export const getConfig = async (argv: ArgumentsCamelCase<CommonArgs>) => {
                 `Failed to parse configuration file: ${e.message} (line ${line}, column ${column})`,
                 { cause: e }
             );
+        }
+
+        // Let environment variable resolution errors pass through with
+        // their original message.
+        if (e instanceof Error && e.message.includes('Environment variable')) {
+            throw e;
         }
 
         if (e instanceof ZodError) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,25 +6,44 @@ import { CommonArgs } from './cliArgs.js';
 import { z, ZodError } from 'zod';
 import { DEFAULT_CONFIG_FILE } from './shared.js';
 
-const ENV_VAR_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+const WHOLE_VALUE_ENV_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
 
 /**
- * Recursively walk a parsed config object and replace `${ENV_VAR}` patterns
- * in any string value with the corresponding environment variable.
+ * Error thrown when an environment variable referenced in the config is
+ * not set. Distinct from other config errors so callers can surface the
+ * specific variable name.
+ */
+export class EnvVarResolutionError extends Error {
+    constructor(varName: string) {
+        super(
+            `Environment variable '${varName}' referenced in config but not set`
+        );
+        this.name = 'EnvVarResolutionError';
+    }
+}
+
+/**
+ * Recursively walk a parsed config object. When a string value is exactly
+ * `\${ENV_VAR}`, replace it with the corresponding environment variable.
  *
- * Throws if a referenced environment variable is not set.
+ * Strings that contain `\${...}` as partial content are left unchanged;
+ * only whole-value references are resolved.
+ *
+ * Throws {@link EnvVarResolutionError} if a referenced environment
+ * variable is not set.
  */
 export const resolveEnvVars = (obj: unknown): unknown => {
     if (typeof obj === 'string') {
-        return obj.replace(ENV_VAR_PATTERN, (_match, varName) => {
-            const value = process.env[varName as string];
+        const match = obj.match(WHOLE_VALUE_ENV_PATTERN);
+        if (match) {
+            const varName = match[1] as string;
+            const value = process.env[varName];
             if (value === undefined) {
-                throw new Error(
-                    `Environment variable '${varName}' referenced in config but not set`
-                );
+                throw new EnvVarResolutionError(varName);
             }
             return value;
-        });
+        }
+        return obj;
     }
     if (Array.isArray(obj)) {
         return obj.map(resolveEnvVars);
@@ -265,6 +284,22 @@ export const parseConfigData = (configData: unknown): Config => {
     return config;
 };
 
+/**
+ * Parse a TOML config string into a validated {@link Config}, including
+ * environment variable resolution.
+ *
+ * This is the canonical parsing pipeline used by both `getConfig` and
+ * the `validate` command. It performs:
+ *
+ * 1. TOML parsing
+ * 2. Environment variable interpolation ({@link resolveEnvVars})
+ * 3. Zod schema validation + cleartext server warnings
+ */
+export const parseConfigContent = (configContent: string): Config => {
+    const configData = resolveEnvVars(toml.parse(configContent));
+    return parseConfigData(configData);
+};
+
 export const getConfigFile = (argv: ArgumentsCamelCase<CommonArgs>) => {
     if (argv.config) {
         const argvConfigFile = path.resolve(argv.config);
@@ -291,8 +326,7 @@ export const getConfig = async (argv: ArgumentsCamelCase<CommonArgs>) => {
     const configContent = await fs.readFile(configFile, 'utf-8');
 
     try {
-        const configData = resolveEnvVars(toml.parse(configContent));
-        return parseConfigData(configData);
+        return parseConfigContent(configContent);
     } catch (e) {
         if (e instanceof Error && e.name === 'SyntaxError') {
             const line = 'line' in e ? e.line : -1;
@@ -306,7 +340,7 @@ export const getConfig = async (argv: ArgumentsCamelCase<CommonArgs>) => {
 
         // Let environment variable resolution errors pass through with
         // their original message.
-        if (e instanceof Error && e.message.includes('Environment variable')) {
+        if (e instanceof EnvVarResolutionError) {
             throw e;
         }
 

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -44,7 +44,9 @@ enabled = false
 #                     # via Apple's Foundation Models. Requires macOS 26+ (Tahoe),
 #                     # Apple Silicon, and Apple Intelligence enabled in System Settings.
 #                     # No API key needed; all data stays local.
-openAiApiKey = "<openAiKey>"  # Required only with backend = "openai"
+# openAiApiKey = "\${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
+#                                    # Use an env var (\${MMI_OPENAI_KEY})
+#                                    # or a literal key string
 # openAiModel = "gpt-4o-mini"  # Optional: OpenAI model (default: gpt-5.4-nano)
 # temperature = 0  # Optional: Temperature (0–2 inclusive, default: 0)
 # onTransformError = "warn"  # Optional: "warn" (default) or "fail"

--- a/test/unit/config-loading.test.mjs
+++ b/test/unit/config-loading.test.mjs
@@ -276,6 +276,167 @@ test('getConfig accepts apple-intelligence backend with empty openAiApiKey', asy
     assert.equal(config.payeeTransformation.backend, 'apple-intelligence');
 });
 
+// ---------------------------------------------------------------------------
+// Environment variable interpolation
+// ---------------------------------------------------------------------------
+
+const makeConfigWithEnvVar = () => `
+[payeeTransformation]
+enabled = true
+backend = "openai"
+openAiApiKey = "\${MMI_OPENAI_KEY}"
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig resolves env var in openAiApiKey', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigWithEnvVar(), 'utf8');
+
+    const originalEnv = process.env.MMI_OPENAI_KEY;
+    process.env.MMI_OPENAI_KEY = 'sk-test-key-12345';
+    try {
+        const config = await getConfig({ config: configPath });
+        assert.equal(
+            config.payeeTransformation.openAiApiKey,
+            'sk-test-key-12345'
+        );
+    } finally {
+        if (originalEnv === undefined) {
+            delete process.env.MMI_OPENAI_KEY;
+        } else {
+            process.env.MMI_OPENAI_KEY = originalEnv;
+        }
+    }
+});
+
+test('getConfig rejects when env var is not set', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigWithEnvVar(), 'utf8');
+
+    const originalEnv = process.env.MMI_OPENAI_KEY;
+    delete process.env.MMI_OPENAI_KEY;
+
+    try {
+        await assert.rejects(
+            () => getConfig({ config: configPath }),
+            (error) =>
+                error instanceof Error &&
+                error.message.includes(
+                    "Environment variable 'MMI_OPENAI_KEY' referenced in config but not set"
+                )
+        );
+    } finally {
+        if (originalEnv !== undefined) {
+            process.env.MMI_OPENAI_KEY = originalEnv;
+        }
+    }
+});
+
+const makeConfigWithPartialEnvVar = () => `
+[payeeTransformation]
+enabled = true
+backend = "openai"
+openAiApiKey = "Bearer \${MMI_OPENAI_KEY}"
+
+[import]
+importUncheckedTransactions = true
+synchronizeClearedStatus = true
+synchronizeCategories = false
+categorySyncOnExisting = "ask"
+importComments = false
+commentPrefix = "MoneyMoney Comment: "
+
+[import.transfers]
+enabled = false
+categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
+matchWindowDays = 0
+
+[[actualServers]]
+serverUrl = "http://example.com:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-id"
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+password = ""
+
+[actualServers.budgets.accountMapping]
+"Account" = "actual-account"
+`;
+
+test('getConfig resolves env var within a longer string', async (t) => {
+    const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), 'actual-mmi-config-load-')
+    );
+    const configPath = path.join(tempRoot, 'config.toml');
+
+    t.after(async () => {
+        await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    await writeFile(configPath, makeConfigWithPartialEnvVar(), 'utf8');
+
+    const originalEnv = process.env.MMI_OPENAI_KEY;
+    process.env.MMI_OPENAI_KEY = 'sk-key-embedded';
+    try {
+        const config = await getConfig({ config: configPath });
+        assert.equal(
+            config.payeeTransformation.openAiApiKey,
+            'Bearer sk-key-embedded'
+        );
+    } finally {
+        if (originalEnv === undefined) {
+            delete process.env.MMI_OPENAI_KEY;
+        } else {
+            process.env.MMI_OPENAI_KEY = originalEnv;
+        }
+    }
+});
+
 const makeConfigInvalidBackend = () => `
 [payeeTransformation]
 enabled = true

--- a/test/unit/config-loading.test.mjs
+++ b/test/unit/config-loading.test.mjs
@@ -374,69 +374,6 @@ test('getConfig rejects when env var is not set', async (t) => {
     }
 });
 
-const makeConfigWithPartialEnvVar = () => `
-[payeeTransformation]
-enabled = true
-backend = "openai"
-openAiApiKey = "Bearer \${MMI_OPENAI_KEY}"
-
-[import]
-importUncheckedTransactions = true
-synchronizeClearedStatus = true
-synchronizeCategories = false
-categorySyncOnExisting = "ask"
-importComments = false
-commentPrefix = "MoneyMoney Comment: "
-
-[import.transfers]
-enabled = false
-categoryRefs = ["Umbuchungen > Echte Umbuchungen"]
-matchWindowDays = 0
-
-[[actualServers]]
-serverUrl = "http://example.com:5006"
-serverPassword = "pw"
-
-[[actualServers.budgets]]
-syncId = "budget-id"
-
-[actualServers.budgets.e2eEncryption]
-enabled = false
-password = ""
-
-[actualServers.budgets.accountMapping]
-"Account" = "actual-account"
-`;
-
-test('getConfig resolves env var within a longer string', async (t) => {
-    const tempRoot = await mkdtemp(
-        path.join(os.tmpdir(), 'actual-mmi-config-load-')
-    );
-    const configPath = path.join(tempRoot, 'config.toml');
-
-    t.after(async () => {
-        await rm(tempRoot, { recursive: true, force: true });
-    });
-
-    await writeFile(configPath, makeConfigWithPartialEnvVar(), 'utf8');
-
-    const originalEnv = process.env.MMI_OPENAI_KEY;
-    process.env.MMI_OPENAI_KEY = 'sk-key-embedded';
-    try {
-        const config = await getConfig({ config: configPath });
-        assert.equal(
-            config.payeeTransformation.openAiApiKey,
-            'Bearer sk-key-embedded'
-        );
-    } finally {
-        if (originalEnv === undefined) {
-            delete process.env.MMI_OPENAI_KEY;
-        } else {
-            process.env.MMI_OPENAI_KEY = originalEnv;
-        }
-    }
-});
-
 const makeConfigInvalidBackend = () => `
 [payeeTransformation]
 enabled = true


### PR DESCRIPTION
## Summary

Adds `${ENV_VAR}` interpolation to config file values, so sensitive keys don't need to be stored in plain text in `config.toml`.

## Changes

- **`src/utils/config.ts`**: `resolveEnvVars()` recursively walks the parsed config and replaces any `${VAR_NAME}` pattern in string values with the corresponding environment variable. Throws a clear error if the env var isn't set. Integrated into `getConfig()` between TOML parsing and Zod validation.
- **`src/utils/shared.ts`** + **`assets/config.example.toml`**: Updated example config to document env var usage: `openAiApiKey = "${MMI_OPENAI_KEY}"`
- **`test/unit/config-loading.test.mjs`**: 3 new tests covering env var resolution, missing env var error, and partial interpolation within longer strings.

## Usage

```toml
[payeeTransformation]
enabled = true
openAiApiKey = "${MMI_OPENAI_KEY}"
```

Set `export MMI_OPENAI_KEY=sk-...` before running.

## Testing

```
npm run test:unit  # 209 pass, 0 fail
npm run lint:eslint && npm run lint:prettier  # clean
```

## Release impact

`feat:` → minor release.