### PR TITLE
fix: skip interactive category prompts in --dry-run mode

### DIFF
--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -79,6 +79,7 @@ const handleCommand = async (argv: ArgumentsCamelCase<ImportArgs>) => {
     if (
         config.import.synchronizeCategories &&
         categorySyncOnExisting === 'ask' &&
+        !isDryRun &&
         !process.stdin.isTTY
     ) {
         throw new Error(

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -360,8 +360,15 @@ class Importer {
         isDryRun?: boolean;
         categorySyncOnExisting?: ExistingCategorySyncPolicy;
     }) {
-        const existingCategoryPolicy =
+        let existingCategoryPolicy =
             categorySyncOnExisting ?? this.config.import.categorySyncOnExisting;
+
+        // In dry-run mode, interactive 'ask' policy makes no sense — nothing
+        // will be written. Treat it as 'new' to skip interactive prompts
+        // while still reporting category conflicts in the summary.
+        if (isDryRun && existingCategoryPolicy === 'ask') {
+            existingCategoryPolicy = 'new';
+        }
 
         const fromDate = from ?? subMonths(new Date(), 1);
         const earliestImportDate = this.budgetConfig.earliestImportDate


### PR DESCRIPTION
## Problem

Running `actual-mmi import --dry-run` was not dry on category mismatches — it still prompted the user with interactive "Category conflict" questions, even though no changes would be written.

## Root Cause

The `--dry-run` flag only takes effect *after* `planExistingCategoryUpdates()` returns, in `applyOrPreviewCategoryUpdates()`. The planning method had no awareness of `isDryRun`, so when `existingCategoryPolicy` was `'ask'`, every conflict fell through to the interactive readline prompt — decisions that would be immediately discarded since nothing gets written in dry-run.

Additionally, the TTY guard in `import.command.ts` would throw an error for non-TTY dry-run with `'ask'` policy, even though interactive prompts don't make sense in dry-run mode.

## Fix

Two changes, both minimal:

1. **`src/utils/Importer.ts`**: When `isDryRun` is true and `existingCategoryPolicy` is `'ask'`, treat it as `'new'` (skip conflicts, keep existing categories). Conflicts are still counted and reported in the summary.
2. **`src/commands/import.command.ts`**: Skip the TTY guard when `isDryRun` is true (no interactive prompts will fire).

## Verification

- `npm run build` — compiles cleanly
- `npm run test` — 225/226 pass (one pre-existing config example staleness failure, unrelated)
- `npm run test:cli` — 18/18 pass