### PR TITLE
feat: redesign category mapping UX with readable refs and explicit ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,13 @@ Once configured, run `actual-mmi validate` to verify the format.
 
 ### Import settings
 
-| Option                        | Default                  | Description                                                 |
-| ----------------------------- | ------------------------ | ----------------------------------------------------------- |
-| `importUncheckedTransactions` | `true`                   | Import transactions not yet checked in MoneyMoney           |
-| `synchronizeClearedStatus`    | `true`                   | Sync MoneyMoney's cleared status to Actual                  |
-| `synchronizeCategories`       | `false`                  | Enable [category sync](#category-sync)                      |
-| `categorySyncOnExisting`      | `ask`                    | Policy for existing transactions: `ask`, `new`, or `always` |
-| `importComments`              | `false`                  | Import MoneyMoney comments into Actual notes                |
-| `commentPrefix`               | `"MoneyMoney Comment: "` | Prefix added to imported comments                           |
+| Option                        | Default                  | Description                                                                                             |
+| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `importUncheckedTransactions` | `true`                   | Import transactions not yet checked in MoneyMoney                                                       |
+| `synchronizeClearedStatus`    | `true`                   | Sync MoneyMoney's cleared status to Actual                                                              |
+| `categorySync`                | none                     | Category sync policy: `"off"` (don't apply), `"new"` (new imports only), `"all"` (also update existing) |
+| `importComments`              | `false`                  | Import MoneyMoney comments into Actual notes                                                            |
+| `commentPrefix`               | `"MoneyMoney Comment: "` | Prefix added to imported comments                                                                       |
 
 ### Comment import
 
@@ -197,29 +196,54 @@ actual-mmi import --dry-run -l 3
 
 ### Category sync
 
-Category sync maps MoneyMoney categories to Actual categories during import. Enable it with `synchronizeCategories = true` in your config.
+Category sync maps MoneyMoney categories to Actual categories during import. Enable it by setting `categorySync = "new"` or `categorySync = "all"` in your `[import]` section.
 
-#### Policies for existing transactions
+#### Policies
 
-When `synchronizeCategories = true`, the `categorySyncOnExisting` option controls how conflicts are handled for transactions that already exist in Actual:
-
-- **`ask`** (default): Prompt interactively for each conflict. Requires a TTY; use `-C=new` or `-C=always` in non-interactive environments. Prompt choices: `y`/`yes` to update, `n`/`no` to keep, `A`/`all` to update all remaining, `N`/`none` to keep all remaining, and `q`/`quit` to abort.
-- **`new`**: Only apply categories to newly imported transactions; leave existing transactions unchanged.
-- **`always`**: Always apply the mapped category, overwriting any existing category in Actual.
-
-Override at runtime with `--category-sync-on-existing` or `-C`:
-
-```bash
-actual-mmi import -C=new      # Only new transactions
-actual-mmi import -C=always   # Overwrite existing categories
-```
+- **`"off"`**: Don't apply category mappings (default when no `categorySync` is set).
+- **`"new"`**: Apply categories to newly imported transactions only; leave existing transactions unchanged.
+- **`"all"`**: Apply the mapped category to both new and existing transactions. Existing transactions with a different category will be overwritten.
 
 #### How it works
 
 1. **New transactions**: Categories are assigned based on your `[actualServers.budgets.categoryMapping]`
 2. **Existing transactions (backfill)**: Uncategorised transactions in Actual get the mapped category applied
-3. **Conflicts**: When an existing transaction has a different category, the `categorySyncOnExisting` policy applies
+3. **Conflicts**: When an existing transaction has a different category, the policy determines whether to overwrite
 4. **Auto-rule override detection**: After import, the importer re-fetches new transactions and warns if Actual's auto-rules changed a synced category
+
+#### Category mapping config
+
+The mapping uses human-readable `path:` refs by default. Each key is a MoneyMoney category path, each value an Actual category path:
+
+```toml
+[actualServers.budgets.categoryMapping]
+# Tool-managed block: running actual-mmi categories map --write-config rewrites this section.
+# Keys use "path:" refs by default. Fall back to "uuid:" or "id:" for ambiguous categories.
+# MoneyMoney: Ausgaben > Lebenshaltung > Lebensmittel
+# Actual: Lebenshaltung > 💳🧀 Lebensmittel
+"path:Ausgaben > Lebenshaltung > Lebensmittel" = "path:Lebenshaltung > 💳🧀 Lebensmittel"
+```
+
+For categories with duplicate names, use `uuid:` (MoneyMoney) or `id:` (Actual) as escape hatches:
+
+```toml
+"uuid:1d3f24ce-b007-4d64-98a2-6869cfae075a" = "id:82852131-7413-4517-8bd7-3df8da60b8d1"
+```
+
+#### Intentionally ignored categories
+
+To exclude specific MoneyMoney categories from the "unresolved" count (e.g., transfer categories), list them under the budget:
+
+```toml
+[[actualServers.budgets]]
+syncId = "<syncId>"
+# Place ignoredMoneyMoneyCategoryRefs BEFORE any [actualServers.budgets.*] sub-table
+ignoredMoneyMoneyCategoryRefs = ["path:Umbuchungen > Echte Umbuchungen"]
+
+[actualServers.budgets.e2eEncryption]
+```
+
+Ignored categories are excluded from the unresolved count, suggestions, and `--write-config` output. They appear in a separate "Intentionally Ignored" section in the mapping report.
 
 #### Category mapping CLI
 
@@ -236,21 +260,16 @@ actual-mmi categories map -s http://localhost:5006 -b <syncId> --format toml
 
 The audit report includes:
 
+- **Status Bar**: One-line summary (mapped, suggestions, invalid, unresolved, ignored)
 - **Configured Mappings**: Current mappings from your config
 - **Safe Suggestions**: High-confidence matches (identical category names)
-- **Invalid**: Mappings pointing to non-existent Actual categories
+- **Invalid**: Mappings pointing to non-existent categories
 - **Unresolved**: MoneyMoney categories without a mapping
+- **Intentionally Ignored**: Categories excluded from mapping by `ignoredMoneyMoneyCategoryRefs`
 - **Unused**: Mapped Actual categories not found in the budget
-- **Next Actions**: Recommended steps to complete your mapping
+- **Next Actions**: Context-aware recommendations based on current state
 
-With `--write-config`, the tool rewrites your `[actualServers.budgets.categoryMapping]` block with annotated comments for readability:
-
-```toml
-[actualServers.budgets.categoryMapping]
-# MoneyMoney: Ausgaben > Lebenshaltung > Lebensmittel
-# Actual: Lebenshaltung > 💳🧀 Lebensmittel
-"7f5c..." = "8aa1..."
-```
+With `--write-config`, the tool rewrites your `[actualServers.budgets.categoryMapping]` block with annotated comments for readability.
 
 ### Payee transformation
 
@@ -345,7 +364,6 @@ The configuration file (default: `~/.actually/config.toml`) may contain Actual p
 | `E2E encryption password is required`                                                          | If your Actual budget uses end-to-end encryption, set `enabled = true` and provide the `password` in `[actualServers.budgets.e2eEncryption]`.                               |
 | OpenAI model error (the default model is unavailable for your account)                         | The default model is `gpt-5.4-nano`. Set `payeeTransformation.openAiModel` to a model available on your OpenAI account (e.g. `gpt-4o-mini`).                                |
 | `Apple Intelligence backend is unavailable`                                                    | Requires macOS 26+ (Tahoe), Apple Silicon (M1 or later), and Apple Intelligence enabled in System Settings. Also ensure `tsfm-sdk` is installed.                            |
-| `Category sync policy 'ask' requires an interactive terminal`                                  | Use `-C=new` or `-C=always` when running in a non-interactive environment (CI, cron, launchd).                                                                              |
 | Auto-rule override warning: "Actual's rules changed the category of transaction X from Y to Z" | This is informational. Add a corresponding rule in Actual, or adjust the rule ordering so it doesn't conflict with the synced category.                                     |
 | Duplicate `imported_id` in Actual budget                                                       | Actual contains multiple transactions with the same importer ID. Inspect/merge/delete the duplicate transactions before relying on category backfill or duplicate skipping. |
 

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -30,8 +30,7 @@ enabled = false
 [import]
 importUncheckedTransactions = true
 synchronizeClearedStatus = true
-synchronizeCategories = false
-categorySyncOnExisting = "ask" # ask|new|always
+categorySync = "off" # off|new|all (off = don't apply category mappings, new = new imports only, all = also update existing)
 importComments = false
 commentPrefix = "MoneyMoney Comment: "
 
@@ -56,6 +55,13 @@ serverPassword = "<password>"
 syncId = "<syncId>" # Get this value from the Actual advanced settings
 # earliestImportDate = "2024-01-01" # Optional, only import transactions from this date
 
+# Intentionally ignored MoneyMoney categories (optional)
+# Place this at the budget level (before any [actualServers.budgets.*] subsections).
+# Categories listed here are excluded from the "unresolved" count in
+# the mapping report. Use this for transfer categories or categories
+# that should never receive category assignments.
+# ignoredMoneyMoneyCategoryRefs = ["path:Umbuchungen > Echte Umbuchungen"]
+
 # E2E encryption for the budget, if enabled
 [actualServers.budgets.e2eEncryption]
 enabled = false
@@ -71,7 +77,8 @@ password = ""
 # Category map for the budget (optional)
 # Tool-managed block: running actual-mmi categories map --write-config
 # rewrites this section with annotated comments for readability.
-# The key is a MoneyMoney category UUID, the value is an Actual category ID.
+# Keys use human-readable "path:" refs by default: "path:Expenses > Food"
+# Fall back to "uuid:<uuid>" or "id:<id>" only for ambiguous categories.
 [actualServers.budgets.categoryMapping]
-"<monMonCategoryUuid>" = "<actualCategoryId>"
+"path:<monMonCategoryPath>" = "path:<actualCategoryPath>"
 

--- a/src/commands/categories.command.ts
+++ b/src/commands/categories.command.ts
@@ -114,11 +114,8 @@ const handleMapCommand = async (
             }
         } catch (err) {
             // Non-fatal: budget names will fall back to syncId
-            logger.warn(
-                `Could not resolve budget names for server ${serverConfig.serverUrl}`
-            );
             logger.debug(
-                `Error details: ${err instanceof Error ? err.message : String(err)}`
+                `Could not resolve budget names for server ${serverConfig.serverUrl}: ${err instanceof Error ? err.message : String(err)}`
             );
         }
 

--- a/src/commands/categories.command.ts
+++ b/src/commands/categories.command.ts
@@ -18,12 +18,14 @@ import {
     ActualServerConfig,
     getConfig,
     getConfigFile,
+    resolveCategorySyncPolicy,
 } from '../utils/config.js';
 
 type MapFormat = 'table' | 'json' | 'toml';
 type CategoryMapItem = {
     serverUrl: string;
     syncId: string;
+    budgetName: string | undefined;
     report: ReturnType<CategoryMap['getReport']>;
     canonicalMappingEntries: CanonicalMappingEntry[];
     canonicalMapping: Record<string, string>;
@@ -91,13 +93,7 @@ const handleMapCommand = async (
 
     let shutdownFailed = false;
 
-    const reports: Array<{
-        serverUrl: string;
-        syncId: string;
-        report: ReturnType<CategoryMap['getReport']>;
-        canonicalMappingEntries: CanonicalMappingEntry[];
-        canonicalMapping: Record<string, string>;
-    }> = [];
+    const reports: CategoryMapItem[] = [];
 
     const targetsByServer = new Map<ActualServerConfig, ActualBudgetConfig[]>();
     for (const target of matchingTargets) {
@@ -109,6 +105,22 @@ const handleMapCommand = async (
     for (const [serverConfig, budgets] of targetsByServer.entries()) {
         const actualApi = new ActualApi(serverConfig, logger);
         await actualApi.init();
+
+        const budgetNameBySyncId = new Map<string, string>();
+        try {
+            const userFiles = await actualApi.getUserFiles();
+            for (const file of userFiles) {
+                budgetNameBySyncId.set(file.fileId, file.name);
+            }
+        } catch (err) {
+            // Non-fatal: budget names will fall back to syncId
+            logger.warn(
+                `Could not resolve budget names for server ${serverConfig.serverUrl}`
+            );
+            logger.debug(
+                `Error details: ${err instanceof Error ? err.message : String(err)}`
+            );
+        }
 
         try {
             for (const budgetConfig of budgets) {
@@ -124,6 +136,7 @@ const handleMapCommand = async (
                 reports.push({
                     serverUrl: serverConfig.serverUrl,
                     syncId: budgetConfig.syncId,
+                    budgetName: budgetNameBySyncId.get(budgetConfig.syncId),
                     report: categoryMap.getReport(),
                     canonicalMappingEntries:
                         categoryMap.getCanonicalMappingEntries({
@@ -146,7 +159,9 @@ const handleMapCommand = async (
         }
     }
 
-    printReports(reports, outputFormat);
+    const categorySyncPolicy = resolveCategorySyncPolicy(config.import);
+
+    printReports(reports, outputFormat, categorySyncPolicy);
 
     if (!writeConfig) {
         process.exit(shutdownFailed ? 1 : 0);
@@ -235,7 +250,11 @@ const handleMapCommand = async (
     process.exit(shutdownFailed ? 1 : 0);
 };
 
-const printReports = (reports: CategoryMapItem[], format: MapFormat) => {
+const printReports = (
+    reports: CategoryMapItem[],
+    format: MapFormat,
+    categorySyncPolicy: 'off' | 'new' | 'all'
+) => {
     if (format === 'json') {
         console.log(JSON.stringify(reports, null, 4));
         return;
@@ -256,18 +275,39 @@ const printReports = (reports: CategoryMapItem[], format: MapFormat) => {
         return;
     }
 
+    const maxWidth = (process.stdout.columns ?? 142) - 2;
+
     for (const item of reports) {
         const report = item.report;
-        const maxWidth = (process.stdout.columns ?? 142) - 2;
-        for (const line of formatTableReport(
+
+        // --- Status bar ---
+        console.log(formatStatusBar(report));
+        console.log();
+
+        // --- Warning banner ---
+        if (categorySyncPolicy === 'off') {
+            console.log(formatSyncOffBanner(maxWidth));
+            console.log();
+        }
+
+        // --- Sections (only non-empty) ---
+        const sections = buildTableSections(
             item.serverUrl,
             item.syncId,
+            item.budgetName,
             report,
             maxWidth
-        )) {
-            console.log(line);
+        );
+
+        for (const section of sections) {
+            console.log(section.header);
+            for (const line of section.lines) {
+                console.log(line);
+            }
+            if (section.lines.length > 0) {
+                console.log();
+            }
         }
-        console.log();
     }
 };
 
@@ -396,6 +436,26 @@ export const formatUnresolvedMoneyMoneySection = (
     });
 };
 
+export const formatIgnoredMoneyMoneySection = (
+    report: ReturnType<CategoryMap['getReport']>,
+    maxWidth: number
+) => {
+    const rows = report.ignoredMoneyMoneyCategories.map((category) => {
+        return [category.path, category.ref];
+    });
+
+    return formatSectionWithRows({
+        title: 'Intentionally Ignored:',
+        headers: ['MoneyMoney Path', 'Config Ref'],
+        rows,
+        columns: [
+            { width: 42, alignment: 'left', truncatePriority: 1 },
+            { width: 42, alignment: 'left', truncatePriority: 2 },
+        ],
+        maxWidth,
+    });
+};
+
 export const formatUnusedActualSection = (
     report: ReturnType<CategoryMap['getReport']>,
     maxWidth: number
@@ -441,9 +501,10 @@ export const formatNextActionsSection = (
     if (report.invalidMappings.length > 0) {
         action =
             'Fix invalid category refs in config first, then rerun `actual-mmi categories map`.';
+    } else if (report.safeSuggestions.length > 0) {
+        action = `Run \`actual-mmi categories map --write-config\` to accept ${report.safeSuggestions.length} safe suggestion${report.safeSuggestions.length !== 1 ? 's' : ''} and write them to the config file.`;
     } else if (report.unresolvedMoneyMoneyCategories.length > 0) {
-        action =
-            'Review unresolved categories, then run `actual-mmi categories map --write-config` to apply safe mappings.';
+        action = `${report.unresolvedMoneyMoneyCategories.length} categor${report.unresolvedMoneyMoneyCategories.length !== 1 ? 'ies' : 'y'} unresolved (this may be intentional). Add mappings or mark as ignored with \`ignoredMoneyMoneyCategoryRefs\` in the config.`;
     }
 
     return formatSectionWithRows({
@@ -455,6 +516,139 @@ export const formatNextActionsSection = (
     });
 };
 
+export const formatStatusBar = (
+    report: ReturnType<CategoryMap['getReport']>
+) => {
+    const mapped = report.configuredMappings.length;
+    const suggestions = report.safeSuggestions.length;
+    const invalid = report.invalidMappings.length;
+    const unresolved = report.unresolvedMoneyMoneyCategories.length;
+    const ignored = report.ignoredMoneyMoneyCategories.length;
+
+    const parts: string[] = [];
+    if (mapped > 0) parts.push(`  ✅ ${mapped} mapped`);
+    if (suggestions > 0) parts.push(`💡 ${suggestions} suggestions`);
+    if (invalid > 0) parts.push(`❌ ${invalid} invalid`);
+    if (unresolved > 0) parts.push(`⚠️  ${unresolved} unresolved`);
+    if (ignored > 0) parts.push(`🫷 ${ignored} ignored`);
+    if (parts.length === 0) parts.push('  No categories configured');
+
+    return parts.join('  |  ');
+};
+
+export const formatSyncOffBanner = (maxWidth: number) => {
+    const width = Math.max(maxWidth, 40);
+    const top = '╔' + '═'.repeat(width) + '╗';
+    const bottom = '╚' + '═'.repeat(width) + '╝';
+    const empty = '║' + ' '.repeat(width) + '║';
+    const lines = [
+        '║  ⚠️  CATEGORY SYNC IS DISABLED' +
+            ' '.repeat(Math.max(0, width - 32)) +
+            '║',
+        empty,
+        '║  categorySync is "off" — these mappings will not be applied during import.' +
+            ' '.repeat(Math.max(0, width - 73)) +
+            '║',
+        '║  Set categorySync = "new" or "all" in [import] to enable category sync.' +
+            ' '.repeat(Math.max(0, width - 74)) +
+            '║',
+    ];
+    return [top, ...lines, bottom].join('\n');
+};
+
+type TableSection = {
+    header: string;
+    lines: string[];
+};
+
+export const buildTableSections = (
+    serverUrl: string,
+    syncId: string,
+    budgetName: string | undefined,
+    report: ReturnType<CategoryMap['getReport']>,
+    maxWidth: number
+): TableSection[] => {
+    const sections: TableSection[] = [];
+
+    // Header
+    const budgetLabel = budgetName ? `${budgetName} (${syncId})` : syncId;
+    sections.push({
+        header: `Server: ${serverUrl}`,
+        lines: ['', `Budget: ${budgetLabel}`],
+    });
+
+    // Configured mappings (only if any)
+    if (report.configuredMappings.length > 0) {
+        const formatted = formatConfiguredMappingsSection(report, maxWidth);
+        const title = `Configured Mappings (${report.configuredMappings.length}):`;
+        sections.push({ header: title, lines: formatted.slice(1) });
+    }
+
+    // Invalid mappings (only if any)
+    if (report.invalidMappings.length > 0) {
+        const formatted = formatInvalidMappingsSection(report, maxWidth);
+        const title = `Invalid Mappings (${report.invalidMappings.length}):`;
+        sections.push({ header: title, lines: formatted.slice(1) });
+    }
+
+    // Safe suggestions (only if any)
+    if (report.safeSuggestions.length > 0) {
+        const formatted = formatSafeSuggestionsSection(report, maxWidth);
+        const title = `Safe Suggestions (${report.safeSuggestions.length}):`;
+        const hint = '  Run --write-config to accept these.';
+        sections.push({
+            header: title,
+            lines: [...formatted.slice(1), '', hint],
+        });
+    }
+
+    // Unresolved MoneyMoney categories (only if any)
+    if (report.unresolvedMoneyMoneyCategories.length > 0) {
+        const formatted = formatUnresolvedMoneyMoneySection(report, maxWidth);
+        const title = `Unresolved MoneyMoney Categories (${report.unresolvedMoneyMoneyCategories.length}):`;
+        sections.push({ header: title, lines: formatted.slice(1) });
+    }
+
+    // Intentionally ignored MoneyMoney categories (only if any)
+    if (report.ignoredMoneyMoneyCategories.length > 0) {
+        const formatted = formatIgnoredMoneyMoneySection(report, maxWidth);
+        const title = `Intentionally Ignored (${report.ignoredMoneyMoneyCategories.length}):`;
+        sections.push({ header: title, lines: formatted.slice(1) });
+    }
+
+    // Unused Actual categories (only if any)
+    if (report.unusedActualCategories.length > 0) {
+        const formatted = formatUnusedActualSection(report, maxWidth);
+        const title = `Unused Actual Categories (${report.unusedActualCategories.length}):`;
+        sections.push({ header: title, lines: formatted.slice(1) });
+    }
+
+    // Planning warnings (only if any)
+    if (report.planningWarnings.length > 0) {
+        const formatted = formatPlanningWarningsSection(report, maxWidth);
+        sections.push({
+            header: formatted[0] ?? 'Planning Warnings:',
+            lines: formatted.slice(1),
+        });
+    }
+
+    // Next actions (always)
+    const nextFormatted = formatNextActionsSection(report, maxWidth);
+    sections.push({
+        header: nextFormatted[0] ?? 'Next Actions:',
+        lines: nextFormatted.slice(1),
+    });
+
+    return sections;
+};
+
+/**
+ * Legacy flat format: always renders all sections regardless of content.
+ *
+ * The actual CLI output uses {@link buildTableSections} instead, which
+ * only shows sections that have entries. This function is kept for
+ * backwards-compatible test coverage of the individual section formatters.
+ */
 export const formatTableReport = (
     serverUrl: string,
     syncId: string,
@@ -472,6 +666,8 @@ export const formatTableReport = (
         ...formatSafeSuggestionsSection(report, maxWidth),
         '',
         ...formatUnresolvedMoneyMoneySection(report, maxWidth),
+        '',
+        ...formatIgnoredMoneyMoneySection(report, maxWidth),
         '',
         ...formatUnusedActualSection(report, maxWidth),
         '',
@@ -492,6 +688,12 @@ export const formatTomlReport = (
         `# Unresolved MoneyMoney categories: ${report.unresolvedMoneyMoneyCategories.length}`,
         `# Unused Actual categories: ${report.unusedActualCategories.length}`,
     ];
+
+    if (report.ignoredMoneyMoneyCategories.length > 0) {
+        lines.push(
+            `# Intentionally ignored MoneyMoney categories: ${report.ignoredMoneyMoneyCategories.length}`
+        );
+    }
 
     if (report.planningWarnings.length > 0) {
         lines.push('# Planning is incomplete (this can be intentional).');

--- a/src/commands/categories.command.ts
+++ b/src/commands/categories.command.ts
@@ -293,7 +293,8 @@ const printReports = (
             item.syncId,
             item.budgetName,
             report,
-            maxWidth
+            maxWidth,
+            categorySyncPolicy
         );
 
         for (const section of sections) {
@@ -490,18 +491,28 @@ export const formatPlanningWarningsSection = (
 
 export const formatNextActionsSection = (
     report: ReturnType<CategoryMap['getReport']>,
-    maxWidth: number
+    maxWidth: number,
+    syncOff: boolean
 ) => {
-    let action =
-        'Mapping is complete; ready for import with `actual-mmi import`.';
+    let action: string;
 
     if (report.invalidMappings.length > 0) {
         action =
             'Fix invalid category refs in config first, then rerun `actual-mmi categories map`.';
     } else if (report.safeSuggestions.length > 0) {
-        action = `Run \`actual-mmi categories map --write-config\` to accept ${report.safeSuggestions.length} safe suggestion${report.safeSuggestions.length !== 1 ? 's' : ''} and write them to the config file.`;
+        if (syncOff) {
+            action = `${report.safeSuggestions.length} safe suggestion${report.safeSuggestions.length !== 1 ? 's' : ''} available. Enable categorySync to apply them, then run \`--write-config\`.`;
+        } else {
+            action = `Run \`actual-mmi categories map --write-config\` to accept ${report.safeSuggestions.length} safe suggestion${report.safeSuggestions.length !== 1 ? 's' : ''} and write them to the config file.`;
+        }
     } else if (report.unresolvedMoneyMoneyCategories.length > 0) {
         action = `${report.unresolvedMoneyMoneyCategories.length} categor${report.unresolvedMoneyMoneyCategories.length !== 1 ? 'ies' : 'y'} unresolved (this may be intentional). Add mappings or mark as ignored with \`ignoredMoneyMoneyCategoryRefs\` in the config.`;
+    } else if (syncOff) {
+        action =
+            'Mapping is complete but categorySync is off; mappings will not be applied during import.';
+    } else {
+        action =
+            'Mapping is complete; ready for import with `actual-mmi import`.';
     }
 
     return formatSectionWithRows({
@@ -563,9 +574,11 @@ export const buildTableSections = (
     syncId: string,
     budgetName: string | undefined,
     report: ReturnType<CategoryMap['getReport']>,
-    maxWidth: number
+    maxWidth: number,
+    categorySyncPolicy: 'off' | 'new' | 'all'
 ): TableSection[] => {
     const sections: TableSection[] = [];
+    const syncOff = categorySyncPolicy === 'off';
 
     // Header
     const budgetLabel = budgetName ? `${budgetName} (${syncId})` : syncId;
@@ -630,7 +643,7 @@ export const buildTableSections = (
     }
 
     // Next actions (always)
-    const nextFormatted = formatNextActionsSection(report, maxWidth);
+    const nextFormatted = formatNextActionsSection(report, maxWidth, syncOff);
     sections.push({
         header: nextFormatted[0] ?? 'Next Actions:',
         lines: nextFormatted.slice(1),
@@ -670,7 +683,7 @@ export const formatTableReport = (
         '',
         ...formatPlanningWarningsSection(report, maxWidth),
         '',
-        ...formatNextActionsSection(report, maxWidth),
+        ...formatNextActionsSection(report, maxWidth, false),
     ];
 };
 

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -9,7 +9,7 @@ import Importer from '../utils/Importer.js';
 import Logger, { LogLevel } from '../utils/Logger.js';
 import PayeeTransformer from '../utils/PayeeTransformer.js';
 import { withApiNoiseFilter } from '../utils/ActualApiLogControl.js';
-import { getConfig } from '../utils/config.js';
+import { getConfig, resolveCategorySyncPolicy } from '../utils/config.js';
 import { DATE_FORMAT } from '../utils/shared.js';
 
 export const buildBudgetNameBySyncIdMap = async (
@@ -38,7 +38,6 @@ type ImportArgs = CommonArgs & {
     account?: string | string[];
     server?: string | string[];
     budget?: string | string[];
-    'category-sync-on-existing'?: 'ask' | 'new' | 'always';
     from?: string;
     to?: string;
 };
@@ -72,20 +71,6 @@ const handleCommand = async (argv: ArgumentsCamelCase<ImportArgs>) => {
     const accountRefs = toRefList(argv.account);
     const serverRefs = toRefList(argv.server);
     const budgetRefs = toRefList(argv.budget);
-
-    const categorySyncOnExisting =
-        argv.categorySyncOnExisting ?? config.import.categorySyncOnExisting;
-
-    if (
-        config.import.synchronizeCategories &&
-        categorySyncOnExisting === 'ask' &&
-        !isDryRun &&
-        !process.stdin.isTTY
-    ) {
-        throw new Error(
-            `Category sync policy 'ask' requires an interactive terminal. Use --category-sync-on-existing=new|always for non-interactive runs.`
-        );
-    }
 
     if (fromDate && isNaN(fromDate.getTime())) {
         throw new Error(
@@ -196,7 +181,7 @@ const handleCommand = async (argv: ArgumentsCamelCase<ImportArgs>) => {
                         logger
                     );
                     if (
-                        config.import.synchronizeCategories ||
+                        resolveCategorySyncPolicy(config.import) !== 'off' ||
                         config.import.transfers.enabled
                     ) {
                         await categoryMap.load();
@@ -222,10 +207,8 @@ const handleCommand = async (argv: ArgumentsCamelCase<ImportArgs>) => {
                         from?: Date;
                         to?: Date;
                         isDryRun: boolean;
-                        categorySyncOnExisting?: 'ask' | 'new' | 'always';
                     } = {
                         isDryRun,
-                        categorySyncOnExisting,
                     };
 
                     if (accountRefs) {
@@ -288,13 +271,6 @@ export default {
             .describe(
                 'budget',
                 'Import only to the specified Actual budget identifier (syncId)'
-            )
-            .string('category-sync-on-existing')
-            .alias('category-sync-on-existing', 'C')
-            .choices('category-sync-on-existing', ['ask', 'new', 'always'])
-            .describe(
-                'category-sync-on-existing',
-                'How category sync handles existing imported transactions: ask|new|always'
             )
             .string('from')
             .alias('from', 'f')

--- a/src/commands/validate.command.ts
+++ b/src/commands/validate.command.ts
@@ -3,6 +3,7 @@ import {
     EnvVarResolutionError,
     getConfigFile,
     parseConfigContent,
+    resolveCategorySyncPolicy,
 } from '../utils/config.js';
 import { CommonArgs } from '../utils/cliArgs.js';
 import fs from 'fs/promises';
@@ -43,7 +44,29 @@ const handleValidate = async (argv: ArgumentsCamelCase<CommonArgs>) => {
             const configContent = await fs.readFile(configPath, 'utf-8');
 
             logger.debug(`Parsing configuration file...`);
-            parseConfigContent(configContent);
+            const config = parseConfigContent(configContent);
+
+            // Soft warning: categorySync is 'off' but mappings exist
+            if (resolveCategorySyncPolicy(config.import) === 'off') {
+                const hasMappings = config.actualServers.some((server) =>
+                    server.budgets.some(
+                        (budget) =>
+                            budget.categoryMapping !== undefined &&
+                            Object.keys(budget.categoryMapping).length > 0
+                    )
+                );
+                if (hasMappings) {
+                    logger.warn(
+                        'categorySync is "off" but one or more budgets have categoryMapping entries.'
+                    );
+                    logger.warn(
+                        'These mappings will be ignored during import.'
+                    );
+                    logger.warn(
+                        'Set categorySync to "new" or "all" in [import] to activate them.'
+                    );
+                }
+            }
         } catch (e) {
             if (e instanceof EnvVarResolutionError) {
                 logger.error(e.message);

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -67,6 +67,10 @@ type CategoryMapReport = {
         path: string;
         ref: string;
     }>;
+    invalidIgnoredRefWarnings: Array<{
+        ref: string;
+        reason: string;
+    }>;
 };
 
 const DEFAULT_CATEGORY_PATH_SEPARATOR = ' > ';
@@ -92,6 +96,10 @@ class CategoryMap {
         uuid: string;
         path: string;
         ref: string;
+    }> = [];
+    private invalidIgnoredRefWarnings: Array<{
+        ref: string;
+        reason: string;
     }> = [];
 
     constructor(
@@ -237,7 +245,8 @@ class CategoryMap {
         const unusedActualCategories = this.computeUnusedActualCategories();
         const planningWarnings = this.computePlanningWarnings(
             unresolvedMoneyMoneyCategories.length,
-            unusedActualCategories.length
+            unusedActualCategories.length,
+            this.invalidIgnoredRefWarnings.length
         );
 
         return {
@@ -248,6 +257,7 @@ class CategoryMap {
             unusedActualCategories,
             planningWarnings,
             ignoredMoneyMoneyCategories,
+            invalidIgnoredRefWarnings: this.invalidIgnoredRefWarnings,
         };
     }
 
@@ -258,12 +268,47 @@ class CategoryMap {
     }) {
         return Object.fromEntries(
             this.getCanonicalMappingEntries({ includeSuggestions }).map(
-                (entry) => [
-                    `path:${entry.sourcePath}`,
-                    `path:${entry.targetPath}`,
-                ]
+                (entry) => {
+                    const sourceRef = this.canonicalSourceRef(
+                        entry.sourceUuid,
+                        entry.sourcePath
+                    );
+                    const targetRef = this.canonicalTargetRef(
+                        entry.targetId,
+                        entry.targetPath
+                    );
+                    return [sourceRef, targetRef];
+                }
             )
         );
+    }
+
+    /**
+     * Choose the best ref for a MoneyMoney category in canonical output.
+     *
+     * Prefers "path:" when the path resolves uniquely back to the same UUID.
+     * Falls back to "uuid:" when paths collide (e.g., after normalization).
+     */
+    private canonicalSourceRef(uuid: string, path: string): string {
+        const resolved = this.resolveMoneyMoneyCategoryRef(path);
+        if (resolved.info?.uuid === uuid) {
+            return `path:${path}`;
+        }
+        return `uuid:${uuid}`;
+    }
+
+    /**
+     * Choose the best ref for an Actual category in canonical output.
+     *
+     * Prefers "path:" when the path resolves uniquely back to the same id.
+     * Falls back to "id:" when paths collide or resolution is ambiguous.
+     */
+    private canonicalTargetRef(id: string, path: string): string {
+        const resolved = this.resolveActualCategoryRef(path);
+        if (resolved.info?.id === id) {
+            return `path:${path}`;
+        }
+        return `id:${id}`;
     }
 
     getCanonicalMappingEntries({
@@ -562,25 +607,45 @@ class CategoryMap {
         }> = [];
 
         for (const uuid of resolvedUuids) {
-            this.mappedMoneyMoneyUuids.add(uuid);
             const info = this.monMonCategoryInfos.get(uuid);
-            if (info) {
-                const ref = refs.find((r) => {
-                    const res = this.resolveMoneyMoneyCategoryRef(r);
-                    return res.info?.uuid === uuid;
+            if (!info) continue;
+
+            // Detect mapped+ignored conflicts: an ignored category that is
+            // also explicitly mapped is ambiguous user intent. Flag the mapping
+            // as invalid and skip adding to mappedMoneyMoneyUuids so the
+            // category still appears as unresolved (alerting the user).
+            const conflictingMapping = this.validMappings.find(
+                (m) => m.sourceUuid === uuid
+            );
+            if (conflictingMapping) {
+                this.validMappings = this.validMappings.filter(
+                    (m) => m !== conflictingMapping
+                );
+                const mappedReason =
+                    'Mapped category is also listed in ignoredMoneyMoneyCategoryRefs. Remove one.';
+                this.invalidMappings.push({
+                    ...conflictingMapping,
+                    reason: conflictingMapping.reason
+                        ? `${conflictingMapping.reason}; ${mappedReason}`
+                        : mappedReason,
                 });
-                ignored.push({
-                    uuid: info.uuid,
-                    path: info.path.join(DEFAULT_CATEGORY_PATH_SEPARATOR),
-                    ref: ref ?? uuid,
-                });
+                continue;
             }
+
+            this.mappedMoneyMoneyUuids.add(uuid);
+            const ref = refs.find((r) => {
+                const res = this.resolveMoneyMoneyCategoryRef(r);
+                return res.info?.uuid === uuid;
+            });
+            ignored.push({
+                uuid: info.uuid,
+                path: info.path.join(DEFAULT_CATEGORY_PATH_SEPARATOR),
+                ref: ref ?? uuid,
+            });
         }
 
         for (const invalid of invalidRefs) {
-            this.logger.warn(
-                `Ignored category ref '${invalid.ref}' is invalid: ${invalid.reason}`
-            );
+            this.invalidIgnoredRefWarnings.push(invalid);
         }
 
         this.ignoredState = ignored;
@@ -610,7 +675,8 @@ class CategoryMap {
 
     private computePlanningWarnings(
         unresolvedCount: number,
-        unusedCount: number
+        unusedCount: number,
+        invalidIgnoredRefCount: number
     ) {
         const warnings: string[] = [];
 
@@ -622,6 +688,12 @@ class CategoryMap {
 
         if (unusedCount > 0) {
             warnings.push(`Unused Actual categories: ${unusedCount}`);
+        }
+
+        if (invalidIgnoredRefCount > 0) {
+            warnings.push(
+                `Invalid ignored category refs: ${invalidIgnoredRefCount}`
+            );
         }
 
         if (warnings.length > 0) {
@@ -785,6 +857,7 @@ class CategoryMap {
         this.mappedMoneyMoneyUuids.clear();
         this.mappedCategoryBySourceUuid.clear();
         this.ignoredState = [];
+        this.invalidIgnoredRefWarnings = [];
     }
 }
 

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -62,6 +62,11 @@ type CategoryMapReport = {
     unresolvedMoneyMoneyCategories: Array<{ uuid: string; path: string }>;
     unusedActualCategories: Array<{ id: string; path: string }>;
     planningWarnings: string[];
+    ignoredMoneyMoneyCategories: Array<{
+        uuid: string;
+        path: string;
+        ref: string;
+    }>;
 };
 
 const DEFAULT_CATEGORY_PATH_SEPARATOR = ' > ';
@@ -83,6 +88,11 @@ class CategoryMap {
 
     private mappedMoneyMoneyUuids = new Set<string>();
     private mappedCategoryBySourceUuid = new Map<string, string>();
+    private ignoredState: Array<{
+        uuid: string;
+        path: string;
+        ref: string;
+    }> = [];
 
     constructor(
         private budgetConfig: ActualBudgetConfig,
@@ -113,6 +123,7 @@ class CategoryMap {
         this.buildMoneyMoneyCategoryInfos();
         this.buildActualCategoryInfos(actualCategories, actualGroups);
         this.evaluateConfiguredMappings();
+        this.resolveIgnoredState();
         this.computeSuggestions();
     }
 
@@ -221,6 +232,7 @@ class CategoryMap {
     }
 
     getReport(): CategoryMapReport {
+        const ignoredMoneyMoneyCategories = this.ignoredState;
         const unresolvedMoneyMoneyCategories = this.getUnmappedCategories();
         const unusedActualCategories = this.computeUnusedActualCategories();
         const planningWarnings = this.computePlanningWarnings(
@@ -235,6 +247,7 @@ class CategoryMap {
             unresolvedMoneyMoneyCategories,
             unusedActualCategories,
             planningWarnings,
+            ignoredMoneyMoneyCategories,
         };
     }
 
@@ -245,7 +258,10 @@ class CategoryMap {
     }) {
         return Object.fromEntries(
             this.getCanonicalMappingEntries({ includeSuggestions }).map(
-                (entry) => [entry.sourceUuid, entry.targetId]
+                (entry) => [
+                    `path:${entry.sourcePath}`,
+                    `path:${entry.targetPath}`,
+                ]
             )
         );
     }
@@ -534,6 +550,42 @@ class CategoryMap {
             }));
     }
 
+    private resolveIgnoredState() {
+        const refs = this.budgetConfig.ignoredMoneyMoneyCategoryRefs ?? [];
+        const { resolvedUuids, invalidRefs } =
+            this.resolveMoneyMoneyCategoryRefs(refs);
+
+        const ignored: Array<{
+            uuid: string;
+            path: string;
+            ref: string;
+        }> = [];
+
+        for (const uuid of resolvedUuids) {
+            this.mappedMoneyMoneyUuids.add(uuid);
+            const info = this.monMonCategoryInfos.get(uuid);
+            if (info) {
+                const ref = refs.find((r) => {
+                    const res = this.resolveMoneyMoneyCategoryRef(r);
+                    return res.info?.uuid === uuid;
+                });
+                ignored.push({
+                    uuid: info.uuid,
+                    path: info.path.join(DEFAULT_CATEGORY_PATH_SEPARATOR),
+                    ref: ref ?? uuid,
+                });
+            }
+        }
+
+        for (const invalid of invalidRefs) {
+            this.logger.warn(
+                `Ignored category ref '${invalid.ref}' is invalid: ${invalid.reason}`
+            );
+        }
+
+        this.ignoredState = ignored;
+    }
+
     private computeUnusedActualCategories() {
         const usedActualIds = new Set<string>();
 
@@ -583,12 +635,27 @@ class CategoryMap {
         info?: MoneyMoneyCategoryInfo;
         reason?: string;
     } {
-        const byUuid = this.monMonCategoryInfos.get(ref);
+        // Handle "uuid:" prefix — explicit MoneyMoney category UUID lookup only.
+        if (ref.startsWith('uuid:')) {
+            const uuid = ref.slice(5);
+            const byUuid = this.monMonCategoryInfos.get(uuid);
+            if (byUuid) {
+                return { info: byUuid };
+            }
+            return {
+                reason: `MoneyMoney category uuid '${uuid}' not found.`,
+            };
+        }
+
+        // Strip optional "path:" prefix for human-readable refs.
+        const actualRef = ref.startsWith('path:') ? ref.slice(5) : ref;
+
+        const byUuid = this.monMonCategoryInfos.get(actualRef);
         if (byUuid) {
             return { info: byUuid };
         }
 
-        const normalizedRef = this.normalizeCategoryName(ref);
+        const normalizedRef = this.normalizeCategoryName(actualRef);
         const categories = Array.from(this.monMonCategoryInfos.values());
 
         const byPath = categories.filter((category) => {
@@ -636,12 +703,25 @@ class CategoryMap {
         info?: ActualCategoryInfo;
         reason?: string;
     } {
-        const byId = this.actualCategoryInfos.get(ref);
+        // Handle "id:" prefix — explicit Actual category ID lookup only.
+        if (ref.startsWith('id:')) {
+            const id = ref.slice(3);
+            const byId = this.actualCategoryInfos.get(id);
+            if (byId) {
+                return { info: byId };
+            }
+            return { reason: `Actual category id '${id}' not found.` };
+        }
+
+        // Strip optional "path:" prefix for human-readable refs.
+        const actualRef = ref.startsWith('path:') ? ref.slice(5) : ref;
+
+        const byId = this.actualCategoryInfos.get(actualRef);
         if (byId) {
             return { info: byId };
         }
 
-        const normalizedRef = this.normalizeCategoryName(ref);
+        const normalizedRef = this.normalizeCategoryName(actualRef);
         const categories = Array.from(this.actualCategoryInfos.values());
 
         const byPath = categories.filter((category) => {
@@ -704,6 +784,7 @@ class CategoryMap {
         this.suggestions = [];
         this.mappedMoneyMoneyUuids.clear();
         this.mappedCategoryBySourceUuid.clear();
+        this.ignoredState = [];
     }
 }
 

--- a/src/utils/CategoryMap.ts
+++ b/src/utils/CategoryMap.ts
@@ -51,6 +51,8 @@ type CanonicalMappingEntry = {
     targetId: string;
     sourcePath: string;
     targetPath: string;
+    sourceRef: string;
+    targetRef: string;
     origin: 'configured' | 'suggested';
     reason?: 'exact-normalized' | 'path-exact';
 };
@@ -332,6 +334,14 @@ class CategoryMap {
                     targetId: mapping.targetId,
                     sourcePath: mapping.sourcePath,
                     targetPath: mapping.targetPath,
+                    sourceRef: this.canonicalSourceRef(
+                        mapping.sourceUuid,
+                        mapping.sourcePath
+                    ),
+                    targetRef: this.canonicalTargetRef(
+                        mapping.targetId,
+                        mapping.targetPath
+                    ),
                     origin: 'configured',
                 });
             }
@@ -349,6 +359,14 @@ class CategoryMap {
                         targetId: suggestion.targetId,
                         sourcePath: suggestion.sourcePath,
                         targetPath: suggestion.targetPath,
+                        sourceRef: this.canonicalSourceRef(
+                            suggestion.sourceUuid,
+                            suggestion.sourcePath
+                        ),
+                        targetRef: this.canonicalTargetRef(
+                            suggestion.targetId,
+                            suggestion.targetPath
+                        ),
                         origin: 'suggested',
                         reason: suggestion.reason,
                     });
@@ -621,6 +639,8 @@ class CategoryMap {
                 this.validMappings = this.validMappings.filter(
                     (m) => m !== conflictingMapping
                 );
+                this.mappedMoneyMoneyUuids.delete(uuid);
+                this.mappedCategoryBySourceUuid.delete(uuid);
                 const mappedReason =
                     'Mapped category is also listed in ignoredMoneyMoneyCategoryRefs. Remove one.';
                 this.invalidMappings.push({

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -7,8 +7,6 @@ import {
     subMonths,
 } from 'date-fns';
 import chalk from 'chalk';
-import { stdin, stdout } from 'node:process';
-import { createInterface } from 'node:readline/promises';
 import {
     Account as MonMonAccount,
     Transaction as MonMonTransaction,
@@ -39,7 +37,6 @@ import type {
     ImportRunMetrics,
     PlannedTransferSeed,
     PromptDecision,
-    PromptState,
     TransferPlan,
 } from './Importer.types.js';
 import {
@@ -365,8 +362,8 @@ class Importer {
         const effectiveCategorySync = resolveCategorySyncPolicy(
             this.config.import
         );
-        const existingCategoryPolicy: ExistingCategorySyncPolicy =
-            effectiveCategorySync === 'all' ? 'always' : 'new';
+        const existingCategoryPolicy: ExistingCategorySyncPolicy | undefined =
+            effectiveCategorySync === 'all' ? 'always' : undefined;
 
         const fromDate = from ?? subMonths(new Date(), 1);
         const earliestImportDate = this.budgetConfig.earliestImportDate
@@ -690,7 +687,11 @@ class Importer {
             totalImportErrors: 0,
         };
 
-        const promptState: PromptState = { mode: 'prompt' };
+        const promptState: {
+            promptInterface?: ReturnType<
+                typeof import('node:readline/promises').createInterface
+            >;
+        } = {};
         const categorySyncDebug: string[] = [];
 
         this.logger.phase('Prepare');
@@ -927,6 +928,10 @@ class Importer {
                     continue;
                 }
 
+                if (!existingCategoryPolicy) {
+                    continue;
+                }
+
                 const {
                     pendingUpdates,
                     backfillCount,
@@ -935,8 +940,6 @@ class Importer {
                     transferLockedCount,
                 } = await this.planExistingCategoryUpdates({
                     existingPairs,
-                    existingCategoryPolicy,
-                    promptState,
                 });
 
                 if (transferLockedCount > 0) {
@@ -1347,17 +1350,13 @@ class Importer {
 
     private async planExistingCategoryUpdates({
         existingPairs,
-        existingCategoryPolicy,
-        promptState,
     }: {
         existingPairs: ExistingTransactionPair[];
-        existingCategoryPolicy: ExistingCategorySyncPolicy;
-        promptState: PromptState;
     }): Promise<CategoryUpdatePlan> {
         const pendingUpdates: ExistingCategoryUpdate[] = [];
         let backfillCount = 0;
         let conflictCount = 0;
-        let skippedConflictCount = 0;
+        const skippedConflictCount = 0;
         let transferLockedCount = 0;
 
         for (const pair of existingPairs) {
@@ -1395,94 +1394,15 @@ class Importer {
 
             conflictCount++;
 
-            if (existingCategoryPolicy === 'new') {
-                skippedConflictCount++;
-                continue;
-            }
-
-            if (existingCategoryPolicy === 'always') {
-                pendingUpdates.push(
-                    buildExistingCategoryUpdate({
-                        pair,
-                        targetCategoryId: classification.targetCategoryId,
-                        reason: 'conflict',
-                        fromCategoryId: classification.currentCategoryId,
-                    })
-                );
-                continue;
-            }
-
-            if (promptState.mode === 'none') {
-                skippedConflictCount++;
-                continue;
-            }
-
-            if (promptState.mode === 'all') {
-                pendingUpdates.push(
-                    buildExistingCategoryUpdate({
-                        pair,
-                        targetCategoryId: classification.targetCategoryId,
-                        reason: 'conflict',
-                        fromCategoryId: classification.currentCategoryId,
-                    })
-                );
-                continue;
-            }
-
-            if (!promptState.promptInterface) {
-                this.logger.info(
-                    `Interactive category decisions stay active for the rest of this import across all accounts.`,
-                    `Use A/N to apply a choice to all remaining conflicts, or q to abort.`
-                );
-                promptState.promptInterface = createInterface({
-                    input: stdin,
-                    output: stdout,
-                });
-            }
-
-            const shouldApply = await this.promptForConflictDecision(
-                promptState.promptInterface,
-                pair,
-                classification.currentCategoryId,
-                classification.targetCategoryId
+            pendingUpdates.push(
+                buildExistingCategoryUpdate({
+                    pair,
+                    targetCategoryId: classification.targetCategoryId,
+                    reason: 'conflict',
+                    fromCategoryId: classification.currentCategoryId,
+                })
             );
-
-            if (shouldApply === 'all') {
-                promptState.mode = 'all';
-                pendingUpdates.push(
-                    buildExistingCategoryUpdate({
-                        pair,
-                        targetCategoryId: classification.targetCategoryId,
-                        reason: 'conflict',
-                        fromCategoryId: classification.currentCategoryId,
-                    })
-                );
-                continue;
-            }
-
-            if (shouldApply === 'none') {
-                promptState.mode = 'none';
-                skippedConflictCount++;
-                continue;
-            }
-
-            if (shouldApply === 'quit') {
-                throw new Error('Category sync aborted by user.');
-            }
-
-            if (shouldApply === true) {
-                pendingUpdates.push(
-                    buildExistingCategoryUpdate({
-                        pair,
-                        targetCategoryId: classification.targetCategoryId,
-                        reason: 'conflict',
-                        fromCategoryId: classification.currentCategoryId,
-                    })
-                );
-                continue;
-            }
-
-            skippedConflictCount++;
+            continue;
         }
 
         return {
@@ -1764,35 +1684,6 @@ class Importer {
         const status = (error as { status?: unknown }).status;
 
         return status === 401 || status === 403;
-    }
-
-    private async promptForConflictDecision(
-        promptInterface: ReturnType<typeof createInterface>,
-        pair: ExistingTransactionPair,
-        currentCategoryId: string,
-        targetCategoryId: string
-    ): Promise<PromptDecision> {
-        const fromCategory =
-            this.categoryMap.getActualCategoryPath(currentCategoryId);
-        const toCategory =
-            this.categoryMap.getActualCategoryPath(targetCategoryId);
-        const question = buildConflictPromptText({
-            transactionName: pair.monMonTransaction.name,
-            valueDate: pair.monMonTransaction.valueDate,
-            amount: pair.monMonTransaction.amount,
-            currentCategory: fromCategory,
-            targetCategory: toCategory,
-        });
-
-        while (true) {
-            const answer = (await promptInterface.question(question)).trim();
-            const decision = parsePromptDecision(answer);
-            if (decision !== 'invalid') {
-                return decision;
-            }
-
-            this.logger.warn(`Invalid input '${answer}'. Use y/n/A/N/q.`);
-        }
     }
 
     private async convertToActualTransaction(

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -31,7 +31,6 @@ import type {
     CategoryUpdateClassification,
     CategoryUpdatePlan,
     DuplicateImportedIdGroup,
-    ExistingCategorySyncPolicy,
     ExistingCategoryUpdate,
     ExistingTransactionPair,
     ImportRunMetrics,
@@ -362,7 +361,7 @@ class Importer {
         const effectiveCategorySync = resolveCategorySyncPolicy(
             this.config.import
         );
-        const existingCategoryPolicy: ExistingCategorySyncPolicy | undefined =
+        const existingCategoryPolicy: 'always' | undefined =
             effectiveCategorySync === 'all' ? 'always' : undefined;
 
         const fromDate = from ?? subMonths(new Date(), 1);
@@ -687,11 +686,6 @@ class Importer {
             totalImportErrors: 0,
         };
 
-        const promptState: {
-            promptInterface?: ReturnType<
-                typeof import('node:readline/promises').createInterface
-            >;
-        } = {};
         const categorySyncDebug: string[] = [];
 
         this.logger.phase('Prepare');
@@ -1001,7 +995,7 @@ class Importer {
             }
             this.emitImportRunSummary(runMetrics, isDryRun);
         } finally {
-            promptState.promptInterface?.close();
+            // promptState removed
         }
     }
 

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -17,7 +17,11 @@ import {
 import { AccountMap } from './AccountMap.js';
 import ActualApi from './ActualApi.js';
 import CategoryMap from './CategoryMap.js';
-import { ActualBudgetConfig, Config } from './config.js';
+import {
+    ActualBudgetConfig,
+    Config,
+    resolveCategorySyncPolicy,
+} from './config.js';
 import Logger from './Logger.js';
 import PayeeTransformer from './PayeeTransformer.js';
 import TransferPlanner from './TransferPlanner.js';
@@ -352,23 +356,17 @@ class Importer {
         from,
         to: toDate,
         isDryRun = false,
-        categorySyncOnExisting,
     }: {
         accountRefs?: Array<string>;
         from?: Date;
         to?: Date;
         isDryRun?: boolean;
-        categorySyncOnExisting?: ExistingCategorySyncPolicy;
     }) {
-        let existingCategoryPolicy =
-            categorySyncOnExisting ?? this.config.import.categorySyncOnExisting;
-
-        // In dry-run mode, interactive 'ask' policy makes no sense — nothing
-        // will be written. Treat it as 'new' to skip interactive prompts
-        // while still reporting category conflicts in the summary.
-        if (isDryRun && existingCategoryPolicy === 'ask') {
-            existingCategoryPolicy = 'new';
-        }
+        const effectiveCategorySync = resolveCategorySyncPolicy(
+            this.config.import
+        );
+        const existingCategoryPolicy: ExistingCategorySyncPolicy =
+            effectiveCategorySync === 'all' ? 'always' : 'new';
 
         const fromDate = from ?? subMonths(new Date(), 1);
         const earliestImportDate = this.budgetConfig.earliestImportDate
@@ -413,8 +411,8 @@ class Importer {
 
         this.logger.debug(
             `Category synchronization is ${
-                this.config.import.synchronizeCategories
-                    ? `enabled (existing policy: ${existingCategoryPolicy})`
+                effectiveCategorySync !== 'off'
+                    ? `enabled (mode: ${effectiveCategorySync})`
                     : 'disabled'
             }`
         );
@@ -570,7 +568,7 @@ class Importer {
                 .filter((payee) => payee.transfer_acct)
                 .map((payee) => [payee.transfer_acct as string, payee.id])
         );
-        const shouldSyncCategories = this.config.import.synchronizeCategories;
+        const shouldSyncCategories = effectiveCategorySync !== 'off';
 
         const accountStates = Array.from(accountMapping.entries()).map(
             ([monMonAccount, actualAccount]) => {

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -690,313 +690,301 @@ class Importer {
 
         this.logger.phase('Prepare');
 
-        try {
-            for (const {
-                monMonAccount,
-                actualAccount,
-                accountTransactions,
-                existingActualTransactions,
-                newMonMonTransactions,
-                existingPairs,
-            } of accountStates) {
-                runMetrics.accountsScanned++;
-                this.logger.phase(actualAccount.name);
+        for (const {
+            monMonAccount,
+            actualAccount,
+            accountTransactions,
+            existingActualTransactions,
+            newMonMonTransactions,
+            existingPairs,
+        } of accountStates) {
+            runMetrics.accountsScanned++;
+            this.logger.phase(actualAccount.name);
 
-                const createTransactions: ImportTransactionEntity[] = [];
-                // Maps imported_id → intended category ID (for auto-rule override detection).
-                const intendedCategoryByImportedId = new Map<string, string>();
-                for (const transaction of newMonMonTransactions) {
-                    const importedId =
-                        getIdForMoneyMoneyTransaction(transaction);
-                    if (transferPlan.suppressedImportedIds.has(importedId)) {
-                        continue;
-                    }
+            const createTransactions: ImportTransactionEntity[] = [];
+            // Maps imported_id → intended category ID (for auto-rule override detection).
+            const intendedCategoryByImportedId = new Map<string, string>();
+            for (const transaction of newMonMonTransactions) {
+                const importedId = getIdForMoneyMoneyTransaction(transaction);
+                if (transferPlan.suppressedImportedIds.has(importedId)) {
+                    continue;
+                }
 
-                    const plannedTransfer =
-                        transferPlan.seedByImportedId.get(importedId);
-                    const createTransaction =
-                        await this.convertToActualTransaction(
-                            transaction,
-                            plannedTransfer,
-                            actualAccount.id
+                const plannedTransfer =
+                    transferPlan.seedByImportedId.get(importedId);
+                const createTransaction = await this.convertToActualTransaction(
+                    transaction,
+                    plannedTransfer,
+                    actualAccount.id
+                );
+
+                if (shouldSyncCategories && !plannedTransfer) {
+                    const categoryResolution =
+                        this.categoryMap.getMappedActualCategoryId(
+                            transaction.categoryUuid
                         );
 
-                    if (shouldSyncCategories && !plannedTransfer) {
-                        const categoryResolution =
-                            this.categoryMap.getMappedActualCategoryId(
-                                transaction.categoryUuid
+                    if (categoryResolution.actualCategoryId) {
+                        createTransaction.category =
+                            categoryResolution.actualCategoryId;
+                        if (createTransaction.imported_id) {
+                            intendedCategoryByImportedId.set(
+                                createTransaction.imported_id,
+                                categoryResolution.actualCategoryId
+                            );
+                        }
+                    } else if (
+                        !categoryResolution.isUncategorized &&
+                        !categoryResolution.isMapped
+                    ) {
+                        const warningKey =
+                            categoryResolution.categoryPath ??
+                            transaction.categoryUuid;
+
+                        const isTransferHandled =
+                            transferPlan.seedByImportedId.has(importedId) ||
+                            transferPlan.suppressedImportedIds.has(
+                                importedId
+                            ) ||
+                            transferPlan.existingCounterpartConversionsByImportedId.has(
+                                importedId
                             );
 
-                        if (categoryResolution.actualCategoryId) {
-                            createTransaction.category =
-                                categoryResolution.actualCategoryId;
-                            if (createTransaction.imported_id) {
-                                intendedCategoryByImportedId.set(
-                                    createTransaction.imported_id,
-                                    categoryResolution.actualCategoryId
-                                );
-                            }
-                        } else if (
-                            !categoryResolution.isUncategorized &&
-                            !categoryResolution.isMapped
-                        ) {
-                            const warningKey =
-                                categoryResolution.categoryPath ??
-                                transaction.categoryUuid;
-
-                            const isTransferHandled =
-                                transferPlan.seedByImportedId.has(importedId) ||
-                                transferPlan.suppressedImportedIds.has(
-                                    importedId
-                                ) ||
-                                transferPlan.existingCounterpartConversionsByImportedId.has(
-                                    importedId
-                                );
-
-                            if (
-                                !unmappedCategoryWarnings.has(warningKey) &&
-                                !isTransferHandled
-                            ) {
-                                unmappedCategoryWarnings.add(warningKey);
-                                runMetrics.totalUnmappedCategoryWarnings++;
-                                this.logger.warn(
-                                    `No category mapping found for MoneyMoney category '${warningKey}'. Transaction categories will be left untouched.`
-                                );
-                            } else if (isTransferHandled) {
-                                this.logger.debug(
-                                    `Skipping unmapped category warning for transfer-handled category '${warningKey}'.`
-                                );
-                            }
-                        }
-                    }
-
-                    createTransactions.push(createTransaction);
-                }
-
-                if (!isDryRun) {
-                    await this.applyExistingCounterpartConversions({
-                        newMonMonTransactions,
-                        transferPlan,
-                    });
-                }
-
-                const effectiveExistingActualTransactions =
-                    await this.getExistingTransactionsForStartBalanceCheck({
-                        actualAccountId: actualAccount.id,
-                        existingActualTransactions,
-                        transfersEnabled,
-                        isDryRun,
-                    });
-
-                if (effectiveExistingActualTransactions.length === 0) {
-                    const latestTransactionDate =
-                        getLatestTransactionValueDate(accountTransactions);
-
-                    const startTransaction: ImportTransactionEntity = {
-                        account: actualAccount.id,
-                        date: format(
-                            latestTransactionDate ?? new Date(),
-                            DATE_FORMAT
-                        ),
-                        amount: this.getStartingBalanceForAccount(
-                            monMonAccount,
-                            accountTransactions
-                        ),
-                        imported_id: `${monMonAccount.uuid}-start`,
-                        cleared: true,
-                        notes: 'Starting balance',
-                        imported_payee: 'Starting balance',
-                    };
-
-                    createTransactions.push(startTransaction);
-                }
-
-                if (createTransactions.length > 0) {
-                    this.logger.debug(
-                        `Considering ${createTransactions.length} new transactions for Actual account '${actualAccount.name}'...`
-                    );
-
-                    createTransactions.forEach((t) => {
-                        if (t.payee) {
-                            return;
-                        }
-
-                        t.payee_name = shouldTransformPayees
-                            ? (transformedPayeesByRawName?.[
-                                  t.imported_payee as string
-                              ] ??
-                              t.imported_payee ??
-                              '')
-                            : (t.imported_payee ?? '');
-                    });
-
-                    if (!isDryRun) {
-                        const result = await this.actualApi.importTransactions(
-                            actualAccount.id,
-                            createTransactions
-                        );
-                        runMetrics.totalTransactionsAdded +=
-                            result.added.length;
-                        runMetrics.totalTransactionsUpdated +=
-                            result.updated.length;
                         if (
-                            result.added.length > 0 ||
-                            result.updated.length > 0
+                            !unmappedCategoryWarnings.has(warningKey) &&
+                            !isTransferHandled
                         ) {
-                            runMetrics.accountsWithImportActivity++;
-                        }
-
-                        const importErrors = result.errors ?? [];
-                        const hadImportErrors = importErrors.length > 0;
-
-                        if (hadImportErrors) {
-                            this.hadImportErrors = true;
-                            runMetrics.accountsWithImportErrors++;
-                            runMetrics.totalImportErrors += importErrors.length;
-                            this.logger.error(
-                                'Some errors occurred during import:'
-                            );
-                            for (let i = 0; i < importErrors.length; i++) {
-                                this.logger.error(
-                                    `Error ${i + 1}: ${importErrors[i]?.message ?? 'Unknown error'}`
-                                );
-                            }
-                        }
-
-                        if (hadImportErrors) {
+                            unmappedCategoryWarnings.add(warningKey);
+                            runMetrics.totalUnmappedCategoryWarnings++;
                             this.logger.warn(
-                                `Transaction import to account '${actualAccount.name}' completed with errors`,
-                                [
-                                    `Added ${result.added.length} new transaction.`,
-                                    `Updated ${result.updated.length} existing transaction.`,
-                                ]
+                                `No category mapping found for MoneyMoney category '${warningKey}'. Transaction categories will be left untouched.`
                             );
-                        } else {
-                            this.logger.info(
-                                `Transaction import to account '${actualAccount.name}' successful`,
-                                [
-                                    `Added ${result.added.length} new transaction.`,
-                                    `Updated ${result.updated.length} existing transaction.`,
-                                ]
+                        } else if (isTransferHandled) {
+                            this.logger.debug(
+                                `Skipping unmapped category warning for transfer-handled category '${warningKey}'.`
                             );
                         }
-
-                        const importedTransactions =
-                            result.added.length > 0 || result.updated.length > 0
-                                ? await this.actualApi.getTransactionsByIds(
-                                      actualAccount.id,
-                                      [...result.added, ...result.updated]
-                                  )
-                                : [];
-
-                        await this.applyTransferCounterpartUpdates({
-                            actualAccountName: actualAccount.name,
-                            importedTransactions,
-                            transferPlan,
-                        });
-
-                        if (
-                            intendedCategoryByImportedId.size > 0 &&
-                            result.added.length > 0
-                        ) {
-                            const overrideCount =
-                                await this.detectAndWarnAutoRuleOverrides({
-                                    actualAccountName: actualAccount.name,
-                                    addedIds: result.added,
-                                    importedTransactions,
-                                    intendedCategoryByImportedId,
-                                });
-                            runMetrics.totalAutoRuleOverrides += overrideCount;
-                        }
-                    } else {
-                        runMetrics.totalTransactionsAdded +=
-                            createTransactions.length;
-                        runMetrics.accountsWithImportActivity++;
-                        this.logger.info(
-                            `Dry run: would import ${createTransactions.length} new transactions to '${actualAccount.name}'.`
-                        );
                     }
                 }
 
-                if (!shouldSyncCategories) {
-                    continue;
-                }
+                createTransactions.push(createTransaction);
+            }
 
-                if (!existingCategoryPolicy) {
-                    continue;
-                }
-
-                const {
-                    pendingUpdates,
-                    backfillCount,
-                    conflictCount,
-                    skippedConflictCount,
-                    transferLockedCount,
-                } = await this.planExistingCategoryUpdates({
-                    existingPairs,
+            if (!isDryRun) {
+                await this.applyExistingCounterpartConversions({
+                    newMonMonTransactions,
+                    transferPlan,
                 });
+            }
 
-                if (transferLockedCount > 0) {
-                    categorySyncDebug.push(
-                        `'${actualAccount.name}': excluded ${transferLockedCount} transfer-linked`
-                    );
-                }
-
-                runMetrics.totalBackfills += backfillCount;
-                runMetrics.totalConflicts += conflictCount;
-                runMetrics.totalSkippedConflicts += skippedConflictCount;
-                runMetrics.totalCategoryUpdatesPlanned += pendingUpdates.length;
-                if (backfillCount > 0 || conflictCount > 0) {
-                    runMetrics.accountsWithCategoryActivity++;
-                }
-                if (conflictCount > 0) {
-                    runMetrics.accountsWithConflicts++;
-                }
-
-                this.logCategorySyncSummary({
-                    actualAccountName: actualAccount.name,
-                    existingPairsCount: existingPairs.length,
-                    backfillCount,
-                    conflictCount,
-                    pendingUpdatesCount: pendingUpdates.length,
-                    skippedConflictCount,
-                    categorySyncDebug,
-                });
-
-                if (pendingUpdates.length === 0) {
-                    continue;
-                }
-
-                await this.applyOrPreviewCategoryUpdates({
-                    actualAccountName: actualAccount.name,
-                    pendingUpdates,
+            const effectiveExistingActualTransactions =
+                await this.getExistingTransactionsForStartBalanceCheck({
+                    actualAccountId: actualAccount.id,
+                    existingActualTransactions,
+                    transfersEnabled,
                     isDryRun,
                 });
-                if (isDryRun) {
-                    runMetrics.totalCategoryUpdatesDryRun +=
-                        pendingUpdates.length;
+
+            if (effectiveExistingActualTransactions.length === 0) {
+                const latestTransactionDate =
+                    getLatestTransactionValueDate(accountTransactions);
+
+                const startTransaction: ImportTransactionEntity = {
+                    account: actualAccount.id,
+                    date: format(
+                        latestTransactionDate ?? new Date(),
+                        DATE_FORMAT
+                    ),
+                    amount: this.getStartingBalanceForAccount(
+                        monMonAccount,
+                        accountTransactions
+                    ),
+                    imported_id: `${monMonAccount.uuid}-start`,
+                    cleared: true,
+                    notes: 'Starting balance',
+                    imported_payee: 'Starting balance',
+                };
+
+                createTransactions.push(startTransaction);
+            }
+
+            if (createTransactions.length > 0) {
+                this.logger.debug(
+                    `Considering ${createTransactions.length} new transactions for Actual account '${actualAccount.name}'...`
+                );
+
+                createTransactions.forEach((t) => {
+                    if (t.payee) {
+                        return;
+                    }
+
+                    t.payee_name = shouldTransformPayees
+                        ? (transformedPayeesByRawName?.[
+                              t.imported_payee as string
+                          ] ??
+                          t.imported_payee ??
+                          '')
+                        : (t.imported_payee ?? '');
+                });
+
+                if (!isDryRun) {
+                    const result = await this.actualApi.importTransactions(
+                        actualAccount.id,
+                        createTransactions
+                    );
+                    runMetrics.totalTransactionsAdded += result.added.length;
+                    runMetrics.totalTransactionsUpdated +=
+                        result.updated.length;
+                    if (result.added.length > 0 || result.updated.length > 0) {
+                        runMetrics.accountsWithImportActivity++;
+                    }
+
+                    const importErrors = result.errors ?? [];
+                    const hadImportErrors = importErrors.length > 0;
+
+                    if (hadImportErrors) {
+                        this.hadImportErrors = true;
+                        runMetrics.accountsWithImportErrors++;
+                        runMetrics.totalImportErrors += importErrors.length;
+                        this.logger.error(
+                            'Some errors occurred during import:'
+                        );
+                        for (let i = 0; i < importErrors.length; i++) {
+                            this.logger.error(
+                                `Error ${i + 1}: ${importErrors[i]?.message ?? 'Unknown error'}`
+                            );
+                        }
+                    }
+
+                    if (hadImportErrors) {
+                        this.logger.warn(
+                            `Transaction import to account '${actualAccount.name}' completed with errors`,
+                            [
+                                `Added ${result.added.length} new transaction.`,
+                                `Updated ${result.updated.length} existing transaction.`,
+                            ]
+                        );
+                    } else {
+                        this.logger.info(
+                            `Transaction import to account '${actualAccount.name}' successful`,
+                            [
+                                `Added ${result.added.length} new transaction.`,
+                                `Updated ${result.updated.length} existing transaction.`,
+                            ]
+                        );
+                    }
+
+                    const importedTransactions =
+                        result.added.length > 0 || result.updated.length > 0
+                            ? await this.actualApi.getTransactionsByIds(
+                                  actualAccount.id,
+                                  [...result.added, ...result.updated]
+                              )
+                            : [];
+
+                    await this.applyTransferCounterpartUpdates({
+                        actualAccountName: actualAccount.name,
+                        importedTransactions,
+                        transferPlan,
+                    });
+
+                    if (
+                        intendedCategoryByImportedId.size > 0 &&
+                        result.added.length > 0
+                    ) {
+                        const overrideCount =
+                            await this.detectAndWarnAutoRuleOverrides({
+                                actualAccountName: actualAccount.name,
+                                addedIds: result.added,
+                                importedTransactions,
+                                intendedCategoryByImportedId,
+                            });
+                        runMetrics.totalAutoRuleOverrides += overrideCount;
+                    }
                 } else {
-                    runMetrics.totalCategoryUpdatesApplied +=
-                        pendingUpdates.length;
+                    runMetrics.totalTransactionsAdded +=
+                        createTransactions.length;
+                    runMetrics.accountsWithImportActivity++;
+                    this.logger.info(
+                        `Dry run: would import ${createTransactions.length} new transactions to '${actualAccount.name}'.`
+                    );
                 }
             }
 
-            if (categorySyncDebug.length > 0) {
-                this.logger.debug(
-                    'Category sync (per-account):',
-                    categorySyncDebug
+            if (!shouldSyncCategories) {
+                continue;
+            }
+
+            if (!existingCategoryPolicy) {
+                continue;
+            }
+
+            const {
+                pendingUpdates,
+                backfillCount,
+                conflictCount,
+                skippedConflictCount,
+                transferLockedCount,
+            } = await this.planExistingCategoryUpdates({
+                existingPairs,
+            });
+
+            if (transferLockedCount > 0) {
+                categorySyncDebug.push(
+                    `'${actualAccount.name}': excluded ${transferLockedCount} transfer-linked`
                 );
             }
 
-            if (shouldEmitMappingConflictGuidance(runMetrics)) {
-                this.logger.warn(
-                    `Category conflicts occurred while some categories are unmapped. Review with 'actual-mmi categories map' if needed.`
-                );
+            runMetrics.totalBackfills += backfillCount;
+            runMetrics.totalConflicts += conflictCount;
+            runMetrics.totalSkippedConflicts += skippedConflictCount;
+            runMetrics.totalCategoryUpdatesPlanned += pendingUpdates.length;
+            if (backfillCount > 0 || conflictCount > 0) {
+                runMetrics.accountsWithCategoryActivity++;
             }
-            this.emitImportRunSummary(runMetrics, isDryRun);
-        } finally {
-            // promptState removed
+            if (conflictCount > 0) {
+                runMetrics.accountsWithConflicts++;
+            }
+
+            this.logCategorySyncSummary({
+                actualAccountName: actualAccount.name,
+                existingPairsCount: existingPairs.length,
+                backfillCount,
+                conflictCount,
+                pendingUpdatesCount: pendingUpdates.length,
+                skippedConflictCount,
+                categorySyncDebug,
+            });
+
+            if (pendingUpdates.length === 0) {
+                continue;
+            }
+
+            await this.applyOrPreviewCategoryUpdates({
+                actualAccountName: actualAccount.name,
+                pendingUpdates,
+                isDryRun,
+            });
+            if (isDryRun) {
+                runMetrics.totalCategoryUpdatesDryRun += pendingUpdates.length;
+            } else {
+                runMetrics.totalCategoryUpdatesApplied += pendingUpdates.length;
+            }
         }
+
+        if (categorySyncDebug.length > 0) {
+            this.logger.debug(
+                'Category sync (per-account):',
+                categorySyncDebug
+            );
+        }
+
+        if (shouldEmitMappingConflictGuidance(runMetrics)) {
+            this.logger.warn(
+                `Category conflicts occurred while some categories are unmapped. Review with 'actual-mmi categories map' if needed.`
+            );
+        }
+        this.emitImportRunSummary(runMetrics, isDryRun);
     }
 
     public hasImportErrors() {

--- a/src/utils/Importer.types.ts
+++ b/src/utils/Importer.types.ts
@@ -4,10 +4,11 @@ import type {
     Account as MonMonAccount,
     Transaction as MonMonTransaction,
 } from 'moneymoney';
-import type { Config } from './config.js';
 
+/** Effective existing-category sync behaviour derived from {@link Config.import.categorySync}. */
 export type ExistingCategorySyncPolicy =
-    Config['import']['categorySyncOnExisting'];
+    | 'always' // categorySync = "all"
+    | 'new'; // categorySync = "new" or legacy "ask" fallback
 
 export type CategoryUpdateClassification =
     | { type: 'backfill'; targetCategoryId: string }

--- a/src/utils/Importer.types.ts
+++ b/src/utils/Importer.types.ts
@@ -6,9 +6,7 @@ import type {
 } from 'moneymoney';
 
 /** Effective existing-category sync behaviour derived from {@link Config.import.categorySync}. */
-export type ExistingCategorySyncPolicy =
-    | 'always' // categorySync = "all"
-    | 'new'; // categorySync = "new" or legacy "ask" fallback
+export type ExistingCategorySyncPolicy = 'always'; // categorySync = "all" — backfill uncategorised and overwrite conflicts
 
 export type CategoryUpdateClassification =
     | { type: 'backfill'; targetCategoryId: string }

--- a/src/utils/Importer.types.ts
+++ b/src/utils/Importer.types.ts
@@ -5,9 +5,6 @@ import type {
     Transaction as MonMonTransaction,
 } from 'moneymoney';
 
-/** Effective existing-category sync behaviour derived from {@link Config.import.categorySync}. */
-export type ExistingCategorySyncPolicy = 'always'; // categorySync = "all" — backfill uncategorised and overwrite conflicts
-
 export type CategoryUpdateClassification =
     | { type: 'backfill'; targetCategoryId: string }
     | {

--- a/src/utils/categoryMappingConfigPatch.ts
+++ b/src/utils/categoryMappingConfigPatch.ts
@@ -18,7 +18,11 @@ export const renderCategoryMappingLines = (
 export const renderAnnotatedCategoryMappingLines = (
     entries: CanonicalMappingEntry[]
 ): string[] => {
-    const lines: string[] = ['[actualServers.budgets.categoryMapping]'];
+    const lines: string[] = [
+        '# Tool-managed block: running actual-mmi categories map --write-config rewrites this section.',
+        '# Keys use "path:" refs by default. Fall back to "uuid:" or "id:" for ambiguous categories.',
+        '[actualServers.budgets.categoryMapping]',
+    ];
 
     if (entries.length === 0) {
         lines.push('# No mappings generated.');
@@ -33,10 +37,17 @@ export const renderAnnotatedCategoryMappingLines = (
             ? entry.targetPath
             : `[UNRESOLVED] ${entry.targetId}`;
 
+        const sourceKey = entry.sourcePath?.trim()
+            ? `path:${entry.sourcePath}`
+            : entry.sourceUuid;
+        const targetValue = entry.targetPath?.trim()
+            ? `path:${entry.targetPath}`
+            : entry.targetId;
+
         lines.push(`# MoneyMoney: ${sourcePath}`);
         lines.push(`# Actual: ${targetPath}`);
         lines.push(
-            `${JSON.stringify(entry.sourceUuid)} = ${JSON.stringify(entry.targetId)}`
+            `${JSON.stringify(sourceKey)} = ${JSON.stringify(targetValue)}`
         );
         lines.push('');
     }

--- a/src/utils/categoryMappingConfigPatch.ts
+++ b/src/utils/categoryMappingConfigPatch.ts
@@ -37,12 +37,16 @@ export const renderAnnotatedCategoryMappingLines = (
             ? entry.targetPath
             : `[UNRESOLVED] ${entry.targetId}`;
 
-        const sourceKey = entry.sourcePath?.trim()
-            ? `path:${entry.sourcePath}`
-            : entry.sourceUuid;
-        const targetValue = entry.targetPath?.trim()
-            ? `path:${entry.targetPath}`
-            : entry.targetId;
+        const sourceKey = entry.sourceRef
+            ? entry.sourceRef
+            : entry.sourcePath?.trim()
+              ? `path:${entry.sourcePath}`
+              : entry.sourceUuid;
+        const targetValue = entry.targetRef
+            ? entry.targetRef
+            : entry.targetPath?.trim()
+              ? `path:${entry.targetPath}`
+              : entry.targetId;
 
         lines.push(`# MoneyMoney: ${sourcePath}`);
         lines.push(`# Actual: ${targetPath}`);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -85,7 +85,7 @@ const budgetSchema = z
     .object({
         syncId: z.string(),
         earliestImportDate: z.string().optional(),
-        e2eEncryption: z.object({
+        e2eEncryption: z.strictObject({
             enabled: z.boolean(),
             password: z.string().optional(),
         }),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -91,6 +91,17 @@ const budgetSchema = z
         }),
         accountMapping: z.record(z.string(), z.string()),
         categoryMapping: z.record(z.string(), z.string()).optional(),
+        /**
+         * MoneyMoney category refs to intentionally leave unmapped.
+         *
+         * Categories listed here will not appear as "unresolved" in the
+         * mapping report. Use this for transfer categories or categories
+         * that should never receive category assignments.
+         *
+         * Accepts "path:"-prefixed refs (e.g. "path:Umbuchungen > Echte
+         * Umbuchungen"), bare paths, bare UUIDs, or leaf names.
+         */
+        ignoredMoneyMoneyCategoryRefs: z.array(z.string()).default([]),
     })
     .check((payload) => {
         if (
@@ -178,29 +189,73 @@ const transferImportSchema = z.object({
 });
 const defaultTransferImportConfig = transferImportSchema.parse({});
 
+/**
+ * Resolve the effective category sync policy from config.
+ *
+ * Prefers the new unified `categorySync` field when present. Falls back to
+ * deriving from the legacy `synchronizeCategories` and
+ * `categorySyncOnExisting` fields for backward compatibility.
+ *
+ * Legacy `ask` policy is treated as `new` (sync only new imports; never
+ * overwrite existing transactions without explicit user action).
+ */
+export const resolveCategorySyncPolicy = (
+    imp: z.infer<typeof importSchema>
+): 'off' | 'new' | 'all' => {
+    if (imp.categorySync !== undefined) {
+        return imp.categorySync;
+    }
+    // Derive from legacy fields for backward compat
+    if (!imp.synchronizeCategories) {
+        return 'off';
+    }
+    switch (imp.categorySyncOnExisting) {
+        case 'always':
+            return 'all';
+        default:
+            // 'ask' and 'new' both map to 'new'
+            return 'new';
+    }
+};
+
+const importSchema = z.object({
+    importUncheckedTransactions: z.boolean(),
+    synchronizeClearedStatus: z.boolean().default(true),
+    /**
+     * Legacy: replaced by `categorySync`.
+     * @deprecated Use `categorySync` instead.
+     */
+    synchronizeCategories: z.boolean().default(false),
+    /**
+     * Legacy: replaced by `categorySync`.
+     * @deprecated Use `categorySync` instead.
+     */
+    categorySyncOnExisting: z.enum(['ask', 'new', 'always']).default('ask'),
+    /**
+     * Unified category sync policy controlling both new imports and
+     * existing transactions.
+     *
+     * - `off`: never apply category mappings
+     * - `new`: apply category mappings to newly imported transactions only
+     * - `all`: also update previously imported transactions
+     */
+    categorySync: z.enum(['off', 'new', 'all']).optional(),
+    importComments: z.boolean().default(false),
+    commentPrefix: z.string().default('MoneyMoney Comment: '),
+    transfers: transferImportSchema.default(defaultTransferImportConfig),
+    ignorePatterns: z
+        .object({
+            commentPatterns: z.array(z.string()).optional(),
+            payeePatterns: z.array(z.string()).optional(),
+            purposePatterns: z.array(z.string()).optional(),
+        })
+        .optional(),
+});
+
 export const configSchema = z
     .object({
         payeeTransformation: payeeTransformationSchema,
-        import: z.object({
-            importUncheckedTransactions: z.boolean(),
-            synchronizeClearedStatus: z.boolean().default(true),
-            synchronizeCategories: z.boolean().default(false),
-            categorySyncOnExisting: z
-                .enum(['ask', 'new', 'always'])
-                .default('ask'),
-            importComments: z.boolean().default(false),
-            commentPrefix: z.string().default('MoneyMoney Comment: '),
-            transfers: transferImportSchema.default(
-                defaultTransferImportConfig
-            ),
-            ignorePatterns: z
-                .object({
-                    commentPatterns: z.array(z.string()).optional(),
-                    payeePatterns: z.array(z.string()).optional(),
-                    purposePatterns: z.array(z.string()).optional(),
-                })
-                .optional(),
-        }),
+        import: importSchema,
         actualServers: z.array(actualServerSchema).min(1),
     })
     .check((payload) => {

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -68,8 +68,7 @@ enabled = false
 [import]
 importUncheckedTransactions = true
 synchronizeClearedStatus = true
-synchronizeCategories = false
-categorySyncOnExisting = "ask" # ask|new|always
+categorySync = "off" # off|new|all (off = don't apply category mappings, new = new imports only, all = also update existing)
 importComments = false
 commentPrefix = "MoneyMoney Comment: "
 
@@ -94,6 +93,13 @@ serverPassword = "<password>"
 syncId = "<syncId>" # Get this value from the Actual advanced settings
 # earliestImportDate = "2024-01-01" # Optional, only import transactions from this date
 
+# Intentionally ignored MoneyMoney categories (optional)
+# Place this at the budget level (before any [actualServers.budgets.*] subsections).
+# Categories listed here are excluded from the "unresolved" count in
+# the mapping report. Use this for transfer categories or categories
+# that should never receive category assignments.
+# ignoredMoneyMoneyCategoryRefs = ["path:Umbuchungen > Echte Umbuchungen"]
+
 # E2E encryption for the budget, if enabled
 [actualServers.budgets.e2eEncryption]
 enabled = false
@@ -109,7 +115,8 @@ password = ""
 # Category map for the budget (optional)
 # Tool-managed block: running actual-mmi categories map --write-config
 # rewrites this section with annotated comments for readability.
-# The key is a MoneyMoney category UUID, the value is an Actual category ID.
+# Keys use human-readable "path:" refs by default: "path:Expenses > Food"
+# Fall back to "uuid:<uuid>" or "id:<id>" only for ambiguous categories.
 [actualServers.budgets.categoryMapping]
-"<monMonCategoryUuid>" = "<actualCategoryId>"
+"path:<monMonCategoryPath>" = "path:<actualCategoryPath>"
 `;

--- a/test/cli/parsing.test.mjs
+++ b/test/cli/parsing.test.mjs
@@ -85,17 +85,8 @@ test('shows short aliases for root and import options in help', () => {
     assert.match(result.output, /-a,\s*--account/i);
     assert.match(result.output, /-s,\s*--server/i);
     assert.match(result.output, /-b,\s*--budget/i);
-    assert.match(result.output, /-C,\s*--category-sync-on-existing/i);
     assert.match(result.output, /-f,\s*--from/i);
     assert.match(result.output, /-t,\s*--to/i);
-});
-
-test('fails for invalid category sync policy value', () => {
-    const result = runCli(['import', '--category-sync-on-existing', 'invalid']);
-
-    assert.equal(result.status, 1);
-    assert.match(result.output, /Invalid values/i);
-    assert.match(result.output, /category-sync-on-existing/i);
 });
 
 test('shows categories map command help', () => {

--- a/test/unit/categories-config-write.test.mjs
+++ b/test/unit/categories-config-write.test.mjs
@@ -59,7 +59,7 @@ test('replaceCategoryMappingInConfig inserts missing mapping block', () => {
     assert.match(result.content, /# MoneyMoney: A > B/);
     assert.match(result.content, /# Actual: C > D/);
     assert.match(result.content, /\[actualServers\.budgets\.categoryMapping\]/);
-    assert.match(result.content, /"mm-1" = "actual-1"/);
+    assert.match(result.content, /"path:A > B" = "path:C > D"/);
 });
 
 test('replaceCategoryMappingInConfig replaces existing mapping block', () => {
@@ -83,7 +83,7 @@ test('replaceCategoryMappingInConfig replaces existing mapping block', () => {
     }
 
     assert.doesNotMatch(result.content, /"old-mm" = "old-actual"/);
-    assert.match(result.content, /"new-mm" = "new-actual"/);
+    assert.match(result.content, /"path:X > Y" = "path:Z > Q"/);
 });
 
 test('replaceCategoryMappingInConfig replaces section cleanly before next header', () => {
@@ -118,7 +118,7 @@ syncId = "budget-a"
 
     assert.match(
         result.content,
-        /\[actualServers\.budgets\.categoryMapping\]\n# MoneyMoney: X > Y[\s\S]*"new-mm" = "new-actual"\n\n\[actualServers\.budgets\.accountMapping\]/
+        /# Tool-managed block:.*\n# Keys use "path:".*\n\[actualServers\.budgets\.categoryMapping\]\n# MoneyMoney: X > Y[\s\S]*"path:X > Y" = "path:Z > Q"\n\n\[actualServers\.budgets\.accountMapping\]/
     );
 });
 
@@ -232,7 +232,7 @@ test('replaceCategoryMappingInConfig replaces mapping section at EOF without tra
         return;
     }
 
-    assert.match(result.content, /"new-mm" = "new-actual"/);
+    assert.match(result.content, /"path:X > Y" = "path:Z > Q"/);
     assert.doesNotMatch(result.content, /"old-mm" = "old-actual"/);
 });
 
@@ -257,7 +257,51 @@ test('renderAnnotatedCategoryMappingLines includes unresolved fallback comments'
 test('renderAnnotatedCategoryMappingLines shows explicit empty mapping section', () => {
     const lines = renderAnnotatedCategoryMappingLines([]);
     assert.deepEqual(lines, [
+        '# Tool-managed block: running actual-mmi categories map --write-config rewrites this section.',
+        '# Keys use "path:" refs by default. Fall back to "uuid:" or "id:" for ambiguous categories.',
         '[actualServers.budgets.categoryMapping]',
         '# No mappings generated.',
     ]);
+});
+
+test('replaceCategoryMappingInConfig preserves budget-level ignoredMoneyMoneyCategoryRefs', () => {
+    const configWithIgnored = `
+[[actualServers]]
+serverUrl = "http://localhost:5006"
+serverPassword = "pw"
+
+[[actualServers.budgets]]
+syncId = "budget-a"
+ignoredMoneyMoneyCategoryRefs = ["path:Transfers > Transfer"]
+
+[actualServers.budgets.e2eEncryption]
+enabled = false
+
+[actualServers.budgets.accountMapping]
+"A" = "B"
+
+[actualServers.budgets.categoryMapping]
+# Tool-managed block...
+"path:Food" = "path:Expenses > Food"
+`;
+
+    const entries = [
+        {
+            sourceUuid: 'mm-drink',
+            targetId: 'actual-drink',
+            sourcePath: 'Drink',
+            targetPath: 'Expenses > Drink',
+            origin: 'configured',
+        },
+    ];
+
+    const result = replaceCategoryMappingInConfig(
+        configWithIgnored,
+        'budget-a',
+        entries
+    );
+    assert.equal(result.ok, true);
+    assert.match(result.content, /ignoredMoneyMoneyCategoryRefs =/);
+    assert.match(result.content, /"path:Drink" =/);
+    assert.doesNotMatch(result.content, /"path:Food"/);
 });

--- a/test/unit/categories-map-output.test.mjs
+++ b/test/unit/categories-map-output.test.mjs
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
     formatConfiguredMappingsSection,
+    formatIgnoredMoneyMoneySection,
     formatInvalidMappingsSection,
     formatNextActionsSection,
     formatPlanningWarningsSection,
     formatSafeSuggestionsSection,
+    formatStatusBar,
     formatTableReport,
     formatTomlReport,
     formatUnresolvedMoneyMoneySection,
@@ -20,6 +22,7 @@ const makeReport = ({
     unresolvedMoneyMoneyCategories = [],
     unusedActualCategories = [],
     planningWarnings = [],
+    ignoredMoneyMoneyCategories = [],
 } = {}) => ({
     configuredMappings,
     invalidMappings,
@@ -27,6 +30,7 @@ const makeReport = ({
     unresolvedMoneyMoneyCategories,
     unusedActualCategories,
     planningWarnings,
+    ignoredMoneyMoneyCategories,
 });
 
 test('section formatters show None for empty sections', () => {
@@ -59,6 +63,11 @@ test('section formatters show None for empty sections', () => {
     ]);
     assert.deepEqual(formatPlanningWarningsSection(report, 120), [
         'Planning Warnings:',
+        '',
+        'None',
+    ]);
+    assert.deepEqual(formatIgnoredMoneyMoneySection(report, 120), [
+        'Intentionally Ignored:',
         '',
         'None',
     ]);
@@ -106,6 +115,13 @@ test('formatters include expected headers and rows', () => {
                 path: 'G > H',
             },
         ],
+        ignoredMoneyMoneyCategories: [
+            {
+                uuid: 'mm-ignored-1',
+                path: 'Transfers > Internal',
+                ref: 'path:Transfers > Internal',
+            },
+        ],
         planningWarnings: ['Planning is incomplete (this can be intentional).'],
     });
 
@@ -114,6 +130,7 @@ test('formatters include expected headers and rows', () => {
     const suggestionsLines = formatSafeSuggestionsSection(report, 120);
     const unresolvedLines = formatUnresolvedMoneyMoneySection(report, 120);
     const unusedLines = formatUnusedActualSection(report, 120);
+    const ignoredLines = formatIgnoredMoneyMoneySection(report, 120);
 
     assert.equal(
         configuredLines.some((line) => line.includes('╔')),
@@ -139,6 +156,10 @@ test('formatters include expected headers and rows', () => {
         unusedLines.some((line) => line.includes('ID')),
         true
     );
+    assert.equal(
+        ignoredLines.some((line) => line.includes('MoneyMoney Path')),
+        true
+    );
 });
 
 test('table report includes sections in expected order', () => {
@@ -149,6 +170,7 @@ test('table report includes sections in expected order', () => {
     const invalidIdx = lines.indexOf('Invalid Configured Mappings:');
     const suggestionsIdx = lines.indexOf('Safe Suggestions:');
     const unresolvedIdx = lines.indexOf('Unresolved MoneyMoney Categories:');
+    const ignoredIdx = lines.indexOf('Intentionally Ignored:');
     const unusedIdx = lines.indexOf('Unused Actual Categories:');
     const warningsIdx = lines.indexOf('Planning Warnings:');
     const actionsIdx = lines.indexOf('Next Actions:');
@@ -157,7 +179,8 @@ test('table report includes sections in expected order', () => {
     assert.ok(invalidIdx > configuredIdx);
     assert.ok(suggestionsIdx > invalidIdx);
     assert.ok(unresolvedIdx > suggestionsIdx);
-    assert.ok(unusedIdx > unresolvedIdx);
+    assert.ok(ignoredIdx > unresolvedIdx);
+    assert.ok(unusedIdx > ignoredIdx);
     assert.ok(warningsIdx > unusedIdx);
     assert.ok(actionsIdx > warningsIdx);
 });
@@ -186,6 +209,8 @@ test('unsafe write failures return a non-zero exit code', () => {
     ]);
     assert.equal(calls.info.length, 1);
     assert.deepEqual(calls.info[0][1], [
+        '# Tool-managed block: running actual-mmi categories map --write-config rewrites this section.',
+        '# Keys use "path:" refs by default. Fall back to "uuid:" or "id:" for ambiguous categories.',
         '[actualServers.budgets.categoryMapping]',
         '# No mappings generated.',
     ]);
@@ -201,7 +226,7 @@ test('next actions prioritizes invalid mappings over unresolved categories', () 
 
     const lines = formatNextActionsSection(report, 120).join('\n');
     assert.match(lines, /Fix invalid category refs in config first/);
-    assert.doesNotMatch(lines, /Review unresolved categories/);
+    assert.doesNotMatch(lines, /\d+ categor(y|ies) unresolved/);
 });
 
 test('next actions shows unresolved guidance when no invalid mappings exist', () => {
@@ -210,7 +235,7 @@ test('next actions shows unresolved guidance when no invalid mappings exist', ()
     });
 
     const lines = formatNextActionsSection(report, 120).join('\n');
-    assert.match(lines, /Review unresolved categories/);
+    assert.match(lines, /\d+ categor(y|ies) unresolved/);
     assert.doesNotMatch(lines, /Fix invalid category refs in config first/);
 });
 
@@ -224,6 +249,22 @@ test('next actions shows complete guidance when no invalid or unresolved remain'
     );
     assert.doesNotMatch(lines, /Fix invalid category refs in config first/);
     assert.doesNotMatch(lines, /Review unresolved categories/);
+});
+
+test('next actions shows suggestion guidance when safe suggestions exist', () => {
+    const report = makeReport({
+        safeSuggestions: [
+            { sourcePath: 'A', targetPath: 'B', reason: 'exact-normalized' },
+        ],
+    });
+
+    const lines = formatNextActionsSection(report, 120).join('\n');
+    assert.match(
+        lines,
+        /Run .+actual-mmi categories map --write-config.+accept 1 safe suggestion/
+    );
+    assert.doesNotMatch(lines, /Fix invalid category refs in config first/);
+    assert.doesNotMatch(lines, /\d+ categor(y|ies) unresolved/);
 });
 
 test('toml formatter includes preamble counts and incompleteness note when needed', () => {
@@ -251,7 +292,37 @@ test('toml formatter includes preamble counts and incompleteness note when neede
     ]);
     assert.ok(lines.some((line) => line.includes('# MoneyMoney: A > B')));
     assert.ok(lines.some((line) => line.includes('# Actual: C > D')));
-    assert.ok(lines.some((line) => line.includes('"mm-1" = "actual-1"')));
+    assert.ok(
+        lines.some((line) => line.includes('"path:A > B" = "path:C > D"'))
+    );
+});
+
+test('toml formatter includes ignored count when configured', () => {
+    const report = makeReport({
+        ignoredMoneyMoneyCategories: [
+            {
+                uuid: 'mm-ig',
+                path: 'Transfers > Transfer',
+                ref: 'path:Transfers > Transfer',
+            },
+        ],
+    });
+
+    const lines = formatTomlReport('server', 'budget', report, [
+        {
+            sourceUuid: 'mm-1',
+            targetId: 'actual-1',
+            sourcePath: 'A > B',
+            targetPath: 'C > D',
+            origin: 'configured',
+        },
+    ]);
+
+    assert.ok(
+        lines.some((line) =>
+            line.includes('# Intentionally ignored MoneyMoney categories: 1')
+        )
+    );
 });
 
 test('table output truncates only when max width is narrow', () => {
@@ -271,4 +342,24 @@ test('table output truncates only when max width is narrow', () => {
 
     assert.equal(narrow.includes('…'), true);
     assert.equal(wide.includes('…'), false);
+});
+
+test('formatStatusBar includes ignored count', () => {
+    const report = makeReport({
+        configuredMappings: [
+            {
+                sourceRef: 'mm-1',
+                targetRef: 'actual-1',
+                sourcePath: 'A',
+                targetPath: 'B',
+            },
+        ],
+        ignoredMoneyMoneyCategories: [
+            { uuid: 'mm-ig-1', path: 'X > Y', ref: 'path:X > Y' },
+            { uuid: 'mm-ig-2', path: 'P > Q', ref: 'path:P > Q' },
+        ],
+    });
+
+    const result = formatStatusBar(report);
+    assert.equal(result.includes('🫷 2 ignored'), true);
 });

--- a/test/unit/category-map.test.mjs
+++ b/test/unit/category-map.test.mjs
@@ -430,7 +430,9 @@ test('getCanonicalMapping excludes suggestions when includeSuggestions is false'
     });
 
     assert.deepEqual(withoutSuggestions, {});
-    assert.deepEqual(withSuggestions, { 'mm-food': 'actual-food' });
+    assert.deepEqual(withSuggestions, {
+        'path:Food': 'path:Expenses > Food',
+    });
 });
 
 test('getCanonicalMappingEntries exposes origin and optional reason', () => {
@@ -581,6 +583,7 @@ test('report exposes planning fields and omits legacy report keys', () => {
     assert.ok(Array.isArray(report.unresolvedMoneyMoneyCategories));
     assert.ok(Array.isArray(report.unusedActualCategories));
     assert.ok(Array.isArray(report.planningWarnings));
+    assert.ok(Array.isArray(report.ignoredMoneyMoneyCategories));
     assert.equal('validMappings' in report, false);
     assert.equal('suggestions' in report, false);
     assert.equal('unmappedCategories' in report, false);
@@ -681,4 +684,120 @@ test('planningWarnings include exact messages when unresolved or unused categori
         'Unused Actual categories: 1',
         'Planning is incomplete (this can be intentional).',
     ]);
+});
+
+test('ignoredMoneyMoneyCategoryRefs excludes categories from unresolved', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+        ignoredMoneyMoneyCategoryRefs: ['mm-transfer'],
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-transfer',
+                name: 'Echte Umbuchungen',
+            }),
+            makeMonMonCategory({ uuid: 'mm-food', name: 'Food' }),
+        ],
+        [],
+        []
+    );
+
+    const report = map.getReport();
+
+    assert.deepEqual(report.unresolvedMoneyMoneyCategories, [
+        { uuid: 'mm-food', path: 'Food' },
+    ]);
+
+    assert.equal(report.ignoredMoneyMoneyCategories.length, 1);
+    assert.equal(report.ignoredMoneyMoneyCategories[0]?.uuid, 'mm-transfer');
+    assert.match(
+        report.ignoredMoneyMoneyCategories[0]?.path ?? '',
+        /Echte Umbuchungen/
+    );
+    assert.equal(report.ignoredMoneyMoneyCategories[0]?.ref, 'mm-transfer');
+});
+
+test('ignoredMoneyMoneyCategoryRefs with path: ref', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+        ignoredMoneyMoneyCategoryRefs: ['path:Some Group > Transfer'],
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [
+            makeMonMonCategory({
+                uuid: 'mm-group',
+                name: 'Some Group',
+                group: true,
+                indentation: 0,
+            }),
+            makeMonMonCategory({
+                uuid: 'mm-transfer',
+                name: 'Transfer',
+                indentation: 1,
+            }),
+        ],
+        [],
+        []
+    );
+
+    const report = map.getReport();
+
+    assert.equal(report.ignoredMoneyMoneyCategories.length, 1);
+    assert.equal(report.ignoredMoneyMoneyCategories[0]?.uuid, 'mm-transfer');
+    assert.equal(
+        report.ignoredMoneyMoneyCategories[0]?.ref,
+        'path:Some Group > Transfer'
+    );
+});
+
+test('ignored categories do not appear in planning warnings', () => {
+    const budgetConfig = {
+        syncId: 'sync-id',
+        earliestImportDate: undefined,
+        e2eEncryption: { enabled: false, password: undefined },
+        accountMapping: {},
+        categoryMapping: {},
+        ignoredMoneyMoneyCategoryRefs: ['mm-food'],
+    };
+
+    const map = new CategoryMap(
+        budgetConfig,
+        makeActualApiStub(),
+        makeLogger()
+    );
+
+    map.loadFromData(
+        [makeMonMonCategory({ uuid: 'mm-food', name: 'Food' })],
+        [],
+        []
+    );
+
+    const report = map.getReport();
+
+    assert.equal(report.ignoredMoneyMoneyCategories.length, 1);
+    assert.equal(report.unresolvedMoneyMoneyCategories.length, 0);
+    assert.equal(report.planningWarnings.length, 0);
 });

--- a/test/unit/importer-category-sync-flow.test.mjs
+++ b/test/unit/importer-category-sync-flow.test.mjs
@@ -113,7 +113,7 @@ test('planExistingCategoryUpdates backfills null category for new policy', async
     assert.equal(plan.transferLockedCount, 0);
 });
 
-test('planExistingCategoryUpdates skips conflict for new and applies for always', async () => {
+test('planExistingCategoryUpdates applies conflicts when called (categorySync=all behavior)', async () => {
     const mappingByUuid = {
         'mm-1': {
             actualCategoryId: 'cat-target',
@@ -122,25 +122,13 @@ test('planExistingCategoryUpdates skips conflict for new and applies for always'
         },
     };
 
-    const { importer: importerNew } = makeImporter({ mappingByUuid });
-    const planNew = await importerNew.planExistingCategoryUpdates({
+    const { importer } = makeImporter({ mappingByUuid });
+    const plan = await importer.planExistingCategoryUpdates({
         existingPairs: [makePair({ currentCategoryId: 'cat-current' })],
-        existingCategoryPolicy: 'new',
-        promptState: { mode: 'prompt' },
     });
-    assert.equal(planNew.pendingUpdates.length, 0);
-    assert.equal(planNew.skippedConflictCount, 1);
-    assert.equal(planNew.transferLockedCount, 0);
-
-    const { importer: importerAlways } = makeImporter({ mappingByUuid });
-    const planAlways = await importerAlways.planExistingCategoryUpdates({
-        existingPairs: [makePair({ currentCategoryId: 'cat-current' })],
-        existingCategoryPolicy: 'always',
-        promptState: { mode: 'prompt' },
-    });
-    assert.equal(planAlways.pendingUpdates.length, 1);
-    assert.equal(planAlways.pendingUpdates[0]?.reason, 'conflict');
-    assert.equal(planAlways.transferLockedCount, 0);
+    assert.equal(plan.pendingUpdates.length, 1);
+    assert.equal(plan.pendingUpdates[0]?.reason, 'conflict');
+    assert.equal(plan.transferLockedCount, 0);
 });
 
 test('planExistingCategoryUpdates skips transfer-linked transactions from category sync', async () => {
@@ -168,33 +156,6 @@ test('planExistingCategoryUpdates skips transfer-linked transactions from catego
     assert.equal(plan.conflictCount, 0);
     assert.equal(plan.pendingUpdates.length, 0);
     assert.equal(plan.transferLockedCount, 1);
-});
-
-test('planExistingCategoryUpdates aborts on quit decision', async () => {
-    const { importer } = makeImporter({
-        mappingByUuid: {
-            'mm-1': {
-                actualCategoryId: 'cat-target',
-                isUncategorized: false,
-                isMapped: true,
-            },
-        },
-    });
-
-    importer.promptForConflictDecision = async () => 'quit';
-
-    await assert.rejects(
-        () =>
-            importer.planExistingCategoryUpdates({
-                existingPairs: [makePair({ currentCategoryId: 'cat-current' })],
-                existingCategoryPolicy: 'ask',
-                promptState: {
-                    mode: 'prompt',
-                    promptInterface: {},
-                },
-            }),
-        /Category sync aborted by user/
-    );
 });
 
 test('applyOrPreviewCategoryUpdates does not mutate in dry run', async () => {


### PR DESCRIPTION
## Changes

### Config model
- Replace `synchronizeCategories` + `categorySyncOnExisting` with unified `categorySync` field (`"off" | "new" | "all"`)
- Use human-readable `path:` refs instead of UUIDs in `categoryMapping`
- Add `ignoredMoneyMoneyCategoryRefs` for intentionally unmapped MoneyMoney categories
- Implement `uuid:` prefix for MoneyMoney category ref resolution
- Remove `--category-sync-on-existing` / `-C` CLI flag and unused `"ask"` policy

### CLI output
- Resolve budget name from Actual API instead of showing raw UUID
- Status bar with color-coded counts: mapped, suggestions, invalid, unresolved, ignored
- Sync-off warning banner when `categorySync` is `"off"` but mappings exist
- Conditional sections — only show sections that have content
- Context-aware next actions: distinguish invalid mappings, pending suggestions, unresolved-only, and complete

### Explicit ignore
- Add `ignoredMoneyMoneyCategoryRefs` to budget schema (array of MM category refs)
- Ignored categories excluded from unresolved count, suggestions, and --write-config output
- Separate "Intentionally Ignored" output section with ref and path

### Migration
- `synchronizeCategories` and `categorySyncOnExisting` are deprecated but still parse correctly
- Old UUID keys in `categoryMapping` still work; `path:` refs are the new default
- The `--category-sync-on-existing` / `-C` CLI flag has been removed

### Testing
234/234 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified categorySync = "off" | "new" | "all" for import behavior.
  * Add ignoredMoneyMoneyCategoryRefs to exclude specific categories from unresolved counts.
  * Category mapping supports human-readable path: refs; reports show a status bar and "Intentionally Ignored" section.

* **Bug Fixes / Behavior**
  * Removed interactive "ask" conflict prompt and related CLI option; imports follow resolved policy.
  * Validation now warns when mappings exist but syncing is off.

* **Documentation**
  * Updated docs, examples, and CLI/help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->