### PR TITLE
fix: clarify dry-run output with explicit labeling and readable transaction refs

### DIFF
--- a/src/utils/AccountMap.ts
+++ b/src/utils/AccountMap.ts
@@ -143,8 +143,7 @@ export class AccountMap {
             parsedAccountMapping.set(moneyMoneyAccount, actualAccount);
         }
 
-        this.logger.info('Parsed account mapping', [
-            '[MoneyMoney Account] → [Actual Account]',
+        this.logger.info('Parsed account mapping (MoneyMoney → Actual):', [
             ...Array.from(parsedAccountMapping.entries()).map(
                 ([monMonAccount, actualAccount]) =>
                     `${monMonAccount.name} → ${actualAccount.name}`

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -1415,11 +1415,19 @@ class Importer {
                 const toPath = this.categoryMap.getActualCategoryPath(
                     update.toCategoryId
                 );
-                return `${update.importedId}: ${fromPath} -> ${toPath}`;
+                const tx = update.monMonTransaction;
+                const name = tx.name?.trim() || '(no name)';
+                const date = format(tx.valueDate, DATE_FORMAT);
+                const amount =
+                    tx.amount > 0
+                        ? `+${tx.amount.toFixed(2)}`
+                        : tx.amount.toFixed(2);
+                return `${name} (${amount} on ${date}): change category from "${fromPath}" to "${toPath}"`;
             });
 
+            const plural = pendingUpdates.length === 1 ? '' : 's';
             this.logger.info(
-                `Dry run: would apply ${pendingUpdates.length} category updates in '${actualAccountName}'.`,
+                `Dry run: would update categor${plural === 's' ? 'ies' : 'y'} on ${pendingUpdates.length} existing transaction${plural} in '${actualAccountName}':`,
                 preview
             );
             return;


### PR DESCRIPTION
## What

Improves the clarity of `--dry-run` output in two areas:

### 1. Account mapping direction is now part of the message

**Before:**
```
[INFO] Parsed account mapping
       ↳ [MoneyMoney Account] → [Actual Account]
       ↳ Gehaltskonto → 💸 Gehaltskonto
```

**After:**
```
[INFO] Parsed account mapping (MoneyMoney → Actual):
       ↳ Gehaltskonto → 💸 Gehaltskonto
```

### 2. Category update preview uses human-readable transaction info and explicit wording

**Before:**
```
[INFO] Dry run: would apply 1 category updates in '💸 Gehaltskonto'.
       ↳ dd6b968d-00f3-4922-872a-5e0ab82346b1-13046: Puffer > 💳😮 Ungeplant -> Lebenshaltung > 💳👖 Kleidung
```

**After:**
```
[INFO] Dry run: would update category on 1 existing transaction in '💸 Gehaltskonto':
       ↳ Amazon (-12.34 on 2026-06-01): change category from "Puffer > 💳😮 Ungeplant" to "Lebenshaltung > 💳👖 Kleidung"
```

Three improvements:
- Header says "update category on existing transaction" instead of vague "apply category updates"
- Transaction identified by name/amount/date instead of opaque UUID
- Preview line spells out "change category from X to Y" instead of ambiguous `->`

## Testing

- `npm run build` — clean
- `npm run test` — all 234 tests pass