### PR TITLE
fix: increase body-max-line-length to 200 in commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,6 @@ export default {
     extends: ['@commitlint/config-conventional'],
     rules: {
         'header-max-length': [2, 'always', 120],
+        'body-max-line-length': [2, 'always', 200],
     },
 };


### PR DESCRIPTION
## Problem

The commitlint CI job on `main` is failing because the default `body-max-line-length` of 100 characters trips on commit bodies containing long UUIDs, emoji-heavy account/category names, and code blocks (e.g., the latest commit `18880d8`).

The existing config only raised `header-max-length` to 120 but left body lines at the restrictive default.

## Fix

Set `body-max-line-length` to 200 in `commitlint.config.js`.

## Verification

- `npx commitlint --last --verbose` → 0 problems
- `npx commitlint --from HEAD~20 --to HEAD --verbose` → 0 problems for all recent commits
- `npm run build` → clean
- `npm run test` → 234/234 pass