### PR TITLE
fix: improve payee transformation prompts

### DIFF
--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -79,6 +79,40 @@ const findBestExistingPayee = (payee: string, existingPayeeNames: string[]) => {
     return bestMatch;
 };
 
+const MAX_EXISTING_PAYEES_IN_RAW_LOG = 10;
+
+const formatRawPayeeLog = (payees: string[]) => {
+    return [`User message (${payees.length} payees): ${payees.join('\n')}`];
+};
+
+const formatRawResponseLog = (transformedPayees: Record<string, string>) => {
+    return [
+        `Response JSON (${Object.keys(transformedPayees).length} mappings): ${JSON.stringify(transformedPayees, null, 2)}`,
+    ];
+};
+
+const formatExistingPayeeLog = (
+    existingPayeeNames: string[],
+    totalExistingPayees: number
+) => {
+    if (existingPayeeNames.length === 0) {
+        return ['Existing payees in prompt: 0'];
+    }
+
+    const visiblePayees = existingPayeeNames.slice(
+        0,
+        MAX_EXISTING_PAYEES_IN_RAW_LOG
+    );
+    const hiddenCount = existingPayeeNames.length - visiblePayees.length;
+
+    return [
+        `Existing payees in prompt (first ${visiblePayees.length} of ${existingPayeeNames.length}${totalExistingPayees > existingPayeeNames.length ? ` relevant, ${totalExistingPayees} total` : ''}): ${visiblePayees.join('\n')}`,
+        ...(hiddenCount > 0
+            ? [`... ${hiddenCount} more existing payees omitted from log`]
+            : []),
+    ];
+};
+
 const selectRelevantExistingPayees = (
     existingPayeeNames: string[],
     unresolvedPayees: string[],
@@ -183,6 +217,20 @@ class PayeeTransformer {
             relevantExistingPayees,
             existingPayeeNames.length
         );
+        const promptLogExistingPayees = relevantExistingPayees.slice(
+            0,
+            MAX_EXISTING_PAYEES_IN_RAW_LOG
+        );
+        const systemPromptLog = this.generateInstructionPrompt();
+        const systemPromptPreviewLog = this.generatePrompt(
+            promptLogExistingPayees,
+            existingPayeeNames.length
+        );
+
+        const existingPayeeLog = formatExistingPayeeLog(
+            relevantExistingPayees,
+            existingPayeeNames.length
+        );
 
         try {
             this.logger.debug(`Starting payee transformation...`, [
@@ -193,10 +241,22 @@ class PayeeTransformer {
                 `Backend: ${this.backend.getLabel()}`,
             ]);
 
+            this.logger.debug('Raw payee transformation request', [
+                `Base system message: ${systemPromptLog}`,
+                ...existingPayeeLog,
+                `System message preview (${promptLogExistingPayees.length} of ${relevantExistingPayees.length} existing payees included): ${systemPromptPreviewLog}`,
+                ...formatRawPayeeLog(unresolvedPayees),
+            ]);
+
             const transformedPayees = await this.backend.transformPayees(
                 prompt,
                 unresolvedPayees,
                 this.config.temperature
+            );
+
+            this.logger.debug(
+                'Raw payee transformation response',
+                formatRawResponseLog(transformedPayees)
             );
 
             this.logger.debug(`AI payee transformation completed`, [
@@ -223,6 +283,22 @@ class PayeeTransformer {
                 const original = keyMap.get(rawPayee.toLowerCase());
                 if (original === rawPayee) return rawPayee;
                 if (original !== undefined) return original;
+
+                const normalizedRawPayee = normalizePayee(rawPayee);
+                const matchingKeys = Object.keys(transformedPayees).filter(
+                    (key) => {
+                        const normalizedKey = normalizePayee(key);
+                        return (
+                            normalizedKey.length > 0 &&
+                            normalizedRawPayee.length > 0 &&
+                            (normalizedRawPayee.startsWith(normalizedKey) ||
+                                normalizedKey.startsWith(normalizedRawPayee))
+                        );
+                    }
+                );
+
+                if (matchingKeys.length === 1) return matchingKeys[0];
+
                 return undefined;
             };
 
@@ -291,6 +367,14 @@ class PayeeTransformer {
         existingPayeeNames: string[] = [],
         totalExistingPayees = existingPayeeNames.length
     ) {
+        return `${this.generateBasePrompt(existingPayeeNames, totalExistingPayees)}
+${this.backend.getPromptExamples()}`;
+    }
+
+    private generateBasePrompt(
+        existingPayeeNames: string[] = [],
+        totalExistingPayees = existingPayeeNames.length
+    ) {
         const existingPayeesSection =
             existingPayeeNames.length > 0
                 ? `
@@ -306,8 +390,33 @@ class PayeeTransformer {
             return this.config.prompt + existingPayeesSection;
         }
 
-        return `You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings (how they appear in MoneyMoney). Produce JSON matching the response format shown below. Always return valid JSON and never return "Unknown", "unknown", or any placeholder—if you cannot identify a distinct merchant, normalize the input (remove extraneous punctuation/ordering, fix capitalization) and return that normalized form as the cleaned name. Favor concise, canonical brand names (e.g., Amazon, Netflix, IKEA) and remove terminal IDs, country codes, or POS data. Some raw payee strings may contain corrupted characters from encoding issues (e.g., '?' replacing German umlauts like 'ä', 'ö', 'ü'). When you see '?' in an unusual position, infer the intended word from context and use the corrected spelling in the cleaned name. Do not include explanations, metadata, or anything outside the JSON object.${existingPayeesSection}
-${this.backend.getPromptExamples()}`;
+        return `${this.generateInstructionPrompt()}${existingPayeesSection}`;
+    }
+
+    private generateInstructionPrompt() {
+        if (this.config.prompt?.trim()) {
+            return this.config.prompt;
+        }
+
+        return `You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings from MoneyMoney. Return only a valid JSON object.
+
+Critical JSON rules:
+- The JSON object keys MUST be copied exactly from the input lines.
+- Copy each key character-for-character, including punctuation, spaces, casing, numbers, country codes, and suffixes.
+- Do not clean, normalize, shorten, reorder, or modify JSON keys.
+- Return exactly one JSON property for each input line.
+- Only clean the JSON values.
+
+Value-cleaning rules:
+- The JSON value is the cleaned payee name.
+- Prefer an existing payee name exactly when it clearly matches.
+- Remove terminal IDs, phone numbers, POS metadata, country codes, and payment noise from the value.
+- Favor concise, canonical merchant names (e.g., Amazon, Netflix, IKEA).
+- Never return "Unknown", "unknown", or any placeholder.
+- If you cannot identify a distinct merchant, use a lightly normalized version of the raw input as the JSON value.
+- Some raw payee strings may contain corrupted characters from encoding issues (e.g., '?' replacing German umlauts like 'ä', 'ö', 'ü'). When you see '?' in an unusual position, infer the intended word from context and use the corrected spelling in the JSON value.
+
+Do not include explanations, metadata, or anything outside the JSON object.`;
     }
 
     private describeTransformationError(error: unknown) {

--- a/src/utils/TransformationBackend.ts
+++ b/src/utils/TransformationBackend.ts
@@ -149,6 +149,11 @@ Output:
 {"mappings": [{"rawPayee": "AMZN Mktp US*1234567890", "cleanedPayee": "Amazon"}]}
 
 Input:
+Example Store, 800-5550100 Us
+Output:
+{"mappings": [{"rawPayee": "Example Store, 800-5550100 Us", "cleanedPayee": "Example Store"}]}
+
+Input:
 AMAZON.COM/BILLWA
 AMAZON.COM
 Output:
@@ -307,6 +312,11 @@ Input:
 AMZN Mktp US*1234567890
 Output:
 {"AMZN Mktp US*1234567890": "Amazon"}
+
+Input:
+Example Store, 800-5550100 Us
+Output:
+{"Example Store, 800-5550100 Us": "Example Store"}
 
 Input:
 AMAZON.COM/BILLWA

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -18,7 +18,12 @@ const makeLogger = () => ({
     },
 });
 
-const makeBackendStub = ({ mappings, error, onCreate } = {}) => ({
+const makeBackendStub = ({
+    mappings,
+    error,
+    onCreate,
+    promptExamples,
+} = {}) => ({
     transformPayees: async (_prompt, _payees, _temperature) => {
         onCreate?.(_prompt, _payees, _temperature);
 
@@ -30,7 +35,7 @@ const makeBackendStub = ({ mappings, error, onCreate } = {}) => ({
         return resolved;
     },
     getLabel: () => 'test-model',
-    getPromptExamples: () => '',
+    getPromptExamples: () => promptExamples ?? '',
     isModelUnavailableError: (error) =>
         error.message.toLowerCase().includes('model') &&
         (error.message.toLowerCase().includes('does not exist') ||
@@ -166,6 +171,137 @@ test('transformPayees snaps transformed payees back to existing names', async ()
     });
 });
 
+test('transformPayees logs raw backend request and response', async () => {
+    const logger = makeLogger();
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeBackendStub({
+            mappings: {
+                'Example Store, 800-5550100 Us': 'Example Store',
+            },
+        })
+    );
+
+    await transformer.transformPayees(
+        ['Example Store, 800-5550100 Us'],
+        ['Example Store']
+    );
+
+    const requestLog = logger.debugMessages.find(
+        ([message]) => message === 'Raw payee transformation request'
+    );
+    const responseLog = logger.debugMessages.find(
+        ([message]) => message === 'Raw payee transformation response'
+    );
+
+    assert.ok(requestLog, 'Expected raw request debug log');
+    assert.ok(responseLog, 'Expected raw response debug log');
+    assert.match(
+        requestLog[1].join('\n'),
+        /User message \(1 payees\): Example Store, 800-5550100 Us/
+    );
+    assert.match(responseLog[1].join('\n'), /"Example Store"/);
+});
+
+test('transformPayees raw logs shorten existing payees but keep raw payees and response complete', async () => {
+    const logger = makeLogger();
+    const rawPayees = Array.from(
+        { length: 6 },
+        (_, index) => `Example Store ${index + 1}, 800-555010${index} Us`
+    );
+    const existingPayees = Array.from(
+        { length: 12 },
+        (_, index) => `Example Store ${index + 1}`
+    );
+    const mappings = Object.fromEntries(
+        rawPayees.map((payee) => [payee, payee.split(',')[0]])
+    );
+    const transformer = new PayeeTransformer(
+        { ...makeConfig(), payeeMatchThreshold: 1 },
+        logger,
+        makeBackendStub({
+            mappings,
+            promptExamples: `
+Examples (input separated by newline, output shown as JSON):
+
+Input:
+Example Store, 800-5550100 Us
+Output:
+{"Example Store, 800-5550100 Us": "Example Store"}`,
+        })
+    );
+
+    await transformer.transformPayees(rawPayees, existingPayees);
+
+    const requestLog = logger.debugMessages.find(
+        ([message]) => message === 'Raw payee transformation request'
+    );
+    const responseLog = logger.debugMessages.find(
+        ([message]) => message === 'Raw payee transformation response'
+    );
+
+    assert.ok(requestLog, 'Expected raw request debug log');
+    assert.ok(responseLog, 'Expected raw response debug log');
+
+    const requestDetails = requestLog[1].join('\n');
+    const responseDetails = responseLog[1].join('\n');
+
+    assert.match(requestDetails, /Base system message:/);
+    assert.match(
+        requestDetails,
+        /Existing payees in prompt \(first 10 of 12\):/
+    );
+    assert.match(
+        requestDetails,
+        /\.\.\. 2 more existing payees omitted from log/
+    );
+    assert.match(
+        requestDetails,
+        /System message preview \(10 of 12 existing payees included\):/
+    );
+    assert.match(requestDetails, /Examples \(input separated/);
+    assert.match(requestDetails, /User message \(6 payees\):/);
+    assert.match(requestDetails, /Example Store 6, 800-5550105 Us/);
+    assert.match(responseDetails, /Response JSON \(6 mappings\):/);
+    assert.match(responseDetails, /Example Store 6, 800-5550105 Us/);
+});
+
+test('transformPayees prompt requires exact raw keys and includes noisy suffix example', async () => {
+    const logger = makeLogger();
+    let capturedPrompt;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeBackendStub({
+            mappings: {},
+            promptExamples: `
+Examples (input separated by newline, output shown as JSON):
+
+Input:
+Example Store, 800-5550100 Us
+Output:
+{"Example Store, 800-5550100 Us": "Example Store"}`,
+            onCreate: (prompt) => {
+                capturedPrompt = prompt;
+            },
+        })
+    );
+
+    await transformer.transformPayees(['Coffee Shop Terminal 123'], []);
+
+    assert.match(
+        capturedPrompt,
+        /The JSON object keys MUST be copied exactly from the input lines\./
+    );
+    assert.match(capturedPrompt, /Only clean the JSON values\./);
+    assert.match(capturedPrompt, /Example Store, 800-5550100 Us/);
+    assert.match(
+        capturedPrompt,
+        /"Example Store, 800-5550100 Us": "Example Store"/
+    );
+});
+
 test('transformPayees returns null on API errors', async () => {
     const logger = makeLogger();
     const transformer = new PayeeTransformer(
@@ -242,6 +378,29 @@ test('transformPayees matches AI response keys case-insensitively', async () => 
         'NETFLIX.COM': 'Netflix',
         'Amzn Mktp': 'Amazon',
         Spotify: 'Spotify',
+    });
+});
+
+test('transformPayees accepts unambiguous normalized-prefix AI response keys', async () => {
+    const logger = makeLogger();
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeBackendStub({
+            mappings: {
+                'Example Store': 'Example Store',
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['Example Store, 800-5550100 Us'],
+        ['Example Store']
+    );
+
+    assert.equal(logger.errorMessages.length, 0);
+    assert.deepEqual(result, {
+        'Example Store, 800-5550100 Us': 'Example Store',
     });
 });
 


### PR DESCRIPTION
## Summary
- Require payee transformation backends to preserve raw input strings as JSON keys and clean only values
- Add noisy suffix examples for OpenAI and Apple Intelligence prompts
- Log payee transformation debug context with a shortened existing-payee preview, all raw request payees, and the complete backend response
- Accept unambiguous normalized-prefix response keys to handle Apple Intelligence changing raw keys

## Release impact
- Patch fix for payee transformation accuracy and debug logging
- No config or breaking changes

## Testing
- rtk npm run build
- node --test test/unit/payee-transformer.test.mjs
- Manual Apple Intelligence probe for Newsdemon.Com, 866-3458190 Us → Newsdemon.Com