### PR TITLE
fix: match prefixed existing payees before AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Two backends are available:
 | `openai` (default)   | Cloud      | Yes              | OpenAI account ([api keys](https://platform.openai.com/api-keys)) |
 | `apple-intelligence` | On-device  | No               | macOS 26+ (Tahoe), Apple Silicon, Apple Intelligence enabled      |
 
-With `apple-intelligence`, all payee data is processed locally on your Mac. Nothing is sent to any cloud service. You need the `tsfm-sdk` npm package installed (`npm install tsfm-sdk`). No API key or network access is required beyond the initial package install.
+With `apple-intelligence`, all payee data is processed locally on your Mac. Nothing is sent to any cloud service. You need the `tsfm-sdk` npm package installed (`npm install tsfm-sdk`). No API key or network access is required beyond the initial package install. Treat this backend as best-effort cleanup: it can miss obvious canonical matches from the existing-payee list (for example, leaving `PayPal Europe...` unchanged instead of choosing existing `Paypal`). The importer therefore relies on deterministic local matching before and after AI responses; Apple Intelligence should not be considered the source of truth for avoiding duplicate payees.
 
 With `openai`, raw payee names and a shortlist of existing budget payees are sent to OpenAI for transformation.
 

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -6,6 +6,9 @@ enabled = false
 #                     # via Apple's Foundation Models. Requires macOS 26+ (Tahoe),
 #                     # Apple Silicon, and Apple Intelligence enabled in System Settings.
 #                     # No API key needed; all data stays local.
+#                     # Best-effort cleanup only: it may miss obvious existing-payee
+#                     # matches, so deterministic local matching remains the source
+#                     # of truth for avoiding duplicate payees.
 # openAiApiKey = "${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
 #                                    # Use an env var (${MMI_OPENAI_KEY})
 #                                    # or a literal key string

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -12,6 +12,14 @@ const normalizePayee = (value: string) =>
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '');
 
+const normalizePayeeTokens = (value: string) =>
+    value
+        .normalize('NFKD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((token) => token.length > 0);
+
 const buildBigramCounts = (value: string) => {
     const normalized = normalizePayee(value);
     const counts = new Map<string, number>();
@@ -57,11 +65,39 @@ const diceCoefficient = (left: string, right: string) => {
     return total > 0 ? (2 * intersection) / total : 0;
 };
 
+const scoreExistingPayeeMatch = (payee: string, existingPayeeName: string) => {
+    const normalizedPayee = normalizePayee(payee);
+    const normalizedExistingPayee = normalizePayee(existingPayeeName);
+    const payeeTokens = normalizePayeeTokens(payee);
+    const existingPayeeTokens = normalizePayeeTokens(existingPayeeName);
+
+    if (!normalizedPayee || !normalizedExistingPayee) {
+        return diceCoefficient(payee, existingPayeeName);
+    }
+
+    if (normalizedPayee === normalizedExistingPayee) {
+        return 1;
+    }
+
+    if (
+        normalizedExistingPayee.length >= 5 &&
+        existingPayeeTokens.length > 0 &&
+        existingPayeeTokens.length <= payeeTokens.length &&
+        existingPayeeTokens.every(
+            (token, index) => payeeTokens[index] === token
+        )
+    ) {
+        return 1;
+    }
+
+    return diceCoefficient(payee, existingPayeeName);
+};
+
 const findBestExistingPayee = (payee: string, existingPayeeNames: string[]) => {
     let bestMatch: { payeeName: string; score: number } | null = null;
 
     for (const existingPayeeName of existingPayeeNames) {
-        const score = diceCoefficient(payee, existingPayeeName);
+        const score = scoreExistingPayeeMatch(payee, existingPayeeName);
 
         if (
             !bestMatch ||

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -44,6 +44,9 @@ enabled = false
 #                     # via Apple's Foundation Models. Requires macOS 26+ (Tahoe),
 #                     # Apple Silicon, and Apple Intelligence enabled in System Settings.
 #                     # No API key needed; all data stays local.
+#                     # Best-effort cleanup only: it may miss obvious existing-payee
+#                     # matches, so deterministic local matching remains the source
+#                     # of truth for avoiding duplicate payees.
 # openAiApiKey = "\${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
 #                                    # Use an env var (\${MMI_OPENAI_KEY})
 #                                    # or a literal key string

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -99,6 +99,57 @@ test('transformPayees skips AI for local existing-payee matches', async () => {
     assert.equal(createCalls, 0);
 });
 
+test('transformPayees matches leading canonical existing payee names locally', async () => {
+    const logger = makeLogger();
+    let createCalls = 0;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeBackendStub({
+            onCreate: () => {
+                createCalls++;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['PayPal Europe S.A.R.L. ET C IE S.C.A'],
+        ['Paypal']
+    );
+
+    assert.deepEqual(result, {
+        'PayPal Europe S.A.R.L. ET C IE S.C.A': 'Paypal',
+    });
+    assert.equal(createCalls, 0);
+});
+
+test('transformPayees does not match short leading fragments as existing payees', async () => {
+    const logger = makeLogger();
+    let capturedPayees;
+    const transformer = new PayeeTransformer(
+        makeConfig(),
+        logger,
+        makeBackendStub({
+            mappings: {
+                'Abcdef Market': 'Abcdef Market',
+            },
+            onCreate: (_prompt, payees) => {
+                capturedPayees = payees;
+            },
+        })
+    );
+
+    const result = await transformer.transformPayees(
+        ['Abcdef Market'],
+        ['Abc']
+    );
+
+    assert.deepEqual(capturedPayees, ['Abcdef Market']);
+    assert.deepEqual(result, {
+        'Abcdef Market': 'Abcdef Market',
+    });
+});
+
 test('transformPayees bounds the relevant existing-payee shortlist', async () => {
     const logger = makeLogger();
     let capturedPrompt;
@@ -178,14 +229,14 @@ test('transformPayees logs raw backend request and response', async () => {
         logger,
         makeBackendStub({
             mappings: {
-                'Example Store, 800-5550100 Us': 'Example Store',
+                'Coffee Kiosk, 800-5550100 Us': 'Coffee Kiosk',
             },
         })
     );
 
     await transformer.transformPayees(
-        ['Example Store, 800-5550100 Us'],
-        ['Example Store']
+        ['Coffee Kiosk, 800-5550100 Us'],
+        ['Unrelated Store']
     );
 
     const requestLog = logger.debugMessages.find(
@@ -199,20 +250,20 @@ test('transformPayees logs raw backend request and response', async () => {
     assert.ok(responseLog, 'Expected raw response debug log');
     assert.match(
         requestLog[1].join('\n'),
-        /User message \(1 payees\): Example Store, 800-5550100 Us/
+        /User message \(1 payees\): Coffee Kiosk, 800-5550100 Us/
     );
-    assert.match(responseLog[1].join('\n'), /"Example Store"/);
+    assert.match(responseLog[1].join('\n'), /"Coffee Kiosk"/);
 });
 
 test('transformPayees raw logs shorten existing payees but keep raw payees and response complete', async () => {
     const logger = makeLogger();
     const rawPayees = Array.from(
         { length: 6 },
-        (_, index) => `Example Store ${index + 1}, 800-555010${index} Us`
+        (_, index) => `Coffee Kiosk ${index + 1}, 800-555010${index} Us`
     );
     const existingPayees = Array.from(
         { length: 12 },
-        (_, index) => `Example Store ${index + 1}`
+        (_, index) => `Coffee Stand ${index + 1}`
     );
     const mappings = Object.fromEntries(
         rawPayees.map((payee) => [payee, payee.split(',')[0]])
@@ -262,9 +313,9 @@ Output:
     );
     assert.match(requestDetails, /Examples \(input separated/);
     assert.match(requestDetails, /User message \(6 payees\):/);
-    assert.match(requestDetails, /Example Store 6, 800-5550105 Us/);
+    assert.match(requestDetails, /Coffee Kiosk 6, 800-5550105 Us/);
     assert.match(responseDetails, /Response JSON \(6 mappings\):/);
-    assert.match(responseDetails, /Example Store 6, 800-5550105 Us/);
+    assert.match(responseDetails, /Coffee Kiosk 6, 800-5550105 Us/);
 });
 
 test('transformPayees prompt requires exact raw keys and includes noisy suffix example', async () => {


### PR DESCRIPTION
## Summary
- Match raw payees that start with an existing canonical payee token sequence before calling AI
- Add regression coverage for PayPal Europe matching existing Paypal while avoiding short-fragment false positives
- Document Apple Intelligence as best-effort cleanup for existing-payee matching

## Testing
- npm run generate:example-config
- npm run build
- npm run test:unit