### PR TITLE
fix: handle Actual file reset errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 dist/
 node_modules/
+
+# Ignore dot-directories by default. Whitelist project dot-directories that are
+# intentionally tracked.
+.*/
+!.github/
+!.github/**
+!.husky/
+!.husky/**
 .husky/_

--- a/src/utils/ActualApi.ts
+++ b/src/utils/ActualApi.ts
@@ -14,6 +14,54 @@ import { ActualServerConfig } from './config.js';
 import Logger, { LogLevel } from './Logger.js';
 import { DEFAULT_DATA_DIR } from './shared.js';
 
+/**
+ * Detect whether an unknown thrown value represents an Actual API
+ * `file-has-reset` error.  Checks both the structured shape
+ * (`reason === 'file-has-reset'`) and a message string fallback.
+ */
+function isActualFileHasResetError(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) return false;
+
+    const record = error as Record<string, unknown>;
+
+    if (record.reason === 'file-has-reset') {
+        return true;
+    }
+
+    if (
+        typeof record.message === 'string' &&
+        record.message.toLowerCase().includes('file-has-reset')
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Build a user-facing Error for `file-has-reset` with actionable guidance.
+ * The original error is preserved as `.cause` for diagnosis.
+ */
+function buildFileHasResetError(error: unknown): Error {
+    const message = [
+        'Syncing has been reset on this cloud file (reason: file-has-reset).',
+        '',
+        `Local cached budget data at: ${DEFAULT_DATA_DIR}`,
+        "This directory is the tool's Actual cache and may contain cached data for",
+        'multiple budgets. It is out of sync with the server because sync was reset',
+        'from another device.',
+        '',
+        'Recommended action: quit this command, delete or move this cache directory,',
+        'then rerun this command. The tool will download a fresh copy of the budget.',
+        '',
+        'Alternative: if you intentionally want the local data to become canonical,',
+        "use Actual's desktop/web UI to upload that file, then rerun this command.",
+        'The CLI will not upload data automatically.',
+    ].join('\n');
+
+    return new Error(message, { cause: error });
+}
+
 type UserFile = {
     deleted: number;
     encryptKeyId: null;
@@ -119,16 +167,24 @@ class ActualApi {
 
         this.logger.debug(`Loading budget with syncId ${budgetId}...`);
 
-        await this.withLogControl(async () => {
-            await this.actualApi.downloadBudget(
-                budgetConfig.syncId,
-                budgetConfig.e2eEncryption.enabled
-                    ? {
-                          password: budgetConfig.e2eEncryption.password ?? '',
-                      }
-                    : undefined
-            );
-        });
+        try {
+            await this.withLogControl(async () => {
+                await this.actualApi.downloadBudget(
+                    budgetConfig.syncId,
+                    budgetConfig.e2eEncryption.enabled
+                        ? {
+                              password:
+                                  budgetConfig.e2eEncryption.password ?? '',
+                          }
+                        : undefined
+                );
+            });
+        } catch (error) {
+            if (isActualFileHasResetError(error)) {
+                throw buildFileHasResetError(error);
+            }
+            throw error;
+        }
     }
 
     async importTransactions(

--- a/test/unit/actual-api.test.mjs
+++ b/test/unit/actual-api.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { mock, test } from 'node:test';
 import ActualApi from '../../dist/utils/ActualApi.js';
+import { DEFAULT_DATA_DIR } from '../../dist/utils/shared.js';
 
 const makeLogger = () => ({
     debug: () => {},
@@ -127,6 +128,178 @@ test('ActualApi.getUserFiles surfaces files HTTP failures', async () => {
     assert.equal(fetchImpl.mock.callCount(), 2);
     assert.equal(loginJson.mock.callCount(), 1);
     assert.equal(filesJson.mock.callCount(), 0);
+});
+
+test('ActualApi.loadBudget translates file-has-reset PostError to actionable message', async () => {
+    const fileHasResetError = { type: 'PostError', reason: 'file-has-reset' };
+    const downloadBudget = mock.fn(async () => {
+        throw fileHasResetError;
+    });
+    const api = new ActualApi(
+        {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'pw',
+            budgets: [
+                {
+                    syncId: 'test-budget',
+                    e2eEncryption: { enabled: false },
+                },
+            ],
+        },
+        makeLogger(),
+        { downloadBudget }
+    );
+    api.isInitialized = true;
+
+    await assert.rejects(
+        () => api.loadBudget('test-budget'),
+        (err) => {
+            assert.ok(
+                err.message.includes('file-has-reset'),
+                'message should mention file-has-reset'
+            );
+            assert.ok(
+                err.message.includes(DEFAULT_DATA_DIR),
+                `message should include cache path ${DEFAULT_DATA_DIR}`
+            );
+            assert.ok(
+                err.message.includes('rerun this command'),
+                'message should say "rerun this command"'
+            );
+            assert.ok(
+                !err.message.includes('rerun import'),
+                'message should not mention "rerun import"'
+            );
+            assert.ok(
+                !err.message.includes('rm -rf'),
+                'message should not include an rm -rf command'
+            );
+            assert.ok(
+                err.cause !== undefined,
+                'original error should be preserved as cause'
+            );
+            assert.deepEqual(err.cause, fileHasResetError);
+            return true;
+        }
+    );
+
+    assert.equal(
+        downloadBudget.mock.callCount(),
+        1,
+        'downloadBudget should be called exactly once (no retry)'
+    );
+});
+
+test('ActualApi.loadBudget preserves unknown downloadBudget errors unchanged', async () => {
+    const originalError = new Error('download budget failed');
+    const downloadBudget = mock.fn(async () => {
+        throw originalError;
+    });
+    const api = new ActualApi(
+        {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'pw',
+            budgets: [
+                {
+                    syncId: 'test-budget',
+                    e2eEncryption: { enabled: false },
+                },
+            ],
+        },
+        makeLogger(),
+        { downloadBudget }
+    );
+    api.isInitialized = true;
+
+    await assert.rejects(
+        () => api.loadBudget('test-budget'),
+        (err) => {
+            assert.equal(
+                err,
+                originalError,
+                'unknown errors should propagate exact reference'
+            );
+            return true;
+        }
+    );
+
+    assert.equal(downloadBudget.mock.callCount(), 1);
+});
+
+test('ActualApi.loadBudget detects file-has-reset via Error message fallback', async () => {
+    const downloadBudget = mock.fn(async () => {
+        throw new Error('PostError: file-has-reset — sync group mismatch');
+    });
+    const api = new ActualApi(
+        {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'pw',
+            budgets: [
+                {
+                    syncId: 'test-budget',
+                    e2eEncryption: { enabled: false },
+                },
+            ],
+        },
+        makeLogger(),
+        { downloadBudget }
+    );
+    api.isInitialized = true;
+
+    await assert.rejects(
+        () => api.loadBudget('test-budget'),
+        (err) => {
+            assert.ok(
+                err.message.includes('file-has-reset'),
+                'message should still mention file-has-reset'
+            );
+            assert.ok(
+                err.message.includes(DEFAULT_DATA_DIR),
+                `message should include cache path ${DEFAULT_DATA_DIR}`
+            );
+            assert.ok(
+                err.message.includes('rerun this command'),
+                'message should say "rerun this command"'
+            );
+            assert.ok(
+                err.cause instanceof Error,
+                'cause should be the original Error'
+            );
+            return true;
+        }
+    );
+
+    assert.equal(
+        downloadBudget.mock.callCount(),
+        1,
+        'downloadBudget should be called exactly once (no retry)'
+    );
+});
+
+test('ActualApi.loadBudget throws when budget syncId not found (unchanged behavior)', async () => {
+    const downloadBudget = mock.fn(async () => {});
+    const api = new ActualApi(
+        {
+            serverUrl: 'http://localhost:5006',
+            serverPassword: 'pw',
+            budgets: [
+                {
+                    syncId: 'existing-budget',
+                    e2eEncryption: { enabled: false },
+                },
+            ],
+        },
+        makeLogger(),
+        { downloadBudget }
+    );
+    api.isInitialized = true;
+
+    await assert.rejects(
+        () => api.loadBudget('missing-budget'),
+        /No budget with syncId 'missing-budget' found\./
+    );
+
+    assert.equal(downloadBudget.mock.callCount(), 0);
 });
 
 test('ActualApi.getUserFiles surfaces invalid files JSON', async () => {


### PR DESCRIPTION
## Summary
- translate Actual `file-has-reset` sync failures into an actionable command-neutral error
- preserve unknown `downloadBudget` errors and original reset error causes
- add unit coverage for structured PostError, message fallback, unknown errors, and missing budget behavior
- ignore dot-directories by default while whitelisting tracked `.github/` and `.husky/`

## Testing
- `npm run lint:eslint`
- `npm run lint:prettier`
- `npm run test`

## Release impact
- Patch fix; no breaking changes.

## Notes
- Phase 2 stderr filtering was intentionally skipped because the reset/stderr leak could not be reproduced and the stale budget is no longer available.