### PR TITLE
fix: simplify Apple Intelligence payee transformation prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,22 @@ Two backends are available:
 | `openai` (default)   | Cloud      | Yes              | OpenAI account ([api keys](https://platform.openai.com/api-keys)) |
 | `apple-intelligence` | On-device  | No               | macOS 26+ (Tahoe), Apple Silicon, Apple Intelligence enabled      |
 
-With `apple-intelligence`, all payee data is processed locally on your Mac. Nothing is sent to any cloud service. You need the `tsfm-sdk` npm package installed (`npm install tsfm-sdk`). No API key or network access is required beyond the initial package install. Treat this backend as best-effort cleanup: it can miss obvious canonical matches from the existing-payee list (for example, leaving `PayPal Europe...` unchanged instead of choosing existing `Paypal`). The importer therefore relies on deterministic local matching before and after AI responses; Apple Intelligence should not be considered the source of truth for avoiding duplicate payees.
+With `apple-intelligence`, all payee data is processed locally on your Mac. Nothing is sent to any cloud service. You need the `tsfm-sdk` npm package installed (`npm install tsfm-sdk`). No API key or network access is required beyond the initial package install. See [Apple Intelligence limitations](#apple-intelligence-limitations) below.
+
+### Apple Intelligence limitations
+
+The on-device Apple Foundation Model is smaller and less capable than cloud-based models. It may return payee names unchanged (identity mappings) for subtle cleaning tasks, and can miss obvious matches against the existing-payee list even when those payees are included in the prompt. The deterministic local Dice coefficient matching runs independently of the AI backend and remains the primary defense against creating duplicate payees.
+
+### Recommended: Actual's built-in payee rules
+
+Actual Budget has its own payee rules system that runs automatically during import. Rules can match the raw `imported_payee` field (exact or "contains") and set the canonical payee, category, and more. This is the recommended approach for reliable, persistent payee cleanup — it's user-configurable, doesn't depend on AI quality, and survives across import runs.
+
+To set up payee rules, open Actual's UI and go to **More → Rules** or **More → Payees**. Create a rule like:
+
+- **Condition**: `imported_payee` contains `Lidl`
+- **Action**: set payee to `Lidl`
+
+The rules fire automatically whenever transactions are imported, including when this tool calls `importTransactions`.
 
 With `openai`, raw payee names and a shortlist of existing budget payees are sent to OpenAI for transformation.
 

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -9,6 +9,10 @@ enabled = false
 #                     # Best-effort cleanup only: it may miss obvious existing-payee
 #                     # matches, so deterministic local matching remains the source
 #                     # of truth for avoiding duplicate payees.
+#                     # For reliable cleaning of recurring payees, prefer
+#                     # Actual's built-in payee rules (More → Rules in Actual's UI).
+#                     # Rules match imported_payee with "contains" conditions
+#                     # and run automatically during import.
 # openAiApiKey = "${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
 #                                    # Use an env var (${MMI_OPENAI_KEY})
 #                                    # or a literal key string

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -434,25 +434,7 @@ ${this.backend.getPromptExamples()}`;
             return this.config.prompt;
         }
 
-        return `You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings from MoneyMoney. Return only a valid JSON object.
-
-Critical JSON rules:
-- The JSON object keys MUST be copied exactly from the input lines.
-- Copy each key character-for-character, including punctuation, spaces, casing, numbers, country codes, and suffixes.
-- Do not clean, normalize, shorten, reorder, or modify JSON keys.
-- Return exactly one JSON property for each input line.
-- Only clean the JSON values.
-
-Value-cleaning rules:
-- The JSON value is the cleaned payee name.
-- Prefer an existing payee name exactly when it clearly matches.
-- Remove terminal IDs, phone numbers, POS metadata, country codes, and payment noise from the value.
-- Favor concise, canonical merchant names (e.g., Amazon, Netflix, IKEA).
-- Never return "Unknown", "unknown", or any placeholder.
-- If you cannot identify a distinct merchant, use a lightly normalized version of the raw input as the JSON value.
-- Some raw payee strings may contain corrupted characters from encoding issues (e.g., '?' replacing German umlauts like 'ä', 'ö', 'ü'). When you see '?' in an unusual position, infer the intended word from context and use the corrected spelling in the JSON value.
-
-Do not include explanations, metadata, or anything outside the JSON object.`;
+        return this.backend.getSystemInstruction();
     }
 
     private describeTransformationError(error: unknown) {

--- a/src/utils/TransformationBackend.ts
+++ b/src/utils/TransformationBackend.ts
@@ -82,6 +82,9 @@ export interface TransformationBackend {
      */
     getPromptExamples(): string;
 
+    /** Backend-specific system instruction for the AI model (core instruction only, no existing payees or examples) */
+    getSystemInstruction(): string;
+
     /** Check if error indicates the model is unavailable / doesn't exist */
     isModelUnavailableError(error: Error): boolean;
 
@@ -128,6 +131,28 @@ export class OpenAIBackend implements TransformationBackend {
         }
 
         return mappingsToRecord(parsed.mappings);
+    }
+
+    getSystemInstruction(): string {
+        return `You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings from MoneyMoney. Return only a valid JSON object.
+
+Critical JSON rules:
+- The JSON object keys MUST be copied exactly from the input lines.
+- Copy each key character-for-character, including punctuation, spaces, casing, numbers, country codes, and suffixes.
+- Do not clean, normalize, shorten, reorder, or modify JSON keys.
+- Return exactly one JSON property for each input line.
+- Only clean the JSON values.
+
+Value-cleaning rules:
+- The JSON value is the cleaned payee name.
+- Prefer an existing payee name exactly when it clearly matches.
+- Remove terminal IDs, phone numbers, POS metadata, country codes, and payment noise from the value.
+- Favor concise, canonical merchant names (e.g., Amazon, Netflix, IKEA).
+- Never return "Unknown", "unknown", or any placeholder.
+- If you cannot identify a distinct merchant, use a lightly normalized version of the raw input as the JSON value.
+- Some raw payee strings may contain corrupted characters from encoding issues (e.g., '?' replacing German umlauts like 'ä', 'ö', 'ü'). When you see '?' in an unusual position, infer the intended word from context and use the corrected spelling in the JSON value.
+
+Do not include explanations, metadata, or anything outside the JSON object.`;
     }
 
     getLabel(): string {
@@ -293,6 +318,21 @@ export class AppleIntelligenceBackend implements TransformationBackend {
         } finally {
             session.dispose();
         }
+    }
+
+    getSystemInstruction(): string {
+        return `You are a payee name cleaner. You receive raw bank transaction payee names, one per line. Clean each name by stripping receipt noise and legal suffixes. Return only a JSON object.
+
+Rules:
+- JSON keys: copy each input line exactly, character-for-character.
+- JSON values: the cleaned payee name.
+- Prefer an existing payee name exactly when it clearly matches the same merchant.
+- Remove noise: thank-you tags, location suffixes, legal form suffixes (AG, GmbH, Ltd, Inc), terminal/receipt IDs, phone numbers.
+- Keep the core merchant or bank name.
+- Never return "Unknown", empty, or placeholder values.
+- When you cannot identify a distinct merchant, lightly normalize the raw input.
+
+Do not include explanations, metadata, or anything outside the JSON object.`;
     }
 
     getLabel(): string {

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -47,6 +47,10 @@ enabled = false
 #                     # Best-effort cleanup only: it may miss obvious existing-payee
 #                     # matches, so deterministic local matching remains the source
 #                     # of truth for avoiding duplicate payees.
+#                     # For reliable cleaning of recurring payees, prefer
+#                     # Actual's built-in payee rules (More → Rules in Actual's UI).
+#                     # Rules match imported_payee with "contains" conditions
+#                     # and run automatically during import.
 # openAiApiKey = "\${MMI_OPENAI_KEY}"  # Required only with backend = "openai"
 #                                    # Use an env var (\${MMI_OPENAI_KEY})
 #                                    # or a literal key string

--- a/test/unit/payee-transformer.test.mjs
+++ b/test/unit/payee-transformer.test.mjs
@@ -36,6 +36,14 @@ const makeBackendStub = ({
     },
     getLabel: () => 'test-model',
     getPromptExamples: () => promptExamples ?? '',
+    getSystemInstruction: () =>
+        'You are a transaction-classification specialist. You will receive a newline-separated list of raw payee strings from MoneyMoney. Return only a valid JSON object.\n' +
+        '\n' +
+        'Critical JSON rules:\n' +
+        '- The JSON object keys MUST be copied exactly from the input lines.\n' +
+        '- Only clean the JSON values.\n' +
+        '\n' +
+        'Do not include explanations, metadata, or anything outside the JSON object.',
     isModelUnavailableError: (error) =>
         error.message.toLowerCase().includes('model') &&
         (error.message.toLowerCase().includes('does not exist') ||


### PR DESCRIPTION
## Summary

The on-device Apple Foundation Model was returning identity mappings (no cleaning) for payee names. The complex, rule-heavy system prompt that works for cloud models overwhelms the smaller on-device model.

## Changes

- **Backend-specific system instructions**: Added `getSystemInstruction()` to `TransformationBackend` interface. `OpenAIBackend` keeps the original detailed prompt; `AppleIntelligenceBackend` gets a shorter instruction (~10 lines vs ~20) optimized for on-device models
- **Removed hardcoded heuristic cleaning**: Brittle regex patterns leaking German transaction patterns — users should use Actual's built-in payee rules (which run automatically via `importTransactions`) instead
- **Generic prompt examples**: Replaced German-specific examples (Lidl, ING-DiBa, Leder Schuh) with generic ones (Amazon, Example Store) in Apple backend
- **Delegation**: `PayeeTransformer.generateInstructionPrompt()` now delegates to `backend.getSystemInstruction()`
- **Documentation**: Added Apple Intelligence limitations section and recommended Actual's payee rules as fallback in README and config examples

## Testing

```
npm run build  # clean
npm run test   # 244/244 pass
```